### PR TITLE
Modified setup.py and control/__init__.py to match numpy.

### DIFF
--- a/control/tests/discrete_test.py
+++ b/control/tests/discrete_test.py
@@ -5,7 +5,15 @@
 
 import unittest
 import numpy as np
-from control import *
+from control.statesp import StateSpace
+from control import matlab
+from control.xferfcn import TransferFunction
+from control.lti import isdtime, timebase, isctime, timebaseEqual
+from control.dtime import sample_system
+from control.bdalg import feedback
+from control.timeresp import step_response, impulse_response, forced_response
+from control.freqplot import bode
+
 
 class TestDiscrete(unittest.TestCase):
     """Tests for the DiscreteStateSpace class."""


### PR DESCRIPTION
I tried to avoid using the _CONTROL_SETUP_ switch like numpy
but this was causing some issues for Travis CI. This means for
setup.py test to work we can't do control import * so I had to
change to explicit imports for discrete_test.py. Closes #37.