### PR TITLE
Speed up forced_response/lsim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ control/version.py
 build.log
 *.egg-info/
 .coverage
+doc/_build


### PR DESCRIPTION
Fixes #48.

This version of lsim assumes a constant timestep, as in Matlab.  This algorithm is much faster than the previous implementation, which used a generic ODE integrator: the example in issue #48 now runs over 400x faster, and is now a little faster than scipy.signal.lsim.  This algorithm is more general than the scipy version, since it works even if the system has a pole at the origin.

If we want a version that works with variable timesteps, I suggest adding an `lsim2` function, as in `scipy.signal`, which could call the generic ODE integrator as before.  I don't think this is necessary (for instance, there is nothing like that in Matlab, as far as I know), but if anybody needs it, we can always add it.