### PR TITLE
Fix #45 - make gain vector optional in root_locus

### DIFF
--- a/control/margins.py
+++ b/control/margins.py
@@ -86,11 +86,6 @@ def stability_margins(sysdata, deg=True, returnall=False, epsw=1e-10):
     """Calculate gain, phase and stability margins and associated
     crossover frequencies.
 
-    Usage
-    -----
-    gm, pm, sm, wg, wp, ws = stability_margins(sysdata, deg=True,
-                                               returnall=False, epsw=1e-10)
-
     Parameters
     ----------
     sysdata: linsys or (mag, phase, omega) sequence

--- a/control/matlab.py
+++ b/control/matlab.py
@@ -1509,7 +1509,7 @@ def ssdata(sys):
     return (ss.A, ss.B, ss.C, ss.D)
 
 # Return transfer function data as a tuple
-def tfdata(sys, **kw):
+def tfdata(sys):
     '''
     Return transfer function data objects for a system
 
@@ -1518,17 +1518,12 @@ def tfdata(sys, **kw):
     sys: Lti (StateSpace, or TransferFunction)
         LTI system whose data will be returned
 
-    Keywords
-    --------
-    inputs = int; outputs = int
-        For MIMO transfer function, return num, den for given inputs, outputs
-
     Returns
     -------
     (num, den): numerator and denominator arrays
         Transfer function coefficients (SISO only)
     '''
-    tf = _convertToTransferFunction(sys, **kw)
+    tf = _convertToTransferFunction(sys)
 
     return (tf.num, tf.den)
 

--- a/control/matlab.py
+++ b/control/matlab.py
@@ -1110,11 +1110,8 @@ def rlocus(sys, klist = None, **keywords):
     ----------
     sys: StateSpace or TransferFunction
         Linear system
-    klist:
+    klist: iterable, optional
         optional list of gains
-
-    Keyword parameters
-    ------------------
     xlim : control of x-axis range, normally with tuple, for
         other options, see matplotlib.axes
     ylim : control of y-axis range
@@ -1132,12 +1129,8 @@ def rlocus(sys, klist = None, **keywords):
         list of gains used to compute roots
     """
     from .rlocus import root_locus
-    #! TODO: update with a smart calculation of the gains using sys poles/zeros
-    if klist == None:
-        klist = logspace(-3, 3)
 
-    rlist = root_locus(sys, klist, **keywords)
-    return rlist, klist
+    return root_locus(sys, klist, **keywords)
 
 def margin(*args):
     """Calculate gain and phase margins and associated crossover frequencies

--- a/control/nichols.py
+++ b/control/nichols.py
@@ -103,10 +103,6 @@ def nichols_plot(syslist, omega=None, grid=True):
 def nichols_grid(cl_mags=None, cl_phases=None):
     """Nichols chart grid
 
-    Usage
-    =====
-    nichols_grid()
-
     Plots a Nichols chart grid on the current axis, or creates a new chart
     if no plot already exists.
 
@@ -119,8 +115,8 @@ def nichols_grid(cl_mags=None, cl_phases=None):
         Array of closed-loop phases defining the iso-phase lines on a custom
         Nichols chart. Must be in the range -360 < cl_phases < 0
 
-    Return values
-    -------------
+    Returns
+    -------
     None
     """
     # Default chart size
@@ -211,10 +207,6 @@ def closed_loop_contours(Gcl_mags, Gcl_phases):
     Gol is an open-loop transfer function, and Gcl is a corresponding
     closed-loop transfer function.
 
-    Usage
-    =====
-    contours = closed_loop_contours(Gcl_mags, Gcl_phases)
-
     Parameters
     ----------
     Gcl_mags : array-like
@@ -222,8 +214,8 @@ def closed_loop_contours(Gcl_mags, Gcl_phases):
     Gcl_phases : array-like
         Array of phases in radians of the contours
 
-    Return values
-    -------------
+    Returns
+    -------
     contours : complex array
         Array of complex numbers corresponding to the contours.
     """
@@ -241,10 +233,6 @@ def m_circles(mags, phase_min=-359.75, phase_max=-0.25):
     Gol is an open-loop transfer function, and Gcl is a corresponding
     closed-loop transfer function.
 
-    Usage
-    =====
-    contours = m_circles(mags, phase_min, phase_max)
-
     Parameters
     ----------
     mags : array-like
@@ -254,8 +242,8 @@ def m_circles(mags, phase_min=-359.75, phase_max=-0.25):
     phase_max : degrees
         Maximum phase in degrees of the N-circles
 
-    Return values
-    -------------
+    Returns
+    -------
     contours : complex array
         Array of complex numbers corresponding to the contours.
     """
@@ -271,10 +259,6 @@ def n_circles(phases, mag_min=-40.0, mag_max=12.0):
     Gol is an open-loop transfer function, and Gcl is a corresponding
     closed-loop transfer function.
 
-    Usage
-    =====
-    contours = n_circles(phases, mag_min, mag_max)
-
     Parameters
     ----------
     phases : array-like
@@ -284,8 +268,8 @@ def n_circles(phases, mag_min=-40.0, mag_max=12.0):
     mag_max : dB
         Maximum magnitude in dB of the N-circles
 
-    Return values
-    -------------
+    Returns
+    -------
     contours : complex array
         Array of complex numbers corresponding to the contours.
     """

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -309,7 +309,10 @@ class TestMatlab(unittest.TestCase):
         rlocus(self.siso_ss1)
         rlocus(self.siso_tf1)
         rlocus(self.siso_tf2)
-        rlist, klist = rlocus(self.siso_tf2, klist=[1, 10, 100], Plot=False)
+        klist = [1, 10, 100]
+        rlist, klist_out = rlocus(self.siso_tf2, klist=klist, Plot=False)
+        np.testing.assert_equal(len(rlist), len(klist))
+        np.testing.assert_array_equal(klist, klist_out)
 
     def testNyquist(self):
         nyquist(self.siso_ss1)
@@ -618,7 +621,7 @@ class TestMatlab(unittest.TestCase):
 #        for i in range(len(tfdata)):
 #            np.testing.assert_array_almost_equal(tfdata_1[i], tfdata_2[i])
 
-def suite():
+def test_suite():
    return unittest.TestLoader().loadTestsFromTestCase(TestMatlab)
 
 if __name__ == '__main__':


### PR DESCRIPTION
As a consequence of this change, `root_locus` now returns two items, the roots and the gains used (consistent with `matlab.rlocus`).

This PR also fixes some mistakes I found in the documentation.