### PR TITLE
Build universal wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 build/
 dist/
+htmlcov/
 .ropeproject/
 MANIFEST
 control/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Two little changes to config files, to build universal binaries (with `python setup.py bdist_wheel`) and ignore files generated by `coverage run setup.py test`.