### PR TITLE
Add db2mag and mag2db

### DIFF
--- a/control/__init__.py
+++ b/control/__init__.py
@@ -75,7 +75,7 @@ from .statesp import StateSpace
 from .timeresp import forced_response, initial_response, step_response, \
     impulse_response
 from .xferfcn import TransferFunction
-from .ctrlutil import unwrap, issys
+from .ctrlutil import *
 from .frdata import FRD
 from .canonical import canonical_form, reachable_form
 

--- a/control/ctrlutil.py
+++ b/control/ctrlutil.py
@@ -45,6 +45,8 @@ from . import lti
 import numpy as np
 from numpy import pi
 
+__all__ = ['unwrap', 'issys', 'db2mag', 'mag2db']
+
 # Utility function to unwrap an angle measurement
 def unwrap(angle, period=2*pi):
     """Unwrap a phase angle to give a continuous curve
@@ -78,3 +80,43 @@ def unwrap(angle, period=2*pi):
 def issys(obj):
     """Return True if an object is a system, otherwise False"""
     return isinstance(obj, lti.Lti)
+
+def db2mag(db):
+    """Convert a gain in decibels (dB) to a magnitude
+
+    If A is magnitude,
+
+        db = 20 * log10(A)
+
+    Parameters
+    ----------
+    db : float or ndarray
+        input value or array of values, given in decibels
+
+    Returns
+    -------
+    mag : float or ndarray
+        corresponding magnitudes
+
+    """
+    return 10. ** (db / 20.)
+
+def mag2db(mag):
+    """Convert a magnitude to decibels (dB)
+
+    If A is magnitude,
+
+        db = 20 * log10(A)
+
+    Parameters
+    ----------
+    mag : float or ndarray
+        input magnitude or array of magnitudes
+
+    Returns
+    -------
+    db : float or ndarray
+        corresponding values in decibels
+
+    """
+    return 20. * np.log10(mag)

--- a/control/ctrlutil.py
+++ b/control/ctrlutil.py
@@ -42,61 +42,39 @@
 
 # Packages that we need access to
 from . import lti
-
-# Specific functions that we use
+import numpy as np
 from numpy import pi
 
 # Utility function to unwrap an angle measurement
-
 def unwrap(angle, period=2*pi):
     """Unwrap a phase angle to give a continuous curve
 
     Parameters
     ----------
-    X : array_like
-        Input array
-    period : number
-        Input period (usually either 2``*``pi or 360)
+    angle : array_like
+        Array of angles to be unwrapped
+    period : float, optional
+        Period (defaults to `2*pi`)
 
     Returns
     -------
-    Y : array_like
+    angle_out : array_like
         Output array, with jumps of period/2 eliminated
 
     Examples
     --------
     >>> import numpy as np
-    >>> X = [5.74, 5.97, 6.19, 0.13, 0.35, 0.57]
-    >>> unwrap(X, period=2 * np.pi)
+    >>> theta = [5.74, 5.97, 6.19, 0.13, 0.35, 0.57]
+    >>> unwrap(theta, period=2 * np.pi)
     [5.74, 5.97, 6.19, 6.413185307179586, 6.633185307179586, 6.8531853071795865]
 
     """
-    wrap = 0;
-    last = angle[0];
-
-    for k in range(len(angle)):
-        # See if we need to account for angle wrapping
-        if (angle[k] - last > period/2):
-            wrap -= period
-        elif (last - angle[k] > period/2):
-            wrap += period
-
-        # Update the last value we have sene
-        last = angle[k]
-
-        # Add in the wrap angle if nonzer
-        if (wrap != 0):
-            angle[k] += wrap;
-
-    # return the updated list
+    dangle = np.diff(angle)
+    dangle_desired = (dangle + period/2.) % period - period/2.
+    correction = np.cumsum(dangle_desired - dangle)
+    angle[1:] += correction
     return angle
 
-# Determine if an object is a system
-def issys(object):
-    # Check for a member of one of the classes that we define here
-    #! TODO: this should probably look for an LTI object instead??
-    if (isinstance(object, lti.Lti)):
-        return True
-
-    # Didn't find anything that matched
-    return False
+def issys(obj):
+    """Return True if an object is a system, otherwise False"""
+    return isinstance(obj, lti.Lti)

--- a/control/tests/ctrlutil_test.py
+++ b/control/tests/ctrlutil_test.py
@@ -1,0 +1,43 @@
+import unittest
+import numpy as np
+from control.ctrlutil import *
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.mag = np.array([1, 10, 100, 2, 0.1, 0.01])
+        self.db = np.array([0, 20, 40, 6.0206, -20, -40])
+
+    def check_unwrap_array(self, angle, period=None):
+        if period is None:
+            angle_mod = angle % (2 * np.pi)
+            angle_unwrap = unwrap(angle_mod)
+        else:
+            angle_mod = angle % period
+            angle_unwrap = unwrap(angle_mod, period)
+        np.testing.assert_array_almost_equal(angle_unwrap, angle)
+
+    def test_unwrap_increasing(self):
+        angle = np.linspace(0, 20, 50)
+        self.check_unwrap_array(angle)
+
+    def test_unwrap_decreasing(self):
+        angle = np.linspace(0, -20, 50)
+        self.check_unwrap_array(angle)
+
+    def test_unwrap_inc_degrees(self):
+        angle = np.linspace(0, 720, 50)
+        self.check_unwrap_array(angle, 360)
+
+    def test_unwrap_dec_degrees(self):
+        angle = np.linspace(0, -720, 50)
+        self.check_unwrap_array(angle, 360)
+
+    def test_unwrap_large_skips(self):
+        angle = np.array([0., 4 * np.pi, -2 * np.pi])
+        np.testing.assert_array_almost_equal(unwrap(angle), [0., 0., 0.])
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(TestUtils)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control/tests/ctrlutil_test.py
+++ b/control/tests/ctrlutil_test.py
@@ -41,6 +41,22 @@ class TestUtils(unittest.TestCase):
         angle_unwrapped = [0, 0.2, 0.4, 0.6]
         np.testing.assert_array_almost_equal(unwrap(angle, 1.0), angle_unwrapped)
 
+    def test_db2mag(self):
+        for mag, db in zip(self.mag, self.db):
+            np.testing.assert_almost_equal(mag, db2mag(db))
+
+    def test_db2mag_array(self):
+        mag_array = db2mag(self.db)
+        np.testing.assert_array_almost_equal(mag_array, self.mag)
+
+    def test_mag2db(self):
+        for db, mag in zip(self.db, self.mag):
+            np.testing.assert_almost_equal(db, mag2db(mag))
+
+    def test_mag2db_array(self):
+        db_array = mag2db(self.mag)
+        np.testing.assert_array_almost_equal(db_array, self.db)
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(TestUtils)

--- a/control/tests/ctrlutil_test.py
+++ b/control/tests/ctrlutil_test.py
@@ -5,7 +5,7 @@ from control.ctrlutil import *
 class TestUtils(unittest.TestCase):
     def setUp(self):
         self.mag = np.array([1, 10, 100, 2, 0.1, 0.01])
-        self.db = np.array([0, 20, 40, 6.0206, -20, -40])
+        self.db = np.array([0, 20, 40, 6.0205999, -20, -40])
 
     def check_unwrap_array(self, angle, period=None):
         if period is None:
@@ -35,6 +35,12 @@ class TestUtils(unittest.TestCase):
     def test_unwrap_large_skips(self):
         angle = np.array([0., 4 * np.pi, -2 * np.pi])
         np.testing.assert_array_almost_equal(unwrap(angle), [0., 0., 0.])
+
+    def test_unwrap_list(self):
+        angle = [0, 2.2, 5.4, -0.4]
+        angle_unwrapped = [0, 0.2, 0.4, 0.6]
+        np.testing.assert_array_almost_equal(unwrap(angle, 1.0), angle_unwrapped)
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(TestUtils)


### PR DESCRIPTION
This PR adds some small routines to convert magnitudes to decibels and back, and cleans up a couple of the other utilities in `control/ctrlutil`.  In particular, there was a small bug in the `unwrap` routine, which gave incorrect results for large jumps in phase angle.  The new implementation fixes this bug, and is also faster and cleaner.  The old implementation of `issys` was also unnecessarily verbose.
