### PR TITLE
Margin fix

### DIFF
--- a/control/margins.py
+++ b/control/margins.py
@@ -312,4 +312,4 @@ def margin(*args):
         raise ValueError("Margin needs 1 or 3 arguments; received %i."
             % len(args))
 
-    return margin[0], margin[1], margin[4], margin[3]
+    return margin[0], margin[1], margin[3], margin[4]

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -20,6 +20,7 @@ class TestMargin(unittest.TestCase):
         s = TransferFunction([1, 0], [1])
         self.sys4 = (8.75*(4*s**2+0.4*s+1))/((100*s+1)*(s**2+0.22*s+1)) * \
                                       1./(s**2/(10.**2)+2*0.04*s/10.+1)
+        self.stability_margins4 = [2.2716, 97.5941, 1.0454, 10.0053, 0.0850, 0.4973]
 
     def test_stability_margins(self):
         gm, pm, sm, wg, wp, ws = stability_margins(self.sys1);
@@ -28,7 +29,13 @@ class TestMargin(unittest.TestCase):
         gm, pm, sm, wg, wp, ws = stability_margins(self.sys4);
         np.testing.assert_array_almost_equal(
             [gm, pm, sm, wg, wp, ws],
-            [2.2716, 97.5941, 1.0454, 10.0053, 0.0850, 0.4973], 3) 
+            self.stability_margins4, 3)
+
+    def test_margin(self):
+        gm, pm, wg, wp = margin(self.sys4)
+        np.testing.assert_array_almost_equal(
+            [gm, pm, wg, wp],
+            self.stability_margins4[:2] + self.stability_margins4[3:5], 3)
 
     def test_phase_crossover_frequencies(self):
         omega, gain = phase_crossover_frequencies(self.sys2)

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -257,7 +257,7 @@ class TestMatlab(unittest.TestCase):
         gm, pm, wg, wp = margin(self.siso_ss2);
         gm, pm, wg, wp = margin(self.siso_ss2*self.siso_ss2*2);
         np.testing.assert_array_almost_equal(
-            [gm, pm, wg, wp], [1.5451, 75.9933, 0.6559, 1.2720], decimal=3)
+            [gm, pm, wg, wp], [1.5451, 75.9933, 1.2720, 0.6559], decimal=3)
 
     def testDcgain(self):
         #Create different forms of a SISO system
@@ -608,8 +608,8 @@ class TestMatlab(unittest.TestCase):
         # print("%f %f %f %f" % (gm, pm, wg, wp))
         self.assertAlmostEqual(gm, 3.32065569155)
         self.assertAlmostEqual(pm, 46.9740430224)
-        self.assertAlmostEqual(wg, 0.0616288455466)
-        self.assertAlmostEqual(wp, 0.176469728448)
+        self.assertAlmostEqual(wg, 0.176469728448)
+        self.assertAlmostEqual(wp, 0.0616288455466)
 
 #! TODO: not yet implemented
 #    def testMIMOtfdata(self):

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -554,8 +554,6 @@ class TestMatlab(unittest.TestCase):
                       -0.260952977031384  -0.274201791021713;
                       -0.304617775734327   0.075182622718853"""), sysd.B)
 
-
-    @unittest.skip("need to update margin command")
     def testCombi01(self):
         # test from a "real" case, combines tf, ss, connect and margin
         # this is a type 2 system, with phase starting at -180. The
@@ -610,8 +608,8 @@ class TestMatlab(unittest.TestCase):
         # print("%f %f %f %f" % (gm, pm, wg, wp))
         self.assertAlmostEqual(gm, 3.32065569155)
         self.assertAlmostEqual(pm, 46.9740430224)
-        self.assertAlmostEqual(wp, 0.0616288455466)
-        self.assertAlmostEqual(wg, 0.176469728448)
+        self.assertAlmostEqual(wg, 0.0616288455466)
+        self.assertAlmostEqual(wp, 0.176469728448)
 
 #! TODO: not yet implemented
 #    def testMIMOtfdata(self):


### PR DESCRIPTION
This is a straightforward fix to margin.

The related tests have some odd properties, e.g., TestMargin in margin_test.py has four test systems, but only checks the results for one of them; and similarly TestMatlab.testMargin() runs margin() on five systems, but only checks one result.

Oh, and apologies for the two commits; I didn't run the full test suite before the first commit.