### PR TITLE
Fixes to margin calculation

### DIFF
--- a/control/margins.py
+++ b/control/margins.py
@@ -223,10 +223,18 @@ def stability_margins(sysdata, returnall=False, epsw=1e-10):
             [ sp.optimize.brentq(arg, sys.omega[i], sys.omega[i+1])
               for i in widx if i+1 < len(sys.omega) ])
 
+        # find all stab margins?
+        widx = np.where(np.diff(np.sign(np.diff(dstab(sys.omega)))))[0]
+        wstab = np.array(
+            [ sp.optimize.minimize_scalar(
+                  dstab, bracket=(sys.omega[i], sys.omega[i+1]))
+              for i in widx if i+1 < len(sys.omega) and
+              np.diff(np.diff(dstab(sys.omega[i-1:i+2])))[0] < 0 ])
+        
         # there is really only one stab margin; the closest
-        res = sp.optimize.minimize_scalar(
-            dstab, bracket=(sys.omega[0], sys.omega[-1]))
-        wstab = np.array([res.x])
+        #res = sp.optimize.minimize_scalar(
+        #    dstab, bracket=(sys.omega[0], sys.omega[-1]))
+        #wstab = np.array([res.x])
 
     # margins, as iterables, converted frdata and xferfcn calculations to
     # vector for this

--- a/control/margins.py
+++ b/control/margins.py
@@ -104,7 +104,7 @@ def stability_margins(sysdata, returnall=False, epsw=1e-8):
         minimum stability margins.  For frequency data or FRD systems, only one
         margin is found and returned.
     epsw: float, optional
-        Frequencies below this value (default 1e-10) are considered static gain,
+        Frequencies below this value (default 1e-8) are considered static gain,
         and not returned as margin.
 
     Returns

--- a/control/margins.py
+++ b/control/margins.py
@@ -150,7 +150,7 @@ def stability_margins(sysdata, returnall=False, epsw=1e-10):
         rnum, inum = _polyimsplit(sys.num[0][0])
         rden, iden = _polyimsplit(sys.den[0][0])
 
-        # test imaginary part of tf == 0, for phase crossover/gain margins
+        # test (imaginary part of tf) == 0, for phase crossover/gain margins
         test_w_180 = np.polyadd(np.polymul(inum, rden), np.polymul(rnum, -iden))
         w_180 = np.roots(test_w_180)
 
@@ -180,8 +180,8 @@ def stability_margins(sysdata, returnall=False, epsw=1e-10):
         # to have a minimum
         # from comparison to numerical one below, this seems to be wrong!
         # no one complained so far
-        test_wstabn = np.polyadd(_polysqr(rnum), _polysqr(inum))
-        test_wstabd = np.polyadd(_polysqr(np.polyadd(rnum,rden)),
+        test_wstabd = np.polyadd(_polysqr(rden), _polysqr(iden))
+        test_wstabn = np.polyadd(_polysqr(np.polyadd(rnum,rden)),
                                  _polysqr(np.polyadd(inum,iden)))
         test_wstab = np.polysub(
             np.polymul(np.polyder(test_wstabn),test_wstabd),
@@ -230,21 +230,20 @@ def stability_margins(sysdata, returnall=False, epsw=1e-10):
 
     # margins, as iterables, converted frdata and xferfcn calculations to
     # vector for this
-    GM = 1/(np.abs(sys.evalfr(w_180)[0][0]))
-    print(wstab)
-    SM = 1/np.abs(sys.evalfr(wstab)[0][0]+1)
+    GM = 1/np.abs(sys.evalfr(w_180)[0][0])
+    SM = np.abs(sys.evalfr(wstab)[0][0]+1)
     PM = np.angle(sys.evalfr(wc)[0][0], deg=True) + 180
     
     if returnall:
         return GM, PM, SM, w_180, wc, wstab
     else:
         return (
-            (GM.shape[0] or None) and GM[GM==np.min(GM)][0],
-            (PM.shape[0] or None) and PM[PM==np.min(PM)][0],
-            (SM.shape[0] or None) and SM[0],
-            (w_180.shape[0] or None) and w_180[GM==np.min(GM)][0],
-            (wc.shape[0] or None) and wc[PM==np.min(PM)][0],
-            (wstab.shape[0] or None) and wstab[0])
+            (GM.shape[0] or None) and np.amin(GM),
+            (PM.shape[0] or None) and np.amin(PM),
+            (SM.shape[0] or None) and np.amin(SM),
+            (w_180.shape[0] or None) and w_180[GM==np.amin(GM)][0],
+            (wc.shape[0] or None) and wc[PM==np.amin(PM)][0],
+            (wstab.shape[0] or None) and wstab[SM==np.amin(SM)])
 
 
 # Contributed by Steffen Waldherr <waldherr@ist.uni-stuttgart.de>

--- a/control/margins.py
+++ b/control/margins.py
@@ -130,8 +130,8 @@ def stability_margins(sysdata, returnall=False, epsw=1e-10):
             sys = sysdata
         elif getattr(sysdata, '__iter__', False) and len(sysdata) == 3:
             mag, phase, omega = sysdata
-            sys = frdata.FRD(mag * np.exp(1j * phase * np.pi/180), omega,
-                             smooth=True)
+            sys = frdata.FRD(mag * np.exp(1j * phase * np.pi/180), 
+                             omega, smooth=True)
         else:
             sys = xferfcn._convertToTransferFunction(sysdata)
     except Exception as e:
@@ -227,9 +227,10 @@ def stability_margins(sysdata, returnall=False, epsw=1e-10):
         widx = np.where(np.diff(np.sign(np.diff(dstab(sys.omega)))))[0]
         wstab = np.array(
             [ sp.optimize.minimize_scalar(
-                  dstab, bracket=(sys.omega[i], sys.omega[i+1]))
+                  dstab, bracket=(sys.omega[i], sys.omega[i+1])).x
               for i in widx if i+1 < len(sys.omega) and
               np.diff(np.diff(dstab(sys.omega[i-1:i+2])))[0] < 0 ])
+        print (wstab)
         
         # there is really only one stab margin; the closest
         #res = sp.optimize.minimize_scalar(

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -3,6 +3,7 @@
 # margin_test.py - test suit for stability margin commands
 # RMM, 15 Jul 2011
 
+from __future__ import print_function
 import unittest
 import numpy as np
 from control.xferfcn import TransferFunction
@@ -23,14 +24,18 @@ class TestMargin(unittest.TestCase):
                                       1./(s**2/(10.**2)+2*0.04*s/10.+1)
 
     def test_stability_margins(self):
-        gm, pm, sm, wg, wp, ws = stability_margins(self.sys1);
-        gm, pm, sm, wg, wp, ws = stability_margins(self.sys2);
-        gm, pm, sm, wg, wp, ws = stability_margins(self.sys3);
-        gm, pm, sm, wg, wp, ws = stability_margins(self.sys4);
+        omega = np.logspace(-2, 2, 200)
+        for sys in (self.sys1, self.sys2, self.sys3, self.sys4):
+            out = stability_margins(sys)
+            gm, pm, sm, wg, wp, ws = out
+            outf = stability_margins(FRD(sys, omega))
+        print(sys, out, outf)
+        np.testing.assert_array_almost_equal(out, outf, 3)
+        # final one with fixed values
         np.testing.assert_array_almost_equal(
             [gm, pm, sm, wg, wp, ws],
-            [2.2716, 97.5941, 0.9565, 10.0053, 0.0850, 0.4973], 3) 
-
+            [2.2716, 97.5941, 0.9633, 10.0053, 0.0850, 0.4064], 3) 
+        
     def test_phase_crossover_frequencies(self):
         omega, gain = phase_crossover_frequencies(self.sys2)
         np.testing.assert_array_almost_equal(omega, [1.73205,  0.])
@@ -95,7 +100,6 @@ class TestMargin(unittest.TestCase):
         C=K*(1+1.9*s)
         TFopen=fresp*C*G
         gm, pm, sm, wg, wp, ws = stability_margins(TFopen)
-        print gm
         np.testing.assert_array_almost_equal(
             [pm], [44.55], 2)
 
@@ -105,7 +109,7 @@ class TestMargin(unittest.TestCase):
         h1 = 1/(1+s)
         h2 = 3*(10+s)/(2+s)
         h3 = 0.01*(10-s)/(2+s)/(1+s)
-        gm, pm, sm, wg, wp, ws = stability_margins(h1)
+        gm, pm, wm, wg, wp, ws = stability_margins(h1)
         self.assertEqual(gm, None)
         self.assertEqual(wg, None)
         gm, pm, wm, wg, wp, ws = stability_margins(h2)
@@ -117,7 +121,6 @@ class TestMargin(unittest.TestCase):
         out2b = stability_margins(FRD(h2, omega))
         out3b = stability_margins(FRD(h3, omega))
         
-
         
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(TestMargin)

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -6,6 +6,7 @@
 import unittest
 import numpy as np
 from control.xferfcn import TransferFunction
+from control.frdata import FRD
 from control.statesp import StateSpace
 from control.margins import *
 
@@ -28,7 +29,7 @@ class TestMargin(unittest.TestCase):
         gm, pm, sm, wg, wp, ws = stability_margins(self.sys4);
         np.testing.assert_array_almost_equal(
             [gm, pm, sm, wg, wp, ws],
-            [2.2716, 97.5941, 1.0454, 10.0053, 0.0850, 0.4973], 3) 
+            [2.2716, 97.5941, 0.9565, 10.0053, 0.0850, 0.4973], 3) 
 
     def test_phase_crossover_frequencies(self):
         omega, gain = phase_crossover_frequencies(self.sys2)
@@ -59,7 +60,65 @@ class TestMargin(unittest.TestCase):
         marg2 = np.array(out2)[ind]
         np.testing.assert_array_almost_equal(marg1, marg2, 4)
 
+    def test_frd(self):
+        f = np.array([0.005, 0.010, 0.020, 0.030, 0.040,
+              0.050, 0.060, 0.070, 0.080, 0.090,
+              0.100, 0.200, 0.300, 0.400, 0.500,
+              0.750, 1.000, 1.250, 1.500, 1.750,
+              2.000, 2.250, 2.500, 2.750, 3.000,
+              3.250, 3.500, 3.750, 4.000, 4.250,
+              4.500, 4.750, 5.000, 6.000, 7.000,
+              8.000, 9.000, 10.000 ])
+        gain = np.array([  0.0,   0.0,   0.0,   0.0,   0.0,
+                        0.0,   0.0,   0.0,   0.0,   0.0,
+                   0.0,   0.1,   0.2,   0.3,   0.5,
+                   0.5,  -0.4,  -2.3,  -4.8,  -7.3,
+                  -9.6, -11.7, -13.6, -15.3, -16.9,
+                 -18.3, -19.6, -20.8, -22.0, -23.1,
+                 -24.1, -25.0, -25.9, -29.1, -31.9,
+                 -34.2, -36.2, -38.1 ])
+        phase = np.array([    0,    -1,    -2,    -3,    -4,
+                     -5,    -6,    -7,    -8,    -9,
+                    -10,   -19,   -29,   -40,   -51,
+                    -81,  -114,  -144,  -168,  -187,
+                   -202,  -214,  -224,  -233,  -240,
+                   -247,  -253,  -259,  -264,  -269,
+                   -273,  -277,  -280,  -292,  -301,
+                   -307,  -313,  -317 ])
+        # calculate response as complex number
+        resp = 10**(gain / 20) * np.exp(1j * phase / (180./np.pi))
+        # frequency response data
+        fresp = FRD(resp, f*2*np.pi, smooth=True)
+        s=TransferFunction([1,0],[1])
+        G=1./(s**2)
+        K=1.
+        C=K*(1+1.9*s)
+        TFopen=fresp*C*G
+        gm, pm, sm, wg, wp, ws = stability_margins(TFopen)
+        print gm
+        np.testing.assert_array_almost_equal(
+            [pm], [44.55], 2)
 
+    def test_nocross(self):
+        # what happens when no gain/phase crossover?
+        s = TransferFunction([1, 0], [1])
+        h1 = 1/(1+s)
+        h2 = 3*(10+s)/(2+s)
+        h3 = 0.01*(10-s)/(2+s)/(1+s)
+        gm, pm, sm, wg, wp, ws = stability_margins(h1)
+        self.assertEqual(gm, None)
+        self.assertEqual(wg, None)
+        gm, pm, wm, wg, wp, ws = stability_margins(h2)
+        self.assertEqual(pm, None)
+        gm, pm, wm, wg, wp, ws = stability_margins(h3)
+        self.assertEqual(pm, None)
+        omega = np.logspace(-2,2, 100)
+        out1b = stability_margins(FRD(h1, omega))
+        out2b = stability_margins(FRD(h2, omega))
+        out3b = stability_margins(FRD(h3, omega))
+        
+
+        
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(TestMargin)
 


### PR DESCRIPTION
It seems that back when I implemented a new margin calculation, there were some bugs left. In this pull request, I fixed the following:

- the 'stability margin' (concept unknown in Matlab??) was fixed. We encountered a test case here in Delft that gives 3 solutions & did not match the analytical and numerical approach. Re-implemented the numerical approach, to look through the complete frequency vector and find all crossings (derivative of distance to -1 is zero), and weed out the maxima. Also corrected the analytical solution; this had a typo in there

- checked and fixed gain margin and phase crossover frequency calculations

- added an extra test case, and extended testing.

In an sideways related issue, I found that the "smooth" parameter was dropped from an FRD when the FRD was combined with a linear system, multiplied with a gain, etc. Fixed that to keep smooth FRD smooth, and go nonsmooth as soon as a combination with an FRD without the smooth parameter is requested.