### PR TITLE
Fix autosummary tables on readthedocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
+sudo: false
 language: python
+
+cache:
+  apt: true
+  pip: true
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.local
+
 python:
   - "2.7"
   - "3.3"
@@ -25,9 +34,9 @@ before_install:
 
 # Install packages
 install:
+  - conda install slycot
   - conda build conda-recipe
   - conda install control --use-local
-  - conda install slycot
   - pip install coveralls
 
 # command to run tests

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,6 @@
 numpydoc==0.4
 mock==1.0.1
+# install sphinx from git to get patched version
+# (fixes bug in autosummary where tables do not display)
+-e git://github.com/sphinx-doc/sphinx.git@stable#egg=Sphinx-origin_stable
 


### PR DESCRIPTION
Fix #71

This PR changes the configuration file used by readthedocs, to use the github version of sphinx instead of the latest release (1.3.1).  This fixes the problem with the autosummary tables not displaying on readthedocs.org.

There was also a problem with the travis build failing, because of a version mismatch in the numpy used to build slycot vs. python-control.  This is also fixed, simply by installing slycot before python-control in the travis build.

There are also a few lines added to the travis script to use their new "container-based infrastructure" and attempt to cache things installed by pip.  Ideally, this should speed up the travis build, but it seems about the same.