### PR TITLE
Addressing #84 and #85

### DIFF
--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -32,11 +32,12 @@ class TestStateSpace(unittest.TestCase):
     def testPole(self):
         """Evaluate the poles of a MIMO system."""
 
-        p = self.sys1.pole()
-
-        np.testing.assert_array_almost_equal(p, [3.34747678408874,
+        p = np.sort(self.sys1.pole())
+        true_p = np.sort([3.34747678408874,
             -3.17373839204437 + 1.47492908003839j,
             -3.17373839204437 - 1.47492908003839j])
+
+        np.testing.assert_array_almost_equal(p, true_p)
 
     def testZero(self):
         """Evaluate the zeros of a SISO system."""


### PR DESCRIPTION
* Compute poles of a state-space system using `numpy.linalg.eigvals` as suggested in #84 
* Replaced matrix inversion in the feedback computation by `numpy.linalg.solve` as suggested in #85 
* Also replaced the singularity check with a more stable one. [`numpy.linalg.matrix_rank`](http://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.linalg.matrix_rank.html) uses a reasonable numerical threshold, so that we don't need to check `abs(det(F))` by hand. Determinant is actually very sensitive to matrix scaling, so better not use it. Both the determinant and the SVD required for `matrix_rank` are cubic, so there should be no slowdown.