### PR TITLE
BuildFix: change Travis build to handle conda changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,24 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION conda-build pip coverage
+  # conda-build must be installed in the conda root environment
+  - conda install conda-build
+  # TODO: point at conda.anaconda.org?
   - conda config --add channels http://conda.binstar.org/cwrowley
   - conda info -a
+  - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage slycot
+  - source activate test-environment
+  # coveralls not in conda repos
+  - pip install coveralls
 
 # Install packages
 install:
-  - conda install slycot
-  - conda build conda-recipe
+  - conda build --python "$TRAVIS_PYTHON_VERSION" conda-recipe
   - conda install control --use-local
-  - pip install coveralls
 
 # command to run tests
 script:
   - coverage run setup.py test
+
 after_success:
   - coveralls


### PR DESCRIPTION
Changes:
  - do build and test inside a conda environment
  - specify Python version at conda build stage

These changes triggered by builds failing *without* changes in HEAD; I assume this is due to Conda changes, rather than Travis changes.

See https://travis-ci.org/roryyorke/python-control/builds/142789873 for an example of master HEAD failing; first noticed in the Python 3.3 travis failure in #101 (haven't tested that on top of this fix, but given that it passes on Python 2.7 and 3.4, it seems like it would pass).

Both .travis.yml and conda-recipe/meta-yaml could do with a review by an expert (I'm not one); e.g., why is "nose" a build requirement, rather than a test requirement?  Shouldn't we follow standard (0.7.1+stuff) versioning?  Why does the version end up as 0.6d.stuff on my Travis builds, not 0.7.stuff?