### PR TITLE
Bugfix: xferfcn.TransferFunction can now be minreal'ed to a static gain.

### DIFF
--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -468,6 +468,12 @@ class TestXferFcn(unittest.TestCase):
         np.testing.assert_array_almost_equal(H2b.num[0][0], hr.num[0][0])
         np.testing.assert_array_almost_equal(H2b.den[0][0], hr.den[0][0])
 
+    def testMinreal3(self):
+        """Regression test for minreal of tf([1,1],[1,1])"""
+        g = TransferFunction([1,1],[1,1]).minreal()
+        np.testing.assert_array_almost_equal(1.0, g.num[0][0])
+        np.testing.assert_array_almost_equal(1.0, g.den[0][0])
+
     def testMIMO(self):
         """Test conversion of a single input, two-output state-space
         system against the same TF"""

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -678,12 +678,9 @@ only implemented for SISO functions.")
                         # keep this zero
                         newzeros.append(z)
 
-                # keep result
-                if len(newzeros):
-                    num[i][j] = gain * real(poly(newzeros))
-                else:
-                    num[i][j] = array([gain])
-                den[i][j] = real(poly(poles))
+                # poly([]) returns a scalar, but we always want a 1d array
+                num[i][j] = np.atleast_1d(gain * real(poly(newzeros)))
+                den[i][j] = np.atleast_1d(real(poly(poles)))
 
         # end result
         return TransferFunction(num, den)


### PR DESCRIPTION
Added test for tf([1,1],[1,1]).
