### PR TITLE
Allow static gain StateSpace objects to be straightforwardly created.

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -146,7 +146,7 @@ a StateSpace object.  Recived %s." % type(args[0]))
         if self.states != B.shape[0]:
             raise ValueError("A and B must have the same number of rows.")
         if self.states != C.shape[1]:
-            raise ValueError("A and C C must have the same number of columns.")
+            raise ValueError("A and C must have the same number of columns.")
         if self.inputs != B.shape[1]:
             raise ValueError("B and D must have the same number of columns.")
         if self.outputs != C.shape[0]:

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -180,17 +180,10 @@ a StateSpace object.  Recived %s." % type(args[0]))
                 useless.append(i)
 
         # Remove the useless states.
-        if all(useless == range(self.states)):
-            # All the states were useless.
-            self.A = zeros((1, 1))
-            self.B = zeros((1, self.inputs))
-            self.C = zeros((self.outputs, 1))
-        else:
-            # A more typical scenario.
-            self.A = delete(self.A, useless, 0)
-            self.A = delete(self.A, useless, 1)
-            self.B = delete(self.B, useless, 0)
-            self.C = delete(self.C, useless, 1)
+        self.A = delete(self.A, useless, 0)
+        self.A = delete(self.A, useless, 1)
+        self.B = delete(self.B, useless, 0)
+        self.C = delete(self.C, useless, 1)
 
         self.states = self.A.shape[0]
         self.inputs = self.B.shape[1]

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -5,9 +5,10 @@
 
 import unittest
 import numpy as np
-from scipy.linalg import eigvals
+from numpy.linalg import solve
+from scipy.linalg import eigvals, block_diag
 from control import matlab
-from control.statesp import StateSpace, _convertToStateSpace
+from control.statesp import StateSpace, _convertToStateSpace,tf2ss
 from control.xferfcn import TransferFunction
 
 class TestStateSpace(unittest.TestCase):
@@ -234,6 +235,51 @@ class TestStateSpace(unittest.TestCase):
 
         sys3 = StateSpace(0., 1., 1., 0.)
         np.testing.assert_equal(sys3.dcgain(), np.nan)
+
+
+    def test_scalarStaticGain(self):
+        """Regression: can we create a scalar static gain?"""
+        g1=StateSpace([],[],[],[2])
+        g2=StateSpace([],[],[],[3])
+
+        # make sure StateSpace internals, specifically ABC matrix
+        # sizes, are OK for LTI operations
+        g3 = g1*g2
+        self.assertEqual(6, g3.D[0,0])
+        g4 = g1+g2
+        self.assertEqual(5, g4.D[0,0])
+        g5 = g1.feedback(g2)
+        self.assertAlmostEqual(2./7, g5.D[0,0])
+        g6 = g1.append(g2)
+        np.testing.assert_array_equal(np.diag([2,3]),g6.D)
+
+    def test_matrixStaticGain(self):
+        """Regression: can we create a scalar static gain?"""
+        d1 = np.matrix([[1,2,3],[4,5,6]])
+        d2 = np.matrix([[7,8],[9,10],[11,12]])
+        g1=StateSpace([],[],[],d1)
+        g2=StateSpace([],[],[],d2)
+        g3=StateSpace([],[],[],d2.T)
+
+        h1 = g1*g2
+        np.testing.assert_array_equal(d1*d2, h1.D)
+        h2 = g1+g3
+        np.testing.assert_array_equal(d1+d2.T, h2.D)
+        h3 = g1.feedback(g2)
+        np.testing.assert_array_almost_equal(solve(np.eye(2)+d1*d2,d1), h3.D)
+        h4 = g1.append(g2)
+        np.testing.assert_array_equal(block_diag(d1,d2),h4.D)
+
+
+    def test_BadEmptyMatrices(self):
+        """Mismatched ABCD matrices when some are empty"""
+        self.assertRaises(ValueError,StateSpace, [1], [],  [],  [1])
+        self.assertRaises(ValueError,StateSpace, [1], [1], [],  [1])
+        self.assertRaises(ValueError,StateSpace, [1], [],  [1], [1])
+        self.assertRaises(ValueError,StateSpace, [],  [1], [],  [1])
+        self.assertRaises(ValueError,StateSpace, [],  [1], [1], [1])
+        self.assertRaises(ValueError,StateSpace, [],  [],  [1], [1])
+        self.assertRaises(ValueError,StateSpace, [1], [1], [1], [])
 
 class TestRss(unittest.TestCase):
     """These are tests for the proper functionality of statesp.rss."""

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -254,10 +254,14 @@ class TestStateSpace(unittest.TestCase):
         np.testing.assert_array_equal(np.diag([2,3]),g6.D)
 
     def test_matrixStaticGain(self):
-        """Regression: can we create a scalar static gain?"""
+        """Regression: can we create matrix static gains?"""
         d1 = np.matrix([[1,2,3],[4,5,6]])
         d2 = np.matrix([[7,8],[9,10],[11,12]])
         g1=StateSpace([],[],[],d1)
+
+        # _remove_useless_states was making A = [[0]]
+        self.assertEqual((0,0), g1.A.shape)
+
         g2=StateSpace([],[],[],d2)
         g3=StateSpace([],[],[],d2.T)
 
@@ -269,6 +273,18 @@ class TestStateSpace(unittest.TestCase):
         np.testing.assert_array_almost_equal(solve(np.eye(2)+d1*d2,d1), h3.D)
         h4 = g1.append(g2)
         np.testing.assert_array_equal(block_diag(d1,d2),h4.D)
+
+
+    def test_remove_useless_states(self):
+        """Regression: _remove_useless_states gives correct ABC sizes"""
+        g1 = StateSpace(np.zeros((3,3)),
+                        np.zeros((3,4)),
+                        np.zeros((5,3)),
+                        np.zeros((5,4)))
+        self.assertEqual((0,0), g1.A.shape)
+        self.assertEqual((0,4), g1.B.shape)
+        self.assertEqual((5,0), g1.C.shape)
+        self.assertEqual((5,4), g1.D.shape)
 
 
     def test_BadEmptyMatrices(self):

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -253,6 +253,7 @@ class TestStateSpace(unittest.TestCase):
         g6 = g1.append(g2)
         np.testing.assert_array_equal(np.diag([2,3]),g6.D)
 
+
     def test_matrixStaticGain(self):
         """Regression: can we create matrix static gains?"""
         d1 = np.matrix([[1,2,3],[4,5,6]])
@@ -297,6 +298,29 @@ class TestStateSpace(unittest.TestCase):
         self.assertRaises(ValueError,StateSpace, [],  [],  [1], [1])
         self.assertRaises(ValueError,StateSpace, [1], [1], [1], [])
 
+
+    def test_Empty(self):
+        """Regression: can we create an empty StateSpace object?"""
+        g1=StateSpace([],[],[],[])
+        self.assertEqual(0,g1.states)
+        self.assertEqual(0,g1.inputs)
+        self.assertEqual(0,g1.outputs)
+
+
+    def test_MatrixToStateSpace(self):
+        """_convertToStateSpace(matrix) gives ss([],[],[],D)"""
+        D = np.matrix([[1,2,3],[4,5,6]])
+        g = _convertToStateSpace(D)
+        def empty(shape):
+            m = np.matrix([])
+            m.shape = shape
+            return m
+        np.testing.assert_array_equal(empty((0,0)), g.A)
+        np.testing.assert_array_equal(empty((0,D.shape[1])), g.B)
+        np.testing.assert_array_equal(empty((D.shape[0],0)), g.C)
+        np.testing.assert_array_equal(D,g.D)
+
+        
 class TestRss(unittest.TestCase):
     """These are tests for the proper functionality of statesp.rss."""
 


### PR DESCRIPTION
Lets the (fairly?) obvious StateSpace([],[],[],D) work.  One could previously create these by, e.g., converting a static gain TransferFunction to a StateSpace object.

In this case A will be 0-by-0, B 0-by-inputs, and C outputs-by-0.  My intuition is that this is a generally correct approach (consider the simplification of _remove_useless_states, for example), but it may require some thought during review.
