### PR TITLE
Enable Travis builds for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 # install required system libraries
 before_install:


### PR DESCRIPTION
Following suggestion of @mp4096, add Python 3.5 to .travis.yml.  Sorry @slivingston, you merged #102 before I could push this there.