### PR TITLE
Updates to balred() and gram()

### DIFF
--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -95,6 +95,28 @@ class TestModelsimp(unittest.TestCase):
         np.testing.assert_array_almost_equal(rsys.C, Crtrue,decimal=4)
         np.testing.assert_array_almost_equal(rsys.D, Drtrue,decimal=4)
 
+    def testBalredMatchDC(self):
+        #controlable canonical realization computed in matlab for the transfer function:
+        # num = [1 11 45 32], den = [1 15 60 200 60]
+        A = np.matrix('-15., -7.5, -6.25, -1.875; \
+        8., 0., 0., 0.; \
+        0., 4., 0., 0.; \
+        0., 0., 1., 0.')
+        B = np.matrix('2.; 0.; 0.; 0.')
+        C = np.matrix('0.5, 0.6875, 0.7031, 0.5')
+        D = np.matrix('0.')
+        sys = ss(A,B,C,D)
+        orders = 2
+        rsys = balred(sys,orders,method='matchdc')
+        Artrue = np.matrix('-4.43094773, -4.55232904; -4.55232904, -5.36195206')
+        Brtrue = np.matrix('1.36235673; 1.03114388')
+        Crtrue = np.matrix('1.36235673, 1.03114388')
+        Drtrue = np.matrix('-0.08383902')
+        np.testing.assert_array_almost_equal(rsys.A, Artrue,decimal=2)
+        np.testing.assert_array_almost_equal(rsys.B, Brtrue,decimal=4)
+        np.testing.assert_array_almost_equal(rsys.C, Crtrue,decimal=4)
+        np.testing.assert_array_almost_equal(rsys.D, Drtrue,decimal=4)
+
 def suite():
    return unittest.TestLoader().loadTestsFromTestCase(TestModelsimp)
 

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -71,6 +71,16 @@ class TestStatefbk(unittest.TestCase):
         Wc = gram(sys,'c')
         np.testing.assert_array_almost_equal(Wc, Wctrue)
 
+    def testGramRc(self):
+        A = np.matrix("1. -2.; 3. -4.")
+        B = np.matrix("5. 6.; 7. 8.")
+        C = np.matrix("4. 5.; 6. 7.")
+        D = np.matrix("13. 14.; 15. 16.")
+        sys = ss(A, B, C, D)
+        Rctrue = np.matrix("4.30116263 5.6961343; 0. 0.23249528")
+        Rc = gram(sys,'cf')
+        np.testing.assert_array_almost_equal(Rc, Rctrue)
+
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testGramWo(self):
         A = np.matrix("1. -2.; 3. -4.")
@@ -92,6 +102,16 @@ class TestStatefbk(unittest.TestCase):
         Wotrue = np.matrix("198. -72.; -72. 44.")
         Wo = gram(sys,'o')
         np.testing.assert_array_almost_equal(Wo, Wotrue)
+
+    def testGramRo(self):
+        A = np.matrix("1. -2.; 3. -4.")
+        B = np.matrix("5. 6.; 7. 8.")
+        C = np.matrix("4. 5.; 6. 7.")
+        D = np.matrix("13. 14.; 15. 16.")
+        sys = ss(A, B, C, D)
+        Rotrue = np.matrix("16.04680654 -5.8890222; 0. 4.67112593")
+        Ro = gram(sys,'of')
+        np.testing.assert_array_almost_equal(Ro, Rotrue)
 
     def testGramsys(self):
         num =[1.]


### PR DESCRIPTION
balred() now supports "matchdc" and will handle unstable systems and will accept a list of ORDERS, which will return a list of reduced order systems. gram() now does Cholesky factored gramians if desired. Requires my updates to [slycot](https://github.com/python-control/Slycot/pull/2).
