### PR TITLE
Make output of time response consistent

### DIFF
--- a/control/matlab/timeresp.py
+++ b/control/matlab/timeresp.py
@@ -118,7 +118,7 @@ def impulse(sys, T=None, input=0, output=None, return_x=False):
 
     return yout, T
 
-def initial(sys, T=None, X0=0., input=None, output=None):
+def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
     '''
     Initial condition response of a linear system
 

--- a/control/matlab/timeresp.py
+++ b/control/matlab/timeresp.py
@@ -66,7 +66,7 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
 
     return yout, T
 
-def impulse(sys, T=None, input=0, output=None, return_x=False):
+def impulse(sys, T=None, X0=0., input=0, output=None, return_x=False):
     '''
     Impulse response of a linear system
 
@@ -83,6 +83,11 @@ def impulse(sys, T=None, input=0, output=None, return_x=False):
 
     T: array-like object, optional
         Time vector (argument is autocomputed if not given)
+
+    X0: array-like or number, optional
+        Initial condition (default = 0)
+
+        Numbers are converted to constant arrays with the correct shape.
 
     input: int
         Index of the input that will be used in this simulation.
@@ -110,7 +115,7 @@ def impulse(sys, T=None, input=0, output=None, return_x=False):
     >>> yout, T = impulse(sys, T)
     '''
     from ..timeresp import impulse_response
-    T, yout, xout = impulse_response(sys, T, 0, input, output,
+    T, yout, xout = impulse_response(sys, T, X0, input, output,
                                      transpose = True, return_x=True)
 
     if return_x:

--- a/control/matlab/timeresp.py
+++ b/control/matlab/timeresp.py
@@ -40,11 +40,11 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
     yout: array
         Response of the system
 
-    xout: array (if selected)
-        Individual response of each x variable
-
     T: array
         Time values of the output
+
+    xout: array (if selected)
+        Individual response of each x variable
 
 
 
@@ -62,11 +62,11 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
                                   transpose = True, return_x=True)
 
     if return_x:
-        return yout, xout, T
+        return yout, T, xout
 
     return yout, T
 
-def impulse(sys, T=None, input=0, output=None):
+def impulse(sys, T=None, input=0, output=None, return_x=False):
     '''
     Impulse response of a linear system
 
@@ -94,8 +94,12 @@ def impulse(sys, T=None, input=0, output=None):
     -------
     yout: array
         Response of the system
+
     T: array
         Time values of the output
+
+    xout: array (if selected)
+        Individual response of each x variable
 
     See Also
     --------
@@ -106,8 +110,12 @@ def impulse(sys, T=None, input=0, output=None):
     >>> yout, T = impulse(sys, T)
     '''
     from ..timeresp import impulse_response
-    T, yout = impulse_response(sys, T, 0, input, output,
-                                        transpose = True)
+    T, yout, xout = impulse_response(sys, T, 0, input, output,
+                                     transpose = True, return_x=True)
+
+    if return_x:
+        return yout, T, xout
+
     return yout, T
 
 def initial(sys, T=None, X0=0., input=None, output=None):
@@ -142,8 +150,12 @@ def initial(sys, T=None, X0=0., input=None, output=None):
     -------
     yout: array
         Response of the system
+
     T: array
         Time values of the output
+
+    xout: array (if selected)
+        Individual response of each x variable
 
     See Also
     --------
@@ -155,8 +167,12 @@ def initial(sys, T=None, X0=0., input=None, output=None):
 
     '''
     from ..timeresp import initial_response
-    T, yout = initial_response(sys, T, X0, output=output,
-                               transpose=True)
+    T, yout, xout = initial_response(sys, T, X0, output=output,
+                                     transpose=True, return_x=True)
+
+    if return_x:
+        return yout, T, xout
+
     return yout, T
 
 def lsim(sys, U=0., T=None, X0=0.):

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -161,6 +161,10 @@ class TestMatlab(unittest.TestCase):
         np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
         np.testing.assert_array_almost_equal(tout, t)
 
+        yout, tout, xout = step(sys, T=t, X0=0, return_x=True)
+        np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+        np.testing.assert_array_almost_equal(tout, t)
+
         #Test MIMO system, which contains ``siso_ss1`` twice
         sys = self.mimo_ss1
         y_00, _t = step(sys, T=t, input=0, output=0)
@@ -188,6 +192,20 @@ class TestMatlab(unittest.TestCase):
             np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
             np.testing.assert_array_almost_equal(tout, t)
 
+            # Play with arguments
+            yout, tout = impulse(sys, T=t, X0=0)
+            np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+            np.testing.assert_array_almost_equal(tout, t)
+
+            X0 = np.array([0, 0]);
+            yout, tout = impulse(sys, T=t, X0=X0)
+            np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+            np.testing.assert_array_almost_equal(tout, t)
+
+            yout, tout, xout = impulse(sys, T=t, X0=0, return_x=True)
+            np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+            np.testing.assert_array_almost_equal(tout, t)
+
             #Test MIMO system, which contains ``siso_ss1`` twice
             sys = self.mimo_ss1
             y_00, _t = impulse(sys, T=t, input=0, output=0)
@@ -203,6 +221,11 @@ class TestMatlab(unittest.TestCase):
         youttrue = np.array([11., 8.1494, 5.9361, 4.2258, 2.9118, 1.9092,
                              1.1508, 0.5833, 0.1645, -0.1391])
         yout, tout = initial(sys, T=t, X0=x0)
+        np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+        np.testing.assert_array_almost_equal(tout, t)
+
+        # Play with arguments
+        yout, tout, xout = initial(sys, T=t, X0=x0, return_x=True)
         np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
         np.testing.assert_array_almost_equal(tout, t)
 

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -87,6 +87,20 @@ class TestTimeresp(unittest.TestCase):
         np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
         np.testing.assert_array_almost_equal(tout, t)
 
+        # Play with arguments
+        tout, yout = impulse_response(sys, T=t, X0=0)
+        np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+        np.testing.assert_array_almost_equal(tout, t)
+
+        X0 = np.array([0, 0])
+        tout, yout = impulse_response(sys, T=t, X0=X0)
+        np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+        np.testing.assert_array_almost_equal(tout, t)
+
+        tout, yout, xout = impulse_response(sys, T=t, X0=0, return_x=True)
+        np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+        np.testing.assert_array_almost_equal(tout, t)
+
         # Test MIMO system, which contains ``siso_ss1`` twice
         sys = self.mimo_ss1
         _t, y_00 = impulse_response(sys, T=t, input=0, output=0)
@@ -108,6 +122,11 @@ class TestTimeresp(unittest.TestCase):
         youttrue = np.array([11., 8.1494, 5.9361, 4.2258, 2.9118, 1.9092,
                              1.1508, 0.5833, 0.1645, -0.1391])
         tout, yout = initial_response(sys, T=t, X0=x0)
+        np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
+        np.testing.assert_array_almost_equal(tout, t)
+
+        # Play with arguments
+        tout, yout, xout = initial_response(sys, T=t, X0=x0, return_x=True)
         np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
         np.testing.assert_array_almost_equal(tout, t)
 

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -493,7 +493,7 @@ def step_response(sys, T=None, X0=0., input=None, output=None,
 
 
 def initial_response(sys, T=None, X0=0., input=0, output=None,
-                     transpose=False):
+                     transpose=False, return_x=False):
     # pylint: disable=W0622
     """Initial condition response of a linear system
 
@@ -535,6 +535,8 @@ def initial_response(sys, T=None, X0=0., input=0, output=None,
         Time values of the output
     yout: array
         Response of the system
+    xout: array
+        Individual response of each x variable
 
     See Also
     --------
@@ -553,11 +555,15 @@ def initial_response(sys, T=None, X0=0., input=0, output=None,
     U = np.zeros_like(T)
 
     T, yout, _xout = forced_response(sys, T, U, X0, transpose=transpose)
+
+    if return_x:
+        return T, yout, _xout
+
     return T, yout
 
 
 def impulse_response(sys, T=None, X0=0., input=0, output=None,
-                     transpose=False):
+                     transpose=False, return_x=False):
     # pylint: disable=W0622
     """Impulse response of a linear system
 
@@ -599,6 +605,8 @@ def impulse_response(sys, T=None, X0=0., input=0, output=None,
         Time values of the output
     yout: array
         Response of the system
+    xout: array
+        Individual response of each x variable
 
     See Also
     --------
@@ -637,4 +645,8 @@ def impulse_response(sys, T=None, X0=0., input=0, output=None,
     T, yout, _xout = forced_response(
         sys, T, U, new_X0,
         transpose=transpose)
+
+    if return_x:
+        return T, yout, _xout
+
     return T, yout


### PR DESCRIPTION
Response functions were not self consistent.
This pull requests updates the step_response, initial_response, and impulse_response to have a consistent option to return the xout from the standard responses.

additionally the matlab compatibility was updated to provide returning xout in addition to have the same order of return as the matlab counterparts.

