### PR TITLE
BugFix: DC gain for discrete-time systems

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -612,11 +612,14 @@ inputs/outputs for feedback.")
             at the origin
         """
         try:
-            gain = np.asarray(self.D -
-                              self.C.dot(np.linalg.solve(self.A, self.B)))
+            if self.isctime():
+                gain = np.asarray(self.D -
+                                    self.C.dot(np.linalg.solve(self.A, self.B)))
+            else:
+                gain = self.horner(1)
         except LinAlgError:
-            # zero eigenvalue: singular matrix
-            return np.nan
+            # eigenvalue at DC
+            gain = np.tile(np.nan,(self.outputs,self.inputs))
         return np.squeeze(gain)
 
 

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -524,7 +524,8 @@ class TestXferFcn(unittest.TestCase):
         np.testing.assert_array_almost_equal(H.num[1][0], H2.num[0][0])
         np.testing.assert_array_almost_equal(H.den[1][0], H2.den[0][0])
 
-    def test_dcgain(self):
+    def test_dcgain_cont(self):
+        """Test DC gain for continuous-time transfer functions"""
         sys = TransferFunction(6, 3)
         np.testing.assert_equal(sys.dcgain(), 2)
 
@@ -539,6 +540,26 @@ class TestXferFcn(unittest.TestCase):
         sys4 = TransferFunction(num, den)
         expected = [[5, 7, 11], [2, 2, 2]]
         np.testing.assert_array_equal(sys4.dcgain(), expected)
+
+    def test_dcgain_discr(self):
+        """Test DC gain for discrete-time transfer functions"""
+        # static gain
+        sys = TransferFunction(6, 3, True)
+        np.testing.assert_equal(sys.dcgain(), 2)
+
+        # averaging filter
+        sys = TransferFunction(0.5, [1, -0.5], True)
+        np.testing.assert_almost_equal(sys.dcgain(), 1)
+
+        # differencer
+        sys = TransferFunction(1, [1, -1], True)
+        np.testing.assert_equal(sys.dcgain(), np.inf)
+
+        # summer
+        # causes a RuntimeWarning due to the divide by zero
+        sys = TransferFunction([1,-1], [1], True)
+        np.testing.assert_equal(sys.dcgain(), 0)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(TestXferFcn)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -945,13 +945,23 @@ a zero leading coefficient." % (i, j)
     def dcgain(self):
         """Return the zero-frequency (or DC) gain
 
-        For a transfer function G(s), the DC gain is G(0)
+        For a continous-time transfer function G(s), the DC gain is G(0)
+        For a discrete-time transfer function G(z), the DC gain is G(1)
 
         Returns
         -------
         gain : ndarray
             The zero-frequency gain
         """
+        if self.isctime():
+            return self._dcgain_cont()
+        else:
+            return self(1)
+
+    def _dcgain_cont(self):
+        """_dcgain_cont() -> DC gain as matrix or scalar
+
+        Special cased evaluation at 0 for continuous-time systems"""
         gain = np.empty((self.outputs, self.inputs), dtype=float)
         for i in range(self.outputs):
             for j in range(self.inputs):


### PR DESCRIPTION
Fix for #114.

An alternative design would be to have `LTI.dcgain` call either `self(0)` (ctime) or `self(1)` (dtime); `TransferFunction.__call__` could special case for s=0, so that `g(0)` and `g.dcgain(0)` return the same thing.  In this case `__call__` would need to be implemented for `StateSpace`.  In my opinion `evalfr` and `freqresp` should both use `__call__`, and that `horner` should be deprecated.
