### PR TITLE
Removed matplotlib holds.

### DIFF
--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -176,7 +176,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                     pltline = ax_mag.semilogx(omega_plot, 20 * np.log10(mag), *args, **kwargs)
                 else:
                     pltline = ax_mag.loglog(omega_plot, mag, *args, **kwargs)
-                plt.hold(True);
+
                 if nyquistfrq_plot:
                     ax_mag.axvline(nyquistfrq_plot, color=pltline[0].get_color())
 
@@ -191,7 +191,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                 else:
                     phase_plot = phase
                 ax_phase.semilogx(omega_plot, phase_plot, *args, **kwargs)
-                ax_phase.hold(True);
+
                 if nyquistfrq_plot:
                     ax_phase.axvline(nyquistfrq_plot, color=pltline[0].get_color())
 

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -212,7 +212,7 @@ def phase_plot(odefun, X=None, Y=None, scale=1, X0=None, T=None,
     for i in range(nr):
         state = odeint(odefun, X0[i], TSPAN, args=parms);
         time = TSPAN
-        mpl.hold(True);
+
         mpl.plot(state[:,0], state[:,1])
         #! TODO: add back in colors for stream lines
         # PP_stream_color(np.mod(i-1, len(PP_stream_color))+1));


### PR DESCRIPTION
I found this testing with matplotlib-2.0.

‘hold’ functionality deprecated.

The ‘hold’ keyword argument and all functions and methods related to it are deprecated, along with the ‘axes.hold’ rcParams entry. The behavior will remain consistent with the default hold=True state that has long been in place. Instead of using a function or keyword argument (hold=False) to change that behavior, explicitly clear the axes or figure as needed prior to subsequent plotting commands.

http://matplotlib.org/api/api_changes.html#hold-functionality-deprecated