### PR TITLE
Add run of tests without Slycot on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - conda install conda-build
   - conda config --add channels python-control
   - conda info -a
-  - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage slycot
+  - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage
   - source activate test-environment
   # coveralls not in conda repos
   - pip install coveralls
@@ -45,6 +45,11 @@ install:
 
 # command to run tests
 script:
+  # Before installing Slycot
+  - python setup.py test
+
+  # Now, get and use Slycot
+  - conda install slycot
   - coverage run setup.py test
 
 after_success:

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -107,6 +107,7 @@ class TestModelsimp(unittest.TestCase):
         np.testing.assert_array_almost_equal(rsys.C, Crtrue,decimal=4)
         np.testing.assert_array_almost_equal(rsys.D, Drtrue,decimal=4)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testBalredMatchDC(self):
         #controlable canonical realization computed in matlab for the transfer function:
         # num = [1 11 45 32], den = [1 15 60 200 60]

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -71,6 +71,7 @@ class TestStatefbk(unittest.TestCase):
         Wc = gram(sys,'c')
         np.testing.assert_array_almost_equal(Wc, Wctrue)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testGramRc(self):
         A = np.matrix("1. -2.; 3. -4.")
         B = np.matrix("5. 6.; 7. 8.")
@@ -103,6 +104,7 @@ class TestStatefbk(unittest.TestCase):
         Wo = gram(sys,'o')
         np.testing.assert_array_almost_equal(Wo, Wotrue)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testGramRo(self):
         A = np.matrix("1. -2.; 3. -4.")
         B = np.matrix("5. 6.; 7. 8.")


### PR DESCRIPTION
Because tests and parts of `control` that are used depend on whether Slycot is installed, it is worthwhile to exercise both cases as part of CI testing. This pull request does so. Test coverage is only for the case with Slycot installed (as from before this pull request).

The second commit disables tests that depend on Slycot if it is not found. Affected tests were introduced in PR #118.