### PR TITLE
Make output response matrices consistent between continuous and discrete time

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -14,7 +14,7 @@ import numpy as np
 from control.timeresp import *
 from control.statesp import *
 from control.xferfcn import TransferFunction, _convertToTransferFunction
-
+from control.dtime import c2d
 
 class TestTimeresp(unittest.TestCase):
     def setUp(self):
@@ -76,6 +76,15 @@ class TestTimeresp(unittest.TestCase):
         _t, y_11 = step_response(sys, T=t, input=1, output=1)
         np.testing.assert_array_almost_equal(y_00, youttrue, decimal=4)
         np.testing.assert_array_almost_equal(y_11, youttrue, decimal=4)
+
+        # Make sure continuous and discrete time use same return conventions
+        sysc = self.mimo_ss1
+        sysd = c2d(sysc, 1)           # discrete time system
+        Tvec = np.linspace(0, 10, 11) # make sure to use integer times 0..10
+        Tc, youtc = step_response(sysc, Tvec, input=0)
+        Td, youtd = step_response(sysd, Tvec, input=0)
+        np.testing.assert_array_equal(Tc.shape, Td.shape)
+        np.testing.assert_array_equal(youtc.shape, youtd.shape)
 
     def test_impulse_response(self):
         # Test SISO system

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -324,6 +324,10 @@ def forced_response(sys, T=None, U=0., X0=0., transpose=False):
         dsys = (A, B, C, D, sys.dt)
         tout, yout, xout = sp.signal.dlsim(dsys, U, T, X0)
 
+        # Transpose the output and state vectors to match local convention
+        xout = sp.transpose(xout)
+        yout = sp.transpose(yout)
+
     # See if we need to transpose the data back into MATLAB form
     if (transpose):
         T = np.transpose(T)


### PR DESCRIPTION
This PR addresses issue #142 where the output response matrices were not consistent for continuous and discrete time simulations.  The error was in the discrete time simulation, where the conventions used by `spicy.signal` are different than those used by `python-control`.  Also added a unit test that catches this error.
