### PR TITLE
SISO tf() may not work with numpy arrays with numpy.int elements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   # conda-build must be installed in the conda root environment
-  - conda install conda-build
+  - conda install conda-build=2.1.17
   - conda config --add channels python-control
   - conda info -a
   - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage

--- a/control/tests/tf_input_element_int.py
+++ b/control/tests/tf_input_element_int.py
@@ -1,0 +1,46 @@
+import unittest
+
+import numpy as np
+
+import control as ctl
+
+
+class TestTfInputIntElement(unittest.TestCase):
+    # currently these do not pass
+    def test_tf_den_with_numpy_int_element(self):
+        num = 1
+        den = np.convolve([1, 2, 1], [1, 1, 1])
+
+        sys = ctl.tf(num, den)
+
+        self.assertAlmostEqual(1.0, ctl.dcgain(sys))
+
+    def test_tf_num_with_numpy_int_element(self):
+        num = np.convolve([1], [1, 1])
+        den = np.convolve([1, 2, 1], [1, 1, 1])
+
+        sys = ctl.tf(num, den)
+
+        self.assertAlmostEqual(1.0, ctl.dcgain(sys))
+
+    # currently these pass
+    def test_tf_input_with_int_element_works(self):
+        num = 1
+        den = np.convolve([1.0, 2, 1], [1, 1, 1])
+
+        sys = ctl.tf(num, den)
+
+        self.assertAlmostEqual(1.0, ctl.dcgain(sys))
+
+    def test_ss_input_with_int_element(self):
+        ident = np.matrix(np.identity(2), dtype=int)
+        a = np.matrix([[0, 1],
+                       [-1, -2]], dtype=int) * ident
+        b = np.matrix([[0],
+                       [1]], dtype=int)
+        c = np.matrix([[0, 1]], dtype=int)
+        d = 0
+
+        sys = ctl.ss(a, b, c, d)
+        sys2 = ctl.ss2tf(sys)
+        self.assertAlmostEqual(ctl.dcgain(sys), ctl.dcgain(sys2))

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -135,7 +135,7 @@ class TransferFunction(LTI):
                 else:
                     data[i] = [[array([data[i]])]]
             elif (isinstance(data[i], (list, tuple, ndarray)) and
-                    isinstance(data[i][0], (int, float, complex))):
+                    isinstance(data[i][0], (int, float, complex, np.int64))):
                 # Convert array to list of list of array.
                 if (isinstance(data[i][0], int)):
                     # Convert integers to floats at this point


### PR DESCRIPTION
SISO tf() function may not work if an input argument is numpy.int.
(@sunhapos could identify this)

Please check the test for cases.

Should this be a numpy issue?  If so, is a quick patch such as 3fe4067 desirable?

Thanks,

KW
