### PR TITLE
Travis CI update for new/old scipy + improved slycot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,19 @@ cache:
 
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
+  - "3.6"
+
+# Test against multiple version of SciPy, with and without slycot
+#
+# Because there were significant changes in SciPy between v0 and v1, we 
+# test against both of these using the Travis CI environment capability
+#
+# We also want to test with and without slycot
+env:
+  - SCIPY=0.19.1 SLYCOT=
+  - SCIPY=0.19.1 SLYCOT=slycot
+  - SCIPY=1.0.0 SLYCOT=
 
 # install required system libraries
 before_install:
@@ -40,16 +50,15 @@ before_install:
 
 # Install packages
 install:
-  - conda build --python "$TRAVIS_PYTHON_VERSION" conda-recipe
-  - conda install control --use-local
+  # Install the desired version of SciPy first, w/ or w/out slycot
+  - conda install scipy==$SCIPY $SLYCOT
+  - conda install matplotlib
+  # Don't use conda for installation of control library [preserves scipy]
+  - python setup.py install
 
 # command to run tests
 script:
-  # Before installing Slycot
-  - python setup.py test
-
-  # Now, get and use Slycot
-  - conda install slycot
+  - 'if [ $SLYCOT != "" ]; then python -c "import slycot"; fi'
   - coverage run setup.py test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ cache:
     - $HOME/.local
 
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.5"
+  - "2.7"
 
 # Test against multiple version of SciPy, with and without slycot
 #
@@ -20,12 +20,20 @@ python:
 #
 # We also want to test with and without slycot
 env:
-  - SCIPY=0.19.1 SLYCOT=
-  - SCIPY=0.19.1 SLYCOT=slycot
-  - SCIPY=1.0.0 SLYCOT=
+  - SCIPY=scipy SLYCOT=slycot		# default, with slycot
+  - SCIPY=scipy SLYCOT=			# default, w/out slycot
+  - SCIPY="scipy==0.19.1" SLYCOT=	# legacy support, w/out slycot
 
 # install required system libraries
 before_install:
+  # Install gfortran for testing slycot; use apt-get instead of conda in
+  # order to include the proper CXXABI dependency (updated in GCC 4.9)
+  # Also need to include liblapack here, to make sure paths are right
+  - if [[ "$SLYCOT" != "" ]]; then
+      sudo apt-get update -qq;
+      sudo apt-get install gfortran liblapack-dev;
+    fi
+  # Install display manager to allow testing of plotting functions
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   # use miniconda to install numpy/scipy, to avoid lengthy build from source
@@ -39,22 +47,26 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  # conda-build must be installed in the conda root environment
-  - conda install conda-build
   - conda config --add channels python-control
   - conda info -a
   - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage
   - source activate test-environment
-  # coveralls not in conda repos
+  # Make sure to look in the right place for python libraries (for slycot)
+  - export LIBRARY_PATH="$HOME/miniconda/envs/test-environment/lib"
+  # coveralls not in conda repos => install via pip instead
   - pip install coveralls
 
 # Install packages
 install:
-  # Install the desired version of SciPy first, w/ or w/out slycot
-  - conda install scipy==$SCIPY $SLYCOT
-  - conda install matplotlib
-  # Don't use conda for installation of control library [preserves scipy]
-  - python setup.py install
+  # Install packages needed by python-control
+  - conda install $SCIPY matplotlib
+  # Build slycot from source
+  # For python 3, need to provide pointer to python library
+  #! git clone https://github.com/repagh/Slycot.git slycot;
+  - if [[ "$SLYCOT" != "" ]]; then
+      git clone https://github.com/python-control/Slycot.git slycot;
+      cd slycot; python setup.py install; cd ..;
+    fi
 
 # command to run tests
 script:


### PR DESCRIPTION
This PR addresses two related issues:

- The current version of python-control is incompatible with `scipy-1.0.0` and so all checks are failing.  In this build script we do explicit checks against `scipy-0.19.0` and `scipy-1.0.0`. This is related to issue #164.

- The way that tests were being done against slycot, they were actually not checking to make sure slycot was installed correctly => they 'succeeded' if slycot failed to install.  The new version of the build script separates out the slycot versus non-slycot builds so that this is more obvious.  Issue #168 describes the issue.

In addition to these changes, I updated the python version numbers to check against to 2.7, 3.5, and 3.6 (versions 3.3 and 3.4 seem old enough that we can stop checking against them).

If this PR works correctly, it should have a revised set of Travis CI checks that succeed on the 0.19.1 version of scipy with slicot not installed, but fail on all other cases.
