### PR TITLE
Fixes for SciPy 1.0 compatibility

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -54,6 +54,7 @@ $Id$
 """
 
 import scipy as sp
+import numpy as np
 from . import xferfcn as tf
 from . import statesp as ss
 from . import frdata as frd
@@ -221,18 +222,18 @@ def feedback(sys1, sys2=1, sign=-1):
     """
 
     # Check for correct input types.
-    if not isinstance(sys1, (int, float, complex, tf.TransferFunction,
-                             ss.StateSpace, frd.FRD)):
+    if not isinstance(sys1, (int, float, complex, np.number,
+                             tf.TransferFunction, ss.StateSpace, frd.FRD)):
         raise TypeError("sys1 must be a TransferFunction, StateSpace " +
                         "or FRD object, or a scalar.")
-    if not isinstance(sys2, (int, float, complex, tf.TransferFunction,
-                             ss.StateSpace, frd.FRD)):
+    if not isinstance(sys2, (int, float, complex, np.number,
+                             tf.TransferFunction, ss.StateSpace, frd.FRD)):
         raise TypeError("sys2 must be a TransferFunction, StateSpace " +
                         "or FRD object, or a scalar.")
 
     # If sys1 is a scalar, convert it to the appropriate LTI type so that we can
     # its feedback member function.
-    if isinstance(sys1, (int, float, complex)):
+    if isinstance(sys1, (int, float, complex, np.number)):
         if isinstance(sys2, tf.TransferFunction):
             sys1 = tf._convertToTransferFunction(sys1)
         elif isinstance(sys2, ss.StateSpace):

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -49,6 +49,7 @@ $Id: frd.py 185 2012-08-30 05:44:32Z murrayrm $
 """
 
 # External function declarations
+import numpy as np
 from numpy import angle, array, empty, ones, \
     real, imag, matrix, absolute, eye, linalg, where, dot
 from scipy.interpolate import splprep, splev
@@ -219,7 +220,7 @@ second has %i." % (self.outputs, other.outputs))
         """Multiply two LTI objects (serial connection)."""
 
         # Convert the second argument to a transfer function.
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(self.fresp * other, self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -245,7 +246,7 @@ second has %i." % (self.outputs, other.outputs))
         """Right Multiply two LTI objects (serial connection)."""
 
         # Convert the second argument to an frd function.
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(self.fresp * other, self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -272,7 +273,7 @@ second has %i." % (self.outputs, other.outputs))
     def __truediv__(self, other):
         """Divide two LTI objects."""
 
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(self.fresp * (1/other), self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -295,7 +296,7 @@ second has %i." % (self.outputs, other.outputs))
     # TODO: Division of MIMO transfer function objects is not written yet.
     def __rtruediv__(self, other):
         """Right divide two LTI objects."""
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(other / self.fresp, self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -449,7 +450,7 @@ def _convertToFRD(sys, omega, inputs=1, outputs=1):
 
         return FRD(fresp, omega, smooth=True)
 
-    elif isinstance(sys, (int, float, complex)):
+    elif isinstance(sys, (int, float, complex, np.number)):
         fresp = ones((outputs, inputs, len(omega)), dtype=float)*sys
         return FRD(fresp, omega, smooth=True)
 

--- a/control/lti.py
+++ b/control/lti.py
@@ -12,6 +12,7 @@ timebase()
 timebaseEqual()
 """
 
+import numpy as np
 from numpy import absolute, real
 
 __all__ = ['issiso', 'timebase', 'timebaseEqual', 'isdtime', 'isctime',
@@ -96,7 +97,7 @@ class LTI:
 
 # Test to see if a system is SISO
 def issiso(sys, strict=False):
-    if isinstance(sys, (int, float, complex)) and not strict:
+    if isinstance(sys, (int, float, complex, np.number)) and not strict:
         return True
     elif not isinstance(sys, LTI):
         raise ValueError("Object is not an LTI system")
@@ -114,7 +115,7 @@ def timebase(sys, strict=True):
     set to False, dt = True will be returned as 1.
     """
     # System needs to be either a constant or an LTI system
-    if isinstance(sys, (int, float, complex)):
+    if isinstance(sys, (int, float, complex, np.number)):
         return None
     elif not isinstance(sys, LTI):
         raise ValueError("Timebase not defined")
@@ -162,7 +163,7 @@ def isdtime(sys, strict=False):
     """
 
     # Check to see if this is a constant
-    if isinstance(sys, (int, float, complex)):
+    if isinstance(sys, (int, float, complex, np.number)):
         # OK as long as strict checking is off
         return True if not strict else False
 
@@ -187,7 +188,7 @@ def isctime(sys, strict=False):
     """
 
     # Check to see if this is a constant
-    if isinstance(sys, (int, float, complex)):
+    if isinstance(sys, (int, float, complex, np.number)):
         # OK as long as strict checking is off
         return True if not strict else False
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -58,6 +58,7 @@ from numpy import all, angle, any, array, asarray, concatenate, cos, delete, \
 from numpy.random import rand, randn
 from numpy.linalg import solve, eigvals, matrix_rank
 from numpy.linalg.linalg import LinAlgError
+import scipy as sp
 from scipy.signal import lti, cont2discrete
 # from exceptions import Exception
 import warnings
@@ -218,7 +219,7 @@ a StateSpace object.  Recived %s." % type(args[0]))
         """Add two LTI systems (parallel connection)."""
 
         # Check for a couple of special cases
-        if (isinstance(other, (int, float, complex))):
+        if (isinstance(other, (int, float, complex, np.number))):
             # Just adding a scalar; put it in the D matrix
             A, B, C = self.A, self.B, self.C;
             D = self.D + other;
@@ -275,7 +276,7 @@ a StateSpace object.  Recived %s." % type(args[0]))
         """Multiply two LTI objects (serial connection)."""
 
         # Check for a couple of special cases
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             # Just multiplying by a scalar; change the output
             A, B = self.A, self.B
             C = self.C * other
@@ -316,7 +317,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         """Right multiply two LTI objects (serial connection)."""
 
         # Check for a couple of special cases
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             # Just multiplying by a scalar; change the input
             A, C = self.A, self.C;
             B = self.B * other;
@@ -699,11 +700,10 @@ cannot take keywords.")
                 # TODO: do we want to squeeze first and check dimenations?
                 # I think this will fail if num and den aren't 1-D after
                 # the squeeze
-                lti_sys = lti(squeeze(sys.num), squeeze(sys.den))
-                return StateSpace(lti_sys.A, lti_sys.B, lti_sys.C, lti_sys.D,
-                                  sys.dt)
+                A, B, C, D = sp.signal.tf2ss(squeeze(sys.num), squeeze(sys.den))
+                return StateSpace(A, B, C, D, sys.dt)
 
-    elif isinstance(sys, (int, float, complex)):
+    elif isinstance(sys, (int, float, complex, np.number)):
         if "inputs" in kw:
             inputs = kw["inputs"]
         else:


### PR DESCRIPTION
This PR fixes the SciPy 1.0 compatibility issues raised in issue #164.  There are two main changes:

- Updated `statesp.py` and `xferfcn.py` to use the new forms of the `scipy.signal` library, for which the `lti` class no longer has accessors for `num`, `den`, etc.  The fix is to directly call the `ss2tf` and `tf2ss` functions.

- Also had to add a check for scalars that are of a `numpy` data type, specifically for `int64`.  Prior to Python 3, checking against `int` worked correctly, but this is no longer the case.  As a fix, I added checks throughout the library against `numpy.number`, which captures all scalar data types in `numpy`.

I also checked (manually) to insure that this version works against `scipy-0.19.0`, which should mean it is OK for backward compatibility (this can be checked with PR #169 is merged).