### PR TITLE
Update docstrings for LTI class constructors

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -246,7 +246,8 @@ def feedback(sys1, sys2=1, sign=-1):
     return sys1.feedback(sys2, sign)
 
 def append(*sys):
-    '''
+    '''append(sys1, sys2, ... sysn)
+
     Group models by appending their inputs and outputs
 
     Forms an augmented system model, and appends the inputs and

--- a/control/ctrlutil.py
+++ b/control/ctrlutil.py
@@ -43,17 +43,12 @@
 # Packages that we need access to
 from . import lti
 import numpy as np
-from numpy import pi
-
-# Hack for sphinx.ext.autodoc: if numpy is a mock import, then numpy.pi 
-# will be assigned to _Mock() and this generates a type error
-if not isinstance(pi, float):
-    pi = 3.14
+import math
 
 __all__ = ['unwrap', 'issys', 'db2mag', 'mag2db']
 
 # Utility function to unwrap an angle measurement
-def unwrap(angle, period=2*pi):
+def unwrap(angle, period=2*math.pi):
     """Unwrap a phase angle to give a continuous curve
 
     Parameters

--- a/control/ctrlutil.py
+++ b/control/ctrlutil.py
@@ -45,6 +45,11 @@ from . import lti
 import numpy as np
 from numpy import pi
 
+# Hack for sphinx.ext.autodoc: if numpy is a mock import, then numpy.pi 
+# will be assigned to _Mock() and this generates a type error
+if not isinstance(pi, float):
+    pi = 3.14
+
 __all__ = ['unwrap', 'issys', 'db2mag', 'mag2db']
 
 # Utility function to unwrap an angle measurement

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -57,7 +57,9 @@ from .lti import LTI
 __all__ = ['FRD', 'frd']
 
 class FRD(LTI):
-    """A class for models defined by Frequency Response Data (FRD)
+    """FRD(d, w)
+
+    A class for models defined by frequency response data (FRD)
 
     The FRD class is used to represent systems in frequency response data form.
 
@@ -80,7 +82,9 @@ class FRD(LTI):
     epsw = 1e-8
 
     def __init__(self, *args, **kwargs):
-        """Construct an FRD object
+        """FRD(d, w)
+
+        Construct an FRD object
 
         The default constructor is FRD(d, w), where w is an iterable of
         frequency points, and d is the matching frequency data.
@@ -469,8 +473,9 @@ def _convertToFRD(sys, omega, inputs=1, outputs=1):
                     sys.__class__)
 
 def frd(*args):
-    """
-    Construct a Frequency Response Data model, or convert a system
+    """frd(d, w)
+
+    Construct a frequency response data model
 
     frd models store the (measured) frequency response of a system.
 
@@ -500,6 +505,6 @@ def frd(*args):
 
     See Also
     --------
-    ss, tf
+    FRD, ss, tf
     """
     return FRD(*args)

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -44,6 +44,7 @@
 import matplotlib.pyplot as plt
 import scipy as sp
 import numpy as np
+import math
 from .ctrlutil import unwrap
 from .bdalg import feedback
 
@@ -128,7 +129,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
         else:
             omega_limits = np.array(omega_limits)
             if Hz:
-                omega_limits *= 2.*np.pi
+                omega_limits *= 2.*math.pi
             if omega_num:
                 omega = sp.logspace(np.log10(omega_limits[0]), np.log10(omega_limits[1]), num=omega_num, endpoint=True)
             else:
@@ -142,7 +143,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
         else:
             omega_sys = np.array(omega)
             if sys.isdtime(True):
-                nyquistfrq = 2. * np.pi * 1. / sys.dt / 2.
+                nyquistfrq = 2. * math.pi * 1. / sys.dt / 2.
                 omega_sys = omega_sys[omega_sys < nyquistfrq]
                 # TODO: What distance to the Nyquist frequency is appropriate?
             else:
@@ -154,9 +155,9 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
             phase = unwrap(phase)
             nyquistfrq_plot = None
             if Hz:
-                omega_plot = omega_sys / (2. * np.pi)
+                omega_plot = omega_sys / (2. * math.pi)
                 if nyquistfrq:
-                    nyquistfrq_plot = nyquistfrq / (2. * np.pi)
+                    nyquistfrq_plot = nyquistfrq / (2. * math.pi)
             else:
                 omega_plot = omega_sys
                 if nyquistfrq:
@@ -187,7 +188,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                 # Phase plot
                 ax_phase = plt.subplot(212, sharex=ax_mag);
                 if deg:
-                    phase_plot = phase * 180. / np.pi
+                    phase_plot = phase * 180. / math.pi
                 else:
                     phase_plot = phase
                 ax_phase.semilogx(omega_plot, phase_plot, *args, **kwargs)
@@ -208,8 +209,8 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                     ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], 15.), minor=True)
                 else:
                     ylim = ax_phase.get_ylim()
-                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], np.pi / 4.))
-                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], np.pi / 12.), minor=True)
+                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], math.pi / 4.))
+                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], math.pi / 12.), minor=True)
                 ax_phase.grid(True, which='both')
                 # ax_mag.grid(which='minor', alpha=0.3)
                 # ax_mag.grid(which='major', alpha=0.9)
@@ -449,7 +450,7 @@ def default_frequency_range(syslist, Hz=None, number_of_samples=None, feature_pe
                 features_ = features_[features_ != 0.0];
                 features = np.concatenate((features, features_))
             elif sys.isdtime(strict=True):
-                fn = np.pi * 1. / sys.dt
+                fn = math.pi * 1. / sys.dt
                 # TODO: What distance to the Nyquist frequency is appropriate?
                 freq_interesting.append(fn * 0.9)
 
@@ -475,12 +476,12 @@ def default_frequency_range(syslist, Hz=None, number_of_samples=None, feature_pe
         features = np.array([1.]);
 
     if Hz:
-        features /= 2.*np.pi
+        features /= 2.*math.pi
         features = np.log10(features)
         lsp_min = np.floor(np.min(features) - feature_periphery_decade)
         lsp_max = np.ceil(np.max(features) + feature_periphery_decade)
-        lsp_min += np.log10(2.*np.pi)
-        lsp_max += np.log10(2.*np.pi)
+        lsp_min += np.log10(2.*math.pi)
+        lsp_max += np.log10(2.*math.pi)
     else:
         features = np.log10(features)
         lsp_min = np.floor(np.min(features) - feature_periphery_decade)

--- a/control/margins.py
+++ b/control/margins.py
@@ -50,11 +50,12 @@ Date: 14 July 2011
 $Id$
 """
 
+import math
 import numpy as np
+import scipy as sp
 from . import xferfcn
 from .lti import issiso
 from . import frdata
-import scipy as sp
 
 __all__ = ['stability_margins', 'phase_crossover_frequencies', 'margin']
 
@@ -140,7 +141,7 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
             sys = sysdata
         elif getattr(sysdata, '__iter__', False) and len(sysdata) == 3:
             mag, phase, omega = sysdata
-            sys = frdata.FRD(mag * np.exp(1j * phase * np.pi/180),
+            sys = frdata.FRD(mag * np.exp(1j * phase * math.pi/180),
                              omega, smooth=True)
         else:
             sys = xferfcn._convertToTransferFunction(sysdata)
@@ -336,13 +337,13 @@ def phase_crossover_frequencies(sys):
 
 
 def margin(*args):
-    """margin(sys)
+    """margin(sysdata)
 
     Calculate gain and phase margins and associated crossover frequencies
 
     Parameters
     ----------
-    sysdata: LTI system or (mag, phase, omega) sequence
+    sysdata : LTI system or (mag, phase, omega) sequence
         sys : StateSpace or TransferFunction
             Linear SISO system
         mag, phase, omega : sequence of array_like

--- a/control/margins.py
+++ b/control/margins.py
@@ -336,7 +336,9 @@ def phase_crossover_frequencies(sys):
 
 
 def margin(*args):
-    """Calculate gain and phase margins and associated crossover frequencies
+    """margin(sys)
+
+    Calculate gain and phase margins and associated crossover frequencies
 
     Parameters
     ----------

--- a/control/margins.py
+++ b/control/margins.py
@@ -48,7 +48,6 @@ Author: Richard M. Murray
 Date: 14 July 2011
 
 $Id$
-
 """
 
 import numpy as np
@@ -62,7 +61,7 @@ __all__ = ['stability_margins', 'phase_crossover_frequencies', 'margin']
 # helper functions for stability_margins
 def _polyimsplit(pol):
     """split a polynomial with (iw) applied into a real and an
-       imaginary part with w applied"""
+    imaginary part with w applied"""
     rpencil = np.zeros_like(pol)
     ipencil = np.zeros_like(pol)
     rpencil[-1::-4] = 1.
@@ -294,8 +293,7 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
 # Contributed by Steffen Waldherr <waldherr@ist.uni-stuttgart.de>
 #! TODO - need to add test functions
 def phase_crossover_frequencies(sys):
-    """
-    Compute frequencies and gains at intersections with real axis
+    """Compute frequencies and gains at intersections with real axis
     in Nyquist plot.
 
     Call as:
@@ -360,8 +358,8 @@ def margin(*args):
     Wcp : float
         Phase crossover frequency (corresponding to gain margin) (in rad/sec)
 
-   Margins are of SISO open-loop. If more than one crossover frequency is
-   detected, returns the lowest corresponding margin.
+    Margins are of SISO open-loop. If more than one crossover frequency is
+    detected, returns the lowest corresponding margin.
 
     Examples
     --------

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -10,7 +10,9 @@ from scipy.signal import zpk2tf
 __all__ = ['bode', 'ngrid', 'dcgain']
 
 def bode(*args, **keywords):
-    """Bode plot of the frequency response
+    """bode(syslist[, omega, dB, Hz, deg, ...])
+
+    Bode plot of the frequency response
 
     Plots a bode gain and phase diagram
 

--- a/control/robust.py
+++ b/control/robust.py
@@ -72,7 +72,6 @@ def h2syn(P,nmeas,ncon):
     >>> K = h2syn(P,nmeas,ncon)
 
     """
-
     #Check for ss system object, need a utility for this?
 
     #TODO: Check for continous or discrete, only continuous supported right now
@@ -116,11 +115,11 @@ def hinfsyn(P,nmeas,ncon):
     CL: closed loop system (State-space sys)
     gam: infinity norm of closed loop system
     rcond: 4-vector, reciprocal condition estimates of:
-           1: control transformation matrix
-           2: measurement transformation matrix
-           3: X-Ricatti equation
-           4: Y-Ricatti equation
-      TODO: document significance of rcond
+        1: control transformation matrix
+        2: measurement transformation matrix
+        3: X-Ricatti equation
+        4: Y-Ricatti equation
+    TODO: document significance of rcond
 
     Raises
     ------

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -144,7 +144,9 @@ def acker(A, B, poles):
     return K
 
 def lqr(*args, **keywords):
-    """Linear quadratic regulator design
+    """lqr(A, B, Q, R[, N])
+
+    Linear quadratic regulator design
 
     The lqr() function computes the optimal state feedback controller
     that minimizes the quadratic cost

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1052,7 +1052,8 @@ TransferFunction object.  It is %s." % type(sys))
         raise ValueError("Needs 1 or 4 arguments; received %i." % len(args))
 
 def tf2ss(*args):
-    """
+    """tf2ss(sys)
+
     Transform a transfer function to a state space system.
 
     The function accepts either 1 or 2 parameters:

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -51,9 +51,10 @@ Revised: Kevin K. Chen, Dec 10
 $Id$
 """
 
+import math
 import numpy as np
 from numpy import all, angle, any, array, asarray, concatenate, cos, delete, \
-    dot, empty, exp, eye, matrix, ones, pi, poly, poly1d, roots, shape, sin, \
+    dot, empty, exp, eye, matrix, ones, poly, poly1d, roots, shape, sin, \
     zeros, squeeze
 from numpy.random import rand, randn
 from numpy.linalg import solve, eigvals, matrix_rank
@@ -367,7 +368,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         if isdtime(self, strict=True):
             dt = timebase(self)
             s = exp(1.j * omega * dt)
-            if (omega * dt > pi):
+            if (omega * dt > math.pi):
                 warnings.warn("evalfr: frequency evaluation above Nyquist frequency")
         else:
             s = omega * 1.j
@@ -798,7 +799,7 @@ def _rss_generate(states, inputs, outputs, type):
                 poles[i] = complex(-exp(randn()), 3. * exp(randn()))
             elif type == 'd':
                 mag = rand()
-                phase = 2. * pi * rand()
+                phase = 2. * math.pi * rand()
                 poles[i] = complex(mag * cos(phase),
                     mag * sin(phase))
             poles[i+1] = complex(poles[i].real, -poles[i].imag)

--- a/control/statesp.py+
+++ b/control/statesp.py+
@@ -116,7 +116,7 @@ class StateSpace(LTI):
         elif len(args) == 1:
             # Use the copy constructor.
             if not isinstance(args[0], StateSpace):
-               raise TypeError("The one-argument constructor can only take in a StateSpace object.  Received %s." % type(args[0]))
+                raise TypeError("The one-argument constructor can only take in a StateSpace object.  Received %s." % type(args[0]))
             A = args[0].A
             B = args[0].B
             C = args[0].C
@@ -961,8 +961,7 @@ def _mimo2simo(sys, input, warn_conversion=False):
     return sys
 
 def ss(*args):
-    """ss(A, B, C, D[, dt])
-
+    """
     Create a state space system.
 
     The function accepts either 1, 4 or 5 parameters:
@@ -1020,7 +1019,6 @@ def ss(*args):
 
     See Also
     --------
-    StateSpace
     tf
     ss2tf
     tf2ss

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -65,7 +65,9 @@ __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
 
 class TransferFunction(LTI):
 
-    """A class for representing transfer functions
+    """TransferFunction(num, den[, dt])
+    
+    A class for representing transfer functions
 
     The TransferFunction class is used to represent systems in transfer function
     form.
@@ -87,13 +89,17 @@ class TransferFunction(LTI):
     """
 
     def __init__(self, *args):
-        """Construct a transfer function.
+        """TransferFunction(num, den[, dt])
+
+        Construct a transfer function.
 
         The default constructor is TransferFunction(num, den), where num and
         den are lists of lists of arrays containing polynomial coefficients.
-        To crete a discrete time transfer funtion, use TransferFunction(num,
-        den, dt).  To call the copy constructor, call TransferFunction(sys),
-        where sys is a TransferFunction object (continuous or discrete).
+        To create a discrete time transfer funtion, use TransferFunction(num,
+        den, dt) where 'dt' is the sampling time (or True for unspecified
+        sampling time).  To call the copy constructor, call
+        TransferFunction(sys), where sys is a TransferFunction object
+        (continuous or discrete).
 
         """
 
@@ -1173,10 +1179,11 @@ def _convertToTransferFunction(sys, **kw):
 
 
 def tf(*args):
-    """
+    """tf(num, den[, dt])
+
     Create a transfer function system. Can create MIMO systems.
 
-    The function accepts either 1 or 2 parameters:
+    The function accepts either 1, 2, or 3 parameters:
 
     ``tf(sys)``
         Convert a linear system into transfer function form. Always creates
@@ -1221,6 +1228,7 @@ def tf(*args):
 
     See Also
     --------
+    TransferFunction
     ss
     ss2tf
     tf2ss

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1273,7 +1273,8 @@ TransferFunction object.  It is %s." % type(sys))
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
 
 def ss2tf(*args):
-    """
+    """ss2tf(sys)
+
     Transform a state space system to a transfer function.
 
     The function accepts either 1 or 4 parameters:

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -24,14 +24,14 @@ System creation
 System interconnections
 =======================
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-   append
-   connect
-   feedback
-   negate
-   parallel
-   series
+    append
+    connect
+    feedback
+    negate
+    parallel
+    series
 
 Frequency domain plotting
 =========================
@@ -117,6 +117,8 @@ Model simplification tools
     modred
     era
     markov
+
+.. _utility-and-conversions:
 
 Utility functions and conversions
 =================================

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -15,7 +15,7 @@ LTI system representation
 Linear time invariant (LTI) systems are represented in python-control in
 state space, transfer function, or frequency response data (FRD) form.  Most
 functions in the toolbox will operate on any of these data types and
-functions for convering between between compatible types is provided.
+functions for converting between between compatible types is provided.
 
 State space systems
 -------------------
@@ -44,11 +44,12 @@ transfer functions
 
 .. math::
 
-  G(s) = \frac{\text{num}(s)}{\text{den(s)}}
+  G(s) = \frac{\text{num}(s)}{\text{den}(s)}
        = \frac{a_0 s^n + a_1 s^{n-1} + \cdots + a_n}
               {b_0 s^m + b_1 s^{m-1} + \cdots + b_m},
 
-where n is generally greater than m (for a proper transfer function).
+where n is generally greater than or equal to m (for a proper transfer
+function).
 
 To create a transfer function, use the :class:`TransferFunction`
 constructor:
@@ -97,7 +98,7 @@ Conversion between representations
 ----------------------------------
 LTI systems can be converted between representations either by calling the
 constructor for the desired data type using the original system as the sole
-argument or using the explict conversion functions :func:`ss2tf` and
+argument or using the explicit conversion functions :func:`ss2tf` and
 :func:`tf2ss`.
 
 .. _time-series-convention:

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -9,6 +9,97 @@ Library conventions
 The python-control library uses a set of standard conventions for the way
 that different types of standard information used by the library.
 
+LTI system representation
+=========================
+
+Linear time invariant (LTI) systems are represented in python-control in
+state space, transfer function, or frequency response data (FRD) form.  Most
+functions in the toolbox will operate on any of these data types and
+functions for convering between between compatible types is provided.
+
+State space systems
+-------------------
+The :class:`StateSpace` class is used to represent state-space realizations
+of linear time-invariant (LTI) systems:
+
+.. math::
+
+  \frac{dx}{dt} &= A x + B u \\
+  y &= C x + D u
+
+where u is the input, y is the output, and x is the state.
+
+To create a state space system, use the :class:`StateSpace` constructor:
+
+  sys = StateSpace(A, B, C, D)
+
+State space systems can be manipulated using standard arithmetic operations
+as well as the :func:`feedback`, :func:`parallel`, and :func:`series`
+function.  A full list of functions can be found in :ref:`function-ref`.
+
+Transfer functions
+------------------
+The :class:`TransferFunction` class is used to represent input/output
+transfer functions
+
+.. math::
+
+  G(s) = \frac{\text{num}(s)}{\text{den(s)}}
+       = \frac{a_0 s^n + a_1 s^{n-1} + \cdots + a_n}
+              {b_0 s^m + b_1 s^{m-1} + \cdots + b_m},
+
+where n is generally greater than m (for a proper transfer function).
+
+To create a transfer function, use the :class:`TransferFunction`
+constructor:
+
+  sys = TransferFunction(num, den)
+
+Transfer functions can be manipulated using standard arithmetic operations
+as well as the :func:`feedback`, :func:`parallel`, and :func:`series`
+function.  A full list of functions can be found in :ref:`function-ref`.
+
+FRD (frequency response data) systems
+-------------------------------------
+The :class:`FRD` class is used to represent systems in frequency response
+data form.
+
+The main data members are `omega` and `fresp`, where `omega` is a 1D array
+with the frequency points of the response, and `fresp` is a 3D array, with
+the first dimension corresponding to the output index of the FRD, the second
+dimension corresponding to the input index, and the 3rd dimension
+corresponding to the frequency points in omega.
+
+FRD systems have a somewhat more limited set of functions that are
+available, although all of the standard algebraic manipulations can be
+performed.
+
+Discrete time systems
+---------------------
+By default, all systems are considered to be continuous time systems.  A
+discrete time system is created by specifying the 'time base' dt.  The time
+base argument can be given when a system is constructed:
+
+* dt = None: continuous time
+* dt = number: discrete time system with sampling period 'dt'
+* dt = True: discrete time with unspecified sampling period
+
+Only the :class:`StateSpace` and :class:`TransferFunction` classes allow
+explicit representation of discrete time systems.
+
+Systems must have the same time base in order to be combined.  For
+continuous time systems, the :func:`sample_system` function or the
+:meth:`StateSpace.sample` and :meth:`TransferFunction.sample` methods can be
+used to create a discrete time system from a continuous time system.  See
+:ref:`utility-and-conversions`.
+
+Conversion between representations
+----------------------------------
+LTI systems can be converted between representations either by calling the
+constructor for the desired data type using the original system as the sole
+argument or using the explict conversion functions :func:`ss2tf` and
+:func:`tf2ss`.
+
 .. _time-series-convention:
 
 Time series data


### PR DESCRIPTION
This PR addresses the documentation issues raised in PR #163 related to how the `StateSpace`, `TransferFunction`, and `FRD` constructors are documented.  In this PR, the first line of the docstring is modified for the each of the above classes, as well as their `init` methods and the corresponding `ss`, `tf`, and `frd` functions to have the most common call signature.

This PR leaves in place the copy constructor functionality and only modifies the documentation.

While I was at it, I also fixed some indentation problems and other issues that were causing warnings in sphinx.