### PR TITLE
Use slycot's tb05ad for faster and more accurate frequency response e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __conda_*.txt
 record.txt
 build.log
 *.egg-info/
+.eggs/
 .coverage
 doc/_build
 doc/generated
@@ -18,3 +19,7 @@ examples/.ipynb_checkpoints/
 .project
 Untitled*.ipynb
 *.idea/
+
+# Files created by or for emacs (RMM, 29 Dec 2017)
+*~
+TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,31 @@ cache:
     - $HOME/.local
 
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - "3.6"
   - "3.5"
+  - "2.7"
+
+# Test against multiple version of SciPy, with and without slycot
+#
+# Because there were significant changes in SciPy between v0 and v1, we 
+# test against both of these using the Travis CI environment capability
+#
+# We also want to test with and without slycot
+env:
+  - SCIPY=scipy SLYCOT=slycot		# default, with slycot
+  - SCIPY=scipy SLYCOT=			# default, w/out slycot
+  - SCIPY="scipy==0.19.1" SLYCOT=	# legacy support, w/out slycot
 
 # install required system libraries
 before_install:
+  # Install gfortran for testing slycot; use apt-get instead of conda in
+  # order to include the proper CXXABI dependency (updated in GCC 4.9)
+  # Also need to include liblapack here, to make sure paths are right
+  - if [[ "$SLYCOT" != "" ]]; then
+      sudo apt-get update -qq;
+      sudo apt-get install gfortran liblapack-dev;
+    fi
+  # Install display manager to allow testing of plotting functions
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   # use miniconda to install numpy/scipy, to avoid lengthy build from source
@@ -29,27 +47,30 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  # conda-build must be installed in the conda root environment
-  - conda install conda-build
   - conda config --add channels python-control
   - conda info -a
   - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage
   - source activate test-environment
-  # coveralls not in conda repos
+  # Make sure to look in the right place for python libraries (for slycot)
+  - export LIBRARY_PATH="$HOME/miniconda/envs/test-environment/lib"
+  # coveralls not in conda repos => install via pip instead
   - pip install coveralls
 
 # Install packages
 install:
-  - conda build --python "$TRAVIS_PYTHON_VERSION" conda-recipe
-  - conda install control --use-local
+  # Install packages needed by python-control
+  - conda install $SCIPY matplotlib
+  # Build slycot from source
+  # For python 3, need to provide pointer to python library
+  #! git clone https://github.com/repagh/Slycot.git slycot;
+  - if [[ "$SLYCOT" != "" ]]; then
+      git clone https://github.com/python-control/Slycot.git slycot;
+      cd slycot; python setup.py install; cd ..;
+    fi
 
 # command to run tests
 script:
-  # Before installing Slycot
-  - python setup.py test
-
-  # Now, get and use Slycot
-  - conda install slycot
+  - 'if [ $SLYCOT != "" ]; then python -c "import slycot"; fi'
   - coverage run setup.py test
 
 after_success:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,12 @@
 package:
   name: control
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  git_url: ../
 
 build:
+  number: {{ GIT_DESCRIBE_NUMBER }}
   script:
     - cd $RECIPE_DIR/..
     - $PYTHON make_version.py

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -54,6 +54,7 @@ $Id$
 """
 
 import scipy as sp
+import numpy as np
 from . import xferfcn as tf
 from . import statesp as ss
 from . import frdata as frd
@@ -221,18 +222,18 @@ def feedback(sys1, sys2=1, sign=-1):
     """
 
     # Check for correct input types.
-    if not isinstance(sys1, (int, float, complex, tf.TransferFunction,
-                             ss.StateSpace, frd.FRD)):
+    if not isinstance(sys1, (int, float, complex, np.number,
+                             tf.TransferFunction, ss.StateSpace, frd.FRD)):
         raise TypeError("sys1 must be a TransferFunction, StateSpace " +
                         "or FRD object, or a scalar.")
-    if not isinstance(sys2, (int, float, complex, tf.TransferFunction,
-                             ss.StateSpace, frd.FRD)):
+    if not isinstance(sys2, (int, float, complex, np.number,
+                             tf.TransferFunction, ss.StateSpace, frd.FRD)):
         raise TypeError("sys2 must be a TransferFunction, StateSpace " +
                         "or FRD object, or a scalar.")
 
     # If sys1 is a scalar, convert it to the appropriate LTI type so that we can
     # its feedback member function.
-    if isinstance(sys1, (int, float, complex)):
+    if isinstance(sys1, (int, float, complex, np.number)):
         if isinstance(sys2, tf.TransferFunction):
             sys1 = tf._convertToTransferFunction(sys1)
         elif isinstance(sys2, ss.StateSpace):

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -247,7 +247,8 @@ def feedback(sys1, sys2=1, sign=-1):
     return sys1.feedback(sys2, sign)
 
 def append(*sys):
-    '''
+    '''append(sys1, sys2, ... sysn)
+
     Group models by appending their inputs and outputs
 
     Forms an augmented system model, and appends the inputs and

--- a/control/ctrlutil.py
+++ b/control/ctrlutil.py
@@ -43,12 +43,12 @@
 # Packages that we need access to
 from . import lti
 import numpy as np
-from numpy import pi
+import math
 
 __all__ = ['unwrap', 'issys', 'db2mag', 'mag2db']
 
 # Utility function to unwrap an angle measurement
-def unwrap(angle, period=2*pi):
+def unwrap(angle, period=2*math.pi):
     """Unwrap a phase angle to give a continuous curve
 
     Parameters

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -58,7 +58,9 @@ from .lti import LTI
 __all__ = ['FRD', 'frd']
 
 class FRD(LTI):
-    """A class for models defined by Frequency Response Data (FRD)
+    """FRD(d, w)
+
+    A class for models defined by frequency response data (FRD)
 
     The FRD class is used to represent systems in frequency response data form.
 
@@ -81,7 +83,9 @@ class FRD(LTI):
     epsw = 1e-8
 
     def __init__(self, *args, **kwargs):
-        """Construct an FRD object
+        """FRD(d, w)
+
+        Construct an FRD object
 
         The default constructor is FRD(d, w), where w is an iterable of
         frequency points, and d is the matching frequency data.
@@ -470,8 +474,9 @@ def _convertToFRD(sys, omega, inputs=1, outputs=1):
                     sys.__class__)
 
 def frd(*args):
-    """
-    Construct a Frequency Response Data model, or convert a system
+    """frd(d, w)
+
+    Construct a frequency response data model
 
     frd models store the (measured) frequency response of a system.
 
@@ -501,6 +506,6 @@ def frd(*args):
 
     See Also
     --------
-    ss, tf
+    FRD, ss, tf
     """
     return FRD(*args)

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -49,6 +49,7 @@ $Id: frd.py 185 2012-08-30 05:44:32Z murrayrm $
 """
 
 # External function declarations
+import numpy as np
 from numpy import angle, array, empty, ones, \
     real, imag, matrix, absolute, eye, linalg, where, dot
 from scipy.interpolate import splprep, splev
@@ -219,7 +220,7 @@ second has %i." % (self.outputs, other.outputs))
         """Multiply two LTI objects (serial connection)."""
 
         # Convert the second argument to a transfer function.
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(self.fresp * other, self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -245,7 +246,7 @@ second has %i." % (self.outputs, other.outputs))
         """Right Multiply two LTI objects (serial connection)."""
 
         # Convert the second argument to an frd function.
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(self.fresp * other, self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -272,7 +273,7 @@ second has %i." % (self.outputs, other.outputs))
     def __truediv__(self, other):
         """Divide two LTI objects."""
 
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(self.fresp * (1/other), self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -295,7 +296,7 @@ second has %i." % (self.outputs, other.outputs))
     # TODO: Division of MIMO transfer function objects is not written yet.
     def __rtruediv__(self, other):
         """Right divide two LTI objects."""
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             return FRD(other / self.fresp, self.omega,
                        smooth=(self.ifunc is not None))
         else:
@@ -449,7 +450,7 @@ def _convertToFRD(sys, omega, inputs=1, outputs=1):
 
         return FRD(fresp, omega, smooth=True)
 
-    elif isinstance(sys, (int, float, complex)):
+    elif isinstance(sys, (int, float, complex, np.number)):
         fresp = ones((outputs, inputs, len(omega)), dtype=float)*sys
         return FRD(fresp, omega, smooth=True)
 

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -44,6 +44,7 @@
 import matplotlib.pyplot as plt
 import scipy as sp
 import numpy as np
+import math
 from .ctrlutil import unwrap
 from .bdalg import feedback
 
@@ -128,7 +129,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
         else:
             omega_limits = np.array(omega_limits)
             if Hz:
-                omega_limits *= 2.*np.pi
+                omega_limits *= 2.*math.pi
             if omega_num:
                 omega = sp.logspace(np.log10(omega_limits[0]), np.log10(omega_limits[1]), num=omega_num, endpoint=True)
             else:
@@ -142,7 +143,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
         else:
             omega_sys = np.array(omega)
             if sys.isdtime(True):
-                nyquistfrq = 2. * np.pi * 1. / sys.dt / 2.
+                nyquistfrq = 2. * math.pi * 1. / sys.dt / 2.
                 omega_sys = omega_sys[omega_sys < nyquistfrq]
                 # TODO: What distance to the Nyquist frequency is appropriate?
             else:
@@ -154,9 +155,9 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
             phase = unwrap(phase)
             nyquistfrq_plot = None
             if Hz:
-                omega_plot = omega_sys / (2. * np.pi)
+                omega_plot = omega_sys / (2. * math.pi)
                 if nyquistfrq:
-                    nyquistfrq_plot = nyquistfrq / (2. * np.pi)
+                    nyquistfrq_plot = nyquistfrq / (2. * math.pi)
             else:
                 omega_plot = omega_sys
                 if nyquistfrq:
@@ -187,7 +188,7 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                 # Phase plot
                 ax_phase = plt.subplot(212, sharex=ax_mag);
                 if deg:
-                    phase_plot = phase * 180. / np.pi
+                    phase_plot = phase * 180. / math.pi
                 else:
                     phase_plot = phase
                 ax_phase.semilogx(omega_plot, phase_plot, *args, **kwargs)
@@ -208,8 +209,8 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                     ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], 15.), minor=True)
                 else:
                     ylim = ax_phase.get_ylim()
-                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], np.pi / 4.))
-                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], np.pi / 12.), minor=True)
+                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], math.pi / 4.))
+                    ax_phase.set_yticks(genZeroCenteredSeries(ylim[0], ylim[1], math.pi / 12.), minor=True)
                 ax_phase.grid(True, which='both')
                 # ax_mag.grid(which='minor', alpha=0.3)
                 # ax_mag.grid(which='major', alpha=0.9)
@@ -449,7 +450,7 @@ def default_frequency_range(syslist, Hz=None, number_of_samples=None, feature_pe
                 features_ = features_[features_ != 0.0];
                 features = np.concatenate((features, features_))
             elif sys.isdtime(strict=True):
-                fn = np.pi * 1. / sys.dt
+                fn = math.pi * 1. / sys.dt
                 # TODO: What distance to the Nyquist frequency is appropriate?
                 freq_interesting.append(fn * 0.9)
 
@@ -475,12 +476,12 @@ def default_frequency_range(syslist, Hz=None, number_of_samples=None, feature_pe
         features = np.array([1.]);
 
     if Hz:
-        features /= 2.*np.pi
+        features /= 2.*math.pi
         features = np.log10(features)
         lsp_min = np.floor(np.min(features) - feature_periphery_decade)
         lsp_max = np.ceil(np.max(features) + feature_periphery_decade)
-        lsp_min += np.log10(2.*np.pi)
-        lsp_max += np.log10(2.*np.pi)
+        lsp_min += np.log10(2.*math.pi)
+        lsp_max += np.log10(2.*math.pi)
     else:
         features = np.log10(features)
         lsp_min = np.floor(np.min(features) - feature_periphery_decade)

--- a/control/lti.py
+++ b/control/lti.py
@@ -12,6 +12,7 @@ timebase()
 timebaseEqual()
 """
 
+import numpy as np
 from numpy import absolute, real
 
 __all__ = ['issiso', 'timebase', 'timebaseEqual', 'isdtime', 'isctime',
@@ -96,7 +97,7 @@ class LTI:
 
 # Test to see if a system is SISO
 def issiso(sys, strict=False):
-    if isinstance(sys, (int, float, complex)) and not strict:
+    if isinstance(sys, (int, float, complex, np.number)) and not strict:
         return True
     elif not isinstance(sys, LTI):
         raise ValueError("Object is not an LTI system")
@@ -114,7 +115,7 @@ def timebase(sys, strict=True):
     set to False, dt = True will be returned as 1.
     """
     # System needs to be either a constant or an LTI system
-    if isinstance(sys, (int, float, complex)):
+    if isinstance(sys, (int, float, complex, np.number)):
         return None
     elif not isinstance(sys, LTI):
         raise ValueError("Timebase not defined")
@@ -162,7 +163,7 @@ def isdtime(sys, strict=False):
     """
 
     # Check to see if this is a constant
-    if isinstance(sys, (int, float, complex)):
+    if isinstance(sys, (int, float, complex, np.number)):
         # OK as long as strict checking is off
         return True if not strict else False
 
@@ -187,7 +188,7 @@ def isctime(sys, strict=False):
     """
 
     # Check to see if this is a constant
-    if isinstance(sys, (int, float, complex)):
+    if isinstance(sys, (int, float, complex, np.number)):
         # OK as long as strict checking is off
         return True if not strict else False
 

--- a/control/margins.py
+++ b/control/margins.py
@@ -48,21 +48,21 @@ Author: Richard M. Murray
 Date: 14 July 2011
 
 $Id$
-
 """
 
+import math
 import numpy as np
+import scipy as sp
 from . import xferfcn
 from .lti import issiso
 from . import frdata
-import scipy as sp
 
 __all__ = ['stability_margins', 'phase_crossover_frequencies', 'margin']
 
 # helper functions for stability_margins
 def _polyimsplit(pol):
     """split a polynomial with (iw) applied into a real and an
-       imaginary part with w applied"""
+    imaginary part with w applied"""
     rpencil = np.zeros_like(pol)
     ipencil = np.zeros_like(pol)
     rpencil[-1::-4] = 1.
@@ -141,7 +141,7 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
             sys = sysdata
         elif getattr(sysdata, '__iter__', False) and len(sysdata) == 3:
             mag, phase, omega = sysdata
-            sys = frdata.FRD(mag * np.exp(1j * phase * np.pi/180),
+            sys = frdata.FRD(mag * np.exp(1j * phase * math.pi/180),
                              omega, smooth=True)
         else:
             sys = xferfcn._convertToTransferFunction(sysdata)
@@ -294,8 +294,7 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
 # Contributed by Steffen Waldherr <waldherr@ist.uni-stuttgart.de>
 #! TODO - need to add test functions
 def phase_crossover_frequencies(sys):
-    """
-    Compute frequencies and gains at intersections with real axis
+    """Compute frequencies and gains at intersections with real axis
     in Nyquist plot.
 
     Call as:
@@ -338,11 +337,13 @@ def phase_crossover_frequencies(sys):
 
 
 def margin(*args):
-    """Calculate gain and phase margins and associated crossover frequencies
+    """margin(sysdata)
+
+    Calculate gain and phase margins and associated crossover frequencies
 
     Parameters
     ----------
-    sysdata: LTI system or (mag, phase, omega) sequence
+    sysdata : LTI system or (mag, phase, omega) sequence
         sys : StateSpace or TransferFunction
             Linear SISO system
         mag, phase, omega : sequence of array_like
@@ -360,8 +361,8 @@ def margin(*args):
     Wcp : float
         Phase crossover frequency (corresponding to gain margin) (in rad/sec)
 
-   Margins are of SISO open-loop. If more than one crossover frequency is
-   detected, returns the lowest corresponding margin.
+    Margins are of SISO open-loop. If more than one crossover frequency is
+    detected, returns the lowest corresponding margin.
 
     Examples
     --------

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -10,7 +10,9 @@ from scipy.signal import zpk2tf
 __all__ = ['bode', 'ngrid', 'dcgain']
 
 def bode(*args, **keywords):
-    """Bode plot of the frequency response
+    """bode(syslist[, omega, dB, Hz, deg, ...])
+
+    Bode plot of the frequency response
 
     Plots a bode gain and phase diagram
 

--- a/control/robust.py
+++ b/control/robust.py
@@ -72,7 +72,6 @@ def h2syn(P,nmeas,ncon):
     >>> K = h2syn(P,nmeas,ncon)
 
     """
-
     #Check for ss system object, need a utility for this?
 
     #TODO: Check for continous or discrete, only continuous supported right now
@@ -116,11 +115,11 @@ def hinfsyn(P,nmeas,ncon):
     CL: closed loop system (State-space sys)
     gam: infinity norm of closed loop system
     rcond: 4-vector, reciprocal condition estimates of:
-           1: control transformation matrix
-           2: measurement transformation matrix
-           3: X-Ricatti equation
-           4: Y-Ricatti equation
-      TODO: document significance of rcond
+        1: control transformation matrix
+        2: measurement transformation matrix
+        3: X-Ricatti equation
+        4: Y-Ricatti equation
+    TODO: document significance of rcond
 
     Raises
     ------

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -144,7 +144,9 @@ def acker(A, B, poles):
     return K
 
 def lqr(*args, **keywords):
-    """Linear quadratic regulator design
+    """lqr(A, B, Q, R[, N])
+
+    Linear quadratic regulator design
 
     The lqr() function computes the optimal state feedback controller
     that minimizes the quadratic cost

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -58,6 +58,7 @@ from numpy import all, angle, any, array, asarray, concatenate, cos, delete, \
 from numpy.random import rand, randn
 from numpy.linalg import solve, eigvals, matrix_rank
 from numpy.linalg.linalg import LinAlgError
+import scipy as sp
 from scipy.signal import lti, cont2discrete
 # from exceptions import Exception
 import warnings
@@ -218,7 +219,7 @@ a StateSpace object.  Recived %s." % type(args[0]))
         """Add two LTI systems (parallel connection)."""
 
         # Check for a couple of special cases
-        if (isinstance(other, (int, float, complex))):
+        if (isinstance(other, (int, float, complex, np.number))):
             # Just adding a scalar; put it in the D matrix
             A, B, C = self.A, self.B, self.C;
             D = self.D + other;
@@ -275,7 +276,7 @@ a StateSpace object.  Recived %s." % type(args[0]))
         """Multiply two LTI objects (serial connection)."""
 
         # Check for a couple of special cases
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             # Just multiplying by a scalar; change the output
             A, B = self.A, self.B
             C = self.C * other
@@ -316,7 +317,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         """Right multiply two LTI objects (serial connection)."""
 
         # Check for a couple of special cases
-        if isinstance(other, (int, float, complex)):
+        if isinstance(other, (int, float, complex, np.number)):
             # Just multiplying by a scalar; change the input
             A, C = self.A, self.C;
             B = self.B * other;
@@ -699,11 +700,10 @@ cannot take keywords.")
                 # TODO: do we want to squeeze first and check dimenations?
                 # I think this will fail if num and den aren't 1-D after
                 # the squeeze
-                lti_sys = lti(squeeze(sys.num), squeeze(sys.den))
-                return StateSpace(lti_sys.A, lti_sys.B, lti_sys.C, lti_sys.D,
-                                  sys.dt)
+                A, B, C, D = sp.signal.tf2ss(squeeze(sys.num), squeeze(sys.den))
+                return StateSpace(A, B, C, D, sys.dt)
 
-    elif isinstance(sys, (int, float, complex)):
+    elif isinstance(sys, (int, float, complex, np.number)):
         if "inputs" in kw:
             inputs = kw["inputs"]
         else:

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -385,23 +385,100 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
                               self.B) + self.D
         return array(resp)
 
+
     # Method for generating the frequency response of the system
-    def freqresp(self, omega):
-        """Evaluate the system's transfer func. at a list of ang. frequencies.
+    def freqresp(self, omega_s):
+        """Evaluate the system's transfer func. at a list of freqs, omega.
 
         mag, phase, omega = self.freqresp(omega)
 
-        reports the value of the magnitude, phase, and angular frequency of the
-        system's transfer function matrix evaluated at s = i * omega, where
-        omega is a list of angular frequencies, and is a sorted version of the
-        input omega.
+        Reports the frequency response of the system,
+
+             G(j*omega) = mag*exp(j*phase)
+
+        for continuous time. For discrete time systems, the response is
+        evaluated around the unit circle such that
+
+             G(exp(j*omega*dt)) = mag*exp(j*phase).
+
+        Inputs:
+        ------
+           omega_s: A list of frequencies in radians/sec at which the system
+                    should be evaluated. The list can be either a python list
+                    or a numpy array and will be sorted before evaluation.
+
+        Returns:
+        -------
+           mag: The magnitude (absolute value, not dB or log10) of the system
+                frequency response.
+
+           phase: The wrapped phase in radians of the system frequency
+                  response.
+
+           omega_s: The list of sorted frequencies at which the response
+                    was evaluated.
 
         """
-        # when evaluating at many frequencies, much faster to convert to
-        # transfer function first and then evaluate, than to solve an
-        # n-dimensional linear system at each frequency
-        tf = _convertToTransferFunction(self)
-        return tf.freqresp(omega)
+
+        # In case omega is passed in as a list, rather than a proper array.
+        omega_s = np.asarray(omega_s)
+
+        numFreqs = len(omega_s)
+        Gfrf = np.empty((self.outputs, self.inputs, numFreqs),
+                        dtype=np.complex128)
+
+        # Sort frequency and calculate complex frequencies on either imaginary
+        # axis (continuous time) or unit circle (discrete time).
+        omega_s.sort()
+        if isdtime(self, strict=True):
+            dt = timebase(self)
+            cmplx_freqs = exp(1.j * omega_s * dt)
+            if ((omega_s * dt).any() > pi):
+                warn_message = ("evalfr: frequency evaluation"
+                                " above Nyquist frequency")
+                warnings.warn(warn_message)
+        else:
+            cmplx_freqs = omega_s * 1.j
+
+        # Do the frequency response evaluation. Use TB05AD from Slycot
+        # if it's available, otherwise use the built-in horners function.
+        try:
+            from slycot import tb05ad
+
+            n = np.shape(self.A)[0]
+            m = self.inputs
+            p = self.outputs
+            # The first call both evalates C(sI-A)^-1 B and also returns
+            # hessenberg transformed matrices at, bt, ct.
+            result = tb05ad(n, m, p, cmplx_freqs[0], self.A,
+                            self.B, self.C, job='NG')
+            # When job='NG', result = (at, bt, ct, g_i, hinvb, info)
+            at = result[0]
+            bt = result[1]
+            ct = result[2]
+
+            # TB05AD freqency evaluation does not include direct feedthrough.
+            Gfrf[:, :, 0] = result[3] + self.D
+
+            # Now, iterate through the remaining frequencies using the
+            # transformed state matrices, at, bt, ct.
+
+            # Start at the second frequency, already have the first.
+            for kk, cmplx_freqs_kk in enumerate(cmplx_freqs[1:numFreqs]):
+                result = tb05ad(n, m, p, cmplx_freqs_kk, at,
+                                bt, ct, job='NH')
+                # When job='NH', result = (g_i, hinvb, info)
+
+                # kk+1 because enumerate starts at kk = 0.
+                # but zero-th spot is already filled.
+                Gfrf[:, :, kk+1] = result[0] + self.D
+
+        except ImportError:  # Slycot unavailable. Fall back to horner.
+            for kk, cmplx_freqs_kk in enumerate(cmplx_freqs):
+                Gfrf[:, :, kk] = self.horner(cmplx_freqs_kk)
+
+        #      mag           phase           omega_s
+        return np.abs(Gfrf), np.angle(Gfrf), omega_s
 
     # Compute poles and zeros
     def pole(self):

--- a/control/statesp.py+
+++ b/control/statesp.py+
@@ -51,15 +51,13 @@ Revised: Kevin K. Chen, Dec 10
 $Id$
 """
 
-import math
 import numpy as np
 from numpy import all, angle, any, array, asarray, concatenate, cos, delete, \
-    dot, empty, exp, eye, matrix, ones, poly, poly1d, roots, shape, sin, \
+    dot, empty, exp, eye, matrix, ones, pi, poly, poly1d, roots, shape, sin, \
     zeros, squeeze
 from numpy.random import rand, randn
 from numpy.linalg import solve, eigvals, matrix_rank
 from numpy.linalg.linalg import LinAlgError
-import scipy as sp
 from scipy.signal import lti, cont2discrete
 # from exceptions import Exception
 import warnings
@@ -118,7 +116,7 @@ class StateSpace(LTI):
         elif len(args) == 1:
             # Use the copy constructor.
             if not isinstance(args[0], StateSpace):
-               raise TypeError("The one-argument constructor can only take in a StateSpace object.  Received %s." % type(args[0]))
+                raise TypeError("The one-argument constructor can only take in a StateSpace object.  Received %s." % type(args[0]))
             A = args[0].A
             B = args[0].B
             C = args[0].C
@@ -225,7 +223,7 @@ class StateSpace(LTI):
         """Add two LTI systems (parallel connection)."""
 
         # Check for a couple of special cases
-        if (isinstance(other, (int, float, complex, np.number))):
+        if (isinstance(other, (int, float, complex))):
             # Just adding a scalar; put it in the D matrix
             A, B, C = self.A, self.B, self.C;
             D = self.D + other;
@@ -282,7 +280,7 @@ class StateSpace(LTI):
         """Multiply two LTI objects (serial connection)."""
 
         # Check for a couple of special cases
-        if isinstance(other, (int, float, complex, np.number)):
+        if isinstance(other, (int, float, complex)):
             # Just multiplying by a scalar; change the output
             A, B = self.A, self.B
             C = self.C * other
@@ -323,7 +321,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         """Right multiply two LTI objects (serial connection)."""
 
         # Check for a couple of special cases
-        if isinstance(other, (int, float, complex, np.number)):
+        if isinstance(other, (int, float, complex)):
             # Just multiplying by a scalar; change the input
             A, C = self.A, self.C;
             B = self.B * other;
@@ -369,7 +367,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         if isdtime(self, strict=True):
             dt = timebase(self)
             s = exp(1.j * omega * dt)
-            if (omega * dt > math.pi):
+            if (omega * dt > pi):
                 warnings.warn("evalfr: frequency evaluation above Nyquist frequency")
         else:
             s = omega * 1.j
@@ -706,10 +704,11 @@ cannot take keywords.")
                 # TODO: do we want to squeeze first and check dimenations?
                 # I think this will fail if num and den aren't 1-D after
                 # the squeeze
-                A, B, C, D = sp.signal.tf2ss(squeeze(sys.num), squeeze(sys.den))
-                return StateSpace(A, B, C, D, sys.dt)
+                lti_sys = lti(squeeze(sys.num), squeeze(sys.den))
+                return StateSpace(lti_sys.A, lti_sys.B, lti_sys.C, lti_sys.D,
+                                  sys.dt)
 
-    elif isinstance(sys, (int, float, complex, np.number)):
+    elif isinstance(sys, (int, float, complex)):
         if "inputs" in kw:
             inputs = kw["inputs"]
         else:
@@ -799,7 +798,7 @@ def _rss_generate(states, inputs, outputs, type):
                 poles[i] = complex(-exp(randn()), 3. * exp(randn()))
             elif type == 'd':
                 mag = rand()
-                phase = 2. * math.pi * rand()
+                phase = 2. * pi * rand()
                 poles[i] = complex(mag * cos(phase),
                     mag * sin(phase))
             poles[i+1] = complex(poles[i].real, -poles[i].imag)
@@ -962,8 +961,7 @@ def _mimo2simo(sys, input, warn_conversion=False):
     return sys
 
 def ss(*args):
-    """ss(A, B, C, D[, dt])
-
+    """
     Create a state space system.
 
     The function accepts either 1, 4 or 5 parameters:
@@ -1021,7 +1019,6 @@ def ss(*args):
 
     See Also
     --------
-    StateSpace
     tf
     ss2tf
     tf2ss
@@ -1053,8 +1050,7 @@ TransferFunction object.  It is %s." % type(sys))
         raise ValueError("Needs 1 or 4 arguments; received %i." % len(args))
 
 def tf2ss(*args):
-    """tf2ss(sys)
-
+    """
     Transform a transfer function to a state space system.
 
     The function accepts either 1 or 2 parameters:

--- a/control/tests/input_element_int_test.py
+++ b/control/tests/input_element_int_test.py
@@ -1,0 +1,54 @@
+# input_element_int_test.py
+#
+# Author: Kangwon Lee (kangwonlee)
+# Date: 22 Oct 2017
+#
+# Unit tests contributed as part of PR #158, "SISO tf() may not work
+# with numpy arrays with numpy.int elements"
+#
+# Modified:
+# * 29 Dec 2017, RMM - updated file name and added header
+
+import unittest
+import numpy as np
+import control as ctl
+
+class TestTfInputIntElement(unittest.TestCase):
+    # currently these do not pass
+    def test_tf_den_with_numpy_int_element(self):
+        num = 1
+        den = np.convolve([1, 2, 1], [1, 1, 1])
+
+        sys = ctl.tf(num, den)
+
+        self.assertAlmostEqual(1.0, ctl.dcgain(sys))
+
+    def test_tf_num_with_numpy_int_element(self):
+        num = np.convolve([1], [1, 1])
+        den = np.convolve([1, 2, 1], [1, 1, 1])
+
+        sys = ctl.tf(num, den)
+
+        self.assertAlmostEqual(1.0, ctl.dcgain(sys))
+
+    # currently these pass
+    def test_tf_input_with_int_element_works(self):
+        num = 1
+        den = np.convolve([1.0, 2, 1], [1, 1, 1])
+
+        sys = ctl.tf(num, den)
+
+        self.assertAlmostEqual(1.0, ctl.dcgain(sys))
+
+    def test_ss_input_with_int_element(self):
+        ident = np.matrix(np.identity(2), dtype=int)
+        a = np.matrix([[0, 1],
+                       [-1, -2]], dtype=int) * ident
+        b = np.matrix([[0],
+                       [1]], dtype=int)
+        c = np.matrix([[0, 1]], dtype=int)
+        d = 0
+
+        sys = ctl.ss(a, b, c, d)
+        sys2 = ctl.ss2tf(sys)
+        self.assertAlmostEqual(ctl.dcgain(sys), ctl.dcgain(sys2))

--- a/control/tests/xferfcn_input_test.py
+++ b/control/tests/xferfcn_input_test.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+#
+# xferfcn_input_test.py - test inputs to TransferFunction class
+# jed-frey, 18 Feb 2017 (based on xferfcn_test.py)
+
+import unittest
+import numpy as np
+
+from numpy import int, int8, int16, int32, int64
+from numpy import float, float16, float32, float64, float128
+from numpy import all, ndarray, array
+
+from control.xferfcn import _cleanPart
+
+class TestXferFcnInput(unittest.TestCase):
+    """These are tests for functionality of cleaning and validating 
+    XferFucnInput."""
+
+    # Tests for raising exceptions.
+    def testBadInputType(self):
+        """Give the part cleaner invalid input type."""
+
+        self.assertRaises(TypeError, _cleanPart, [[0., 1.], [2., 3.]])
+
+    def testBadInputType2(self):
+        """Give the part cleaner another invalid input type."""
+        self.assertRaises(TypeError, _cleanPart, [1,"a"])
+
+    def testScalar(self):
+        """Test single scalar value."""
+        num = 1
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+
+    def testListScalar(self):
+        """Test single scalar value in list."""
+        num = [1]
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+      
+    def testTupleScalar(self):
+        """Test single scalar value in tuple."""
+        num = (1)
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+
+    def testList(self):
+        """Test multiple values in a list."""
+        num = [1, 2]
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0, 2.0], dtype=float))
+
+    def testTuple(self):
+        """Test multiple values in tuple."""
+        num = (1, 2)
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0, 2.0], dtype=float))
+            
+    def testAllScalarTypes(self):
+        """Test single scalar value for all valid data types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = dtype(1)
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+       
+    def testNpArray(self):
+        """Test multiple values in numpy array."""
+        num = np.array([1, 2])
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0, 2.0], dtype=float))
+        
+    def testAllNumpyArrayTypes(self):      
+        """Test scalar value in numpy array of ndim=0 for all data types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = np.array(1, dtype=dtype)
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+
+    def testAllNumpyArrayTypes2(self):      
+        """Test numpy array for all types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = np.array([1, 2], dtype=dtype)
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 2.0], dtype=float))
+           
+    def testListAllTypes(self):
+        """Test list of a single value for all data types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = [dtype(1)]
+            num_ = _cleanPart(num)
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+
+    def testListAllTypes2(self):
+        """List of list of numbers of all data types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = [dtype(1), dtype(2)]
+            num_ = _cleanPart(num)
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 2.0], dtype=float))
+            
+    def testTupleAllTypes(self):
+        """Test tuple of a single value for all data types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = (dtype(1),)
+            num_ = _cleanPart(num)
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+            
+    def testTupleAllTypes2(self):
+        """Test tuple of a single value for all data types."""
+        for dtype in [int, int8, int16, int32, int64, float, float16, float32, float64, float128]:
+            num = (dtype(1), dtype(2))
+            num_ = _cleanPart(num)
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1, 2], dtype=float))
+    
+    def testListListListInt(self):
+        """ Test an int in a list of a list of a list."""
+        num = [[[1]]]
+        num_ = _cleanPart(num)
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+
+    def testListListListFloat(self):
+        """ Test a float in a list of a list of a list."""
+        num = [[[1.0]]]
+        num_ = _cleanPart(num)
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0], dtype=float))
+       
+    def testListListListInts(self):
+        """Test 2 lists of ints in a list in a list."""
+        num = [[[1,1],[2,2]]]
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+        np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+        
+    def testListListListFloats(self):
+        """Test 2 lists of ints in a list in a list."""
+        num = [[[1.0,1.0],[2.0,2.0]]]
+        num_ = _cleanPart(num)
+        
+        assert isinstance(num_, list)
+        assert np.all([isinstance(part, list) for part in num_])
+        np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+        np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+ 
+    def testListListArray(self):
+        """List of list of numpy arrays for all valid types."""
+        for dtype in int, int8, int16, int32, int64, float, float16, float32, float64, float128:
+            num = [[array([1,1], dtype=dtype),array([2,2], dtype=dtype)]]
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+            np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+
+    def testTupleListArray(self):
+        """Tuple of list of numpy arrays for all valid types."""
+        for dtype in int, int8, int16, int32, int64, float, float16, float32, float64, float128:
+            num = ([array([1,1], dtype=dtype),array([2,2], dtype=dtype)],)
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+            np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+            
+    def testListTupleArray(self):
+        """List of tuple of numpy array for all valid types."""
+        for dtype in int, int8, int16, int32, int64, float, float16, float32, float64, float128:
+            num = [(array([1,1], dtype=dtype),array([2,2], dtype=dtype))]
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+            np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+    
+    def testTupleTuplesArrays(self):
+        """Tuple of tuples of numpy arrays for all valid types."""
+        for dtype in int, int8, int16, int32, int64, float, float16, float32, float64, float128:
+            num = ((array([1,1], dtype=dtype),array([2,2], dtype=dtype)),
+                   (array([3,4], dtype=dtype),array([4,4], dtype=dtype)))
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+            np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+    
+    def testListTuplesArrays(self):
+        """List of tuples of numpy arrays for all valid types."""
+        for dtype in int, int8, int16, int32, int64, float, float16, float32, float64, float128:
+            num = [(array([1,1], dtype=dtype),array([2,2], dtype=dtype)),
+                   (array([3,4], dtype=dtype),array([4,4], dtype=dtype))]
+            num_ = _cleanPart(num)
+            
+            assert isinstance(num_, list)
+            assert np.all([isinstance(part, list) for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+            np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+
+    def testListListArrays(self):
+        """List of list of numpy arrays for all valid types."""
+        for dtype in int, int8, int16, int32, int64, float, float16, float32, float64, float128:
+            num = [[array([1,1], dtype=dtype),array([2,2], dtype=dtype)],
+                   [array([3,3], dtype=dtype),array([4,4], dtype=dtype)]]
+            num_ = _cleanPart(num)
+            
+            assert len(num_) == 2
+            assert np.all([isinstance(part, list) for part in num_])
+            assert np.all([len(part) == 2 for part in num_])
+            np.testing.assert_array_equal(num_[0][0], array([1.0, 1.0], dtype=float))
+            np.testing.assert_array_equal(num_[0][1], array([2.0, 2.0], dtype=float))
+            np.testing.assert_array_equal(num_[1][0], array([3.0, 3.0], dtype=float))
+            np.testing.assert_array_equal(num_[1][1], array([4.0, 4.0], dtype=float))
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(TestXferFcnInput)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -461,6 +461,7 @@ class TestXferFcn(unittest.TestCase):
         hr = (s+1)/(s**2+s+1)
         np.testing.assert_array_almost_equal(hm.num[0][0], hr.num[0][0])
         np.testing.assert_array_almost_equal(hm.den[0][0], hr.den[0][0])
+        np.testing.assert_equal(hm.dt, hr.dt)
 
     def testMinreal2(self):
         """This one gave a problem, due to poly([]) giving simply 1
@@ -474,12 +475,24 @@ class TestXferFcn(unittest.TestCase):
         hr = 6205/(s**2+8*s+1241)
         np.testing.assert_array_almost_equal(H2b.num[0][0], hr.num[0][0])
         np.testing.assert_array_almost_equal(H2b.den[0][0], hr.den[0][0])
+        np.testing.assert_equal(H2b.dt, hr.dt)
 
     def testMinreal3(self):
         """Regression test for minreal of tf([1,1],[1,1])"""
         g = TransferFunction([1,1],[1,1]).minreal()
         np.testing.assert_array_almost_equal(1.0, g.num[0][0])
         np.testing.assert_array_almost_equal(1.0, g.den[0][0])
+        np.testing.assert_equal(None, g.dt)
+
+    def testMinreal4(self):
+        """Check minreal on discrete TFs."""
+        T = 0.01
+        z = TransferFunction([1, 0], [1], T)
+        h = (z-1.00000000001)*(z+1.0000000001)/((z**2-1))
+        hm = h.minreal()
+        hr = TransferFunction([1], [1], T)
+        np.testing.assert_array_almost_equal(hm.num[0][0], hr.num[0][0])
+        np.testing.assert_equal(hr.dt, hm.dt)
 
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testMIMO(self):

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -92,12 +92,12 @@ class TransferFunction(LTI):
 
         The default constructor is TransferFunction(num, den), where num and
         den are lists of lists of arrays containing polynomial coefficients.
-        To crete a discrete time transfer funtion, use TransferFunction(num,
+        To create a discrete time transfer funtion, use TransferFunction(num,
         den, dt).  To call the copy constructor, call TransferFunction(sys),
         where sys is a TransferFunction object (continuous or discrete).
 
         """
-
+        args = deepcopy(args)
         if len(args) == 2:
             # The user provided a numerator and a denominator.
             (num, den) = args
@@ -121,55 +121,13 @@ class TransferFunction(LTI):
             raise ValueError("Needs 1, 2 or 3 arguments; received %i."
                              % len(args))
 
-        # Make num and den into lists of lists of arrays, if necessary.
-        # Beware: this is a shallow copy! This should be okay,
-        # but be careful.
-        data = [num, den]
-        for i in range(len(data)):
-            # Check for a scalar (including 0d ndarray)
-            if (isinstance(data[i], (int, float, complex, np.number)) or
-                (isinstance(data[i], ndarray) and data[i].ndim == 0)):
-                # Convert scalar to list of list of array.
-                if (isinstance(data[i], int)):
-                    # Convert integers to floats at this point
-                    data[i] = [[array([data[i]], dtype=float)]]
-                else:
-                    data[i] = [[array([data[i]])]]
-            elif (isinstance(data[i], (list, tuple, ndarray)) and
-                    isinstance(data[i][0], (int, float, complex, np.number))):
-                # Convert array to list of list of array.
-                if (isinstance(data[i][0], int)):
-                    # Convert integers to floats at this point
-                    #! Not sure this covers all cases correctly
-                    data[i] = [[array(data[i], dtype=float)]]
-                else:
-                    data[i] = [[array(data[i])]]
-            elif (isinstance(data[i], list) and
-                    isinstance(data[i][0], list) and
-                    isinstance(data[i][0][0], (list, tuple, ndarray)) and
-                    isinstance(data[i][0][0][0], (int, float, complex, 
-                                                  np.number))):
-                # We might already have the right format.  Convert the
-                # coefficient vectors to arrays, if necessary.
-                for j in range(len(data[i])):
-                    for k in range(len(data[i][j])):
-                        if (isinstance(data[i][j][k], int)):
-                            data[i][j][k] = array(data[i][j][k], dtype=float)
-                        else:
-                            data[i][j][k] = array(data[i][j][k])
-            else:
-                # If the user passed in anything else, then it's unclear what
-                # the meaning is.
-                raise TypeError("The numerator and denominator inputs must be \
-scalars or vectors (for\nSISO), or lists of lists of vectors (for SISO or \
-MIMO).")
-        [num, den] = data
+        num = _cleanPart(num)
+        den = _cleanPart(den)
 
         inputs = len(num[0])
         outputs = len(num)
 
-        # Make sure the numerator and denominator matrices have consistent
-        # sizes.
+        # Make sure numerator and denominator matrices have consistent sizes
         if inputs != len(den[0]):
             raise ValueError("The numerator has %i input(s), but the \
 denominator has %i\ninput(s)." % (inputs, len(den[0])))
@@ -177,8 +135,9 @@ denominator has %i\ninput(s)." % (inputs, len(den[0])))
             raise ValueError("The numerator has %i output(s), but the \
 denominator has %i\noutput(s)." % (outputs, len(den)))
 
+        # Additional checks/updates on structure of the transfer function 
         for i in range(outputs):
-            # Make sure that each row has the same number of columns.
+            # Make sure that each row has the same number of columns
             if len(num[i]) != inputs:
                 raise ValueError("Row 0 of the numerator matrix has %i \
 elements, but row %i\nhas %i." % (inputs, i, len(num[i])))
@@ -186,6 +145,7 @@ elements, but row %i\nhas %i." % (inputs, i, len(num[i])))
                 raise ValueError("Row 0 of the denominator matrix has %i \
 elements, but row %i\nhas %i." % (inputs, i, len(den[i])))
 
+            # Check for zeros in numerator or denominator
             # TODO: Right now these checks are only done during construction.
             # It might be worthwhile to think of a way to perform checks if the
             # user modifies the transfer function after construction.
@@ -1358,3 +1318,52 @@ def tfdata(sys):
     tf = _convertToTransferFunction(sys)
 
     return (tf.num, tf.den)
+
+def _cleanPart(data):
+    '''
+    Return a valid, cleaned up numerator or denominator 
+    for the TransferFunction class.
+    
+    Parameters
+    ----------
+    data: numerator or denominator of a transfer function.
+    
+    Returns
+    -------
+    data: list of lists of ndarrays, with int converted to float
+    '''
+    valid_types = (int, float, complex, np.number)
+    valid_collection = (list, tuple, ndarray)
+
+    if (isinstance(data, valid_types) or
+        (isinstance(data, ndarray) and data.ndim == 0)):
+        # Data is a scalar (including 0d ndarray)
+        data = [[array([data])]]
+    elif (isinstance(data, valid_collection) and
+            all([isinstance(d, valid_types) for d in data])):
+        data = [[array(data)]]
+    elif (isinstance(data, (list, tuple)) and
+          isinstance(data[0], (list, tuple)) and
+              (isinstance(data[0][0], valid_collection) and 
+               all([isinstance(d, valid_types) for d in data[0][0]]))):
+        data = list(data)
+        for j in range(len(data)):
+            data[j] = list(data[j])
+            for k in range(len(data[j])):
+                data[j][k] = array(data[j][k])
+    else:
+        # If the user passed in anything else, then it's unclear what
+        # the meaning is.
+        raise TypeError("The numerator and denominator inputs must be \
+scalars or vectors (for\nSISO), or lists of lists of vectors (for SISO or \
+MIMO).")
+
+    # Check for coefficients that are ints and convert to floats
+    for i in range(len(data)):
+        for j in range(len(data[i])):
+            for k in range(len(data[i][j])):
+                if (isinstance(data[i][j][k], (int, np.int))):
+                    data[i][j][k] = float(data[i][j][k])
+                
+    return data
+    

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -652,7 +652,7 @@ only implemented for SISO functions.")
                 den[i][j] = np.atleast_1d(real(poly(poles)))
 
         # end result
-        return TransferFunction(num, den)
+        return TransferFunction(num, den, self.dt)
 
     def returnScipySignalLTI(self):
         """Return a list of a list of scipy.signal.lti objects.

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -66,7 +66,9 @@ __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
 
 class TransferFunction(LTI):
 
-    """A class for representing transfer functions
+    """TransferFunction(num, den[, dt])
+    
+    A class for representing transfer functions
 
     The TransferFunction class is used to represent systems in transfer function
     form.
@@ -84,17 +86,20 @@ class TransferFunction(LTI):
     non-zero value, then it must match whenever two transfer functions are
     combined.  If 'dt' is set to True, the system will be treated as a
     discrete time system with unspecified sampling time.
-
     """
 
     def __init__(self, *args):
-        """Construct a transfer function.
+        """TransferFunction(num, den[, dt])
+
+        Construct a transfer function.
 
         The default constructor is TransferFunction(num, den), where num and
         den are lists of lists of arrays containing polynomial coefficients.
         To create a discrete time transfer funtion, use TransferFunction(num,
-        den, dt).  To call the copy constructor, call TransferFunction(sys),
-        where sys is a TransferFunction object (continuous or discrete).
+        den, dt) where 'dt' is the sampling time (or True for unspecified
+        sampling time).  To call the copy constructor, call
+        TransferFunction(sys), where sys is a TransferFunction object
+        (continuous or discrete).
 
         """
         args = deepcopy(args)
@@ -1134,10 +1139,11 @@ def _convertToTransferFunction(sys, **kw):
 
 
 def tf(*args):
-    """
+    """tf(num, den[, dt])
+
     Create a transfer function system. Can create MIMO systems.
 
-    The function accepts either 1 or 2 parameters:
+    The function accepts either 1, 2, or 3 parameters:
 
     ``tf(sys)``
         Convert a linear system into transfer function form. Always creates
@@ -1182,6 +1188,7 @@ def tf(*args):
 
     See Also
     --------
+    TransferFunction
     ss
     ss2tf
     tf2ss
@@ -1226,7 +1233,8 @@ TransferFunction object.  It is %s." % type(sys))
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
 
 def ss2tf(*args):
-    """
+    """ss2tf(sys)
+
     Transform a state space system to a transfer function.
 
     The function accepts either 1 or 4 parameters:

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -24,14 +24,14 @@ System creation
 System interconnections
 =======================
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-   append
-   connect
-   feedback
-   negate
-   parallel
-   series
+    append
+    connect
+    feedback
+    negate
+    parallel
+    series
 
 Frequency domain plotting
 =========================
@@ -117,6 +117,8 @@ Model simplification tools
     modred
     era
     markov
+
+.. _utility-and-conversions:
 
 Utility functions and conversions
 =================================

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -9,6 +9,98 @@ Library conventions
 The python-control library uses a set of standard conventions for the way
 that different types of standard information used by the library.
 
+LTI system representation
+=========================
+
+Linear time invariant (LTI) systems are represented in python-control in
+state space, transfer function, or frequency response data (FRD) form.  Most
+functions in the toolbox will operate on any of these data types and
+functions for converting between between compatible types is provided.
+
+State space systems
+-------------------
+The :class:`StateSpace` class is used to represent state-space realizations
+of linear time-invariant (LTI) systems:
+
+.. math::
+
+  \frac{dx}{dt} &= A x + B u \\
+  y &= C x + D u
+
+where u is the input, y is the output, and x is the state.
+
+To create a state space system, use the :class:`StateSpace` constructor:
+
+  sys = StateSpace(A, B, C, D)
+
+State space systems can be manipulated using standard arithmetic operations
+as well as the :func:`feedback`, :func:`parallel`, and :func:`series`
+function.  A full list of functions can be found in :ref:`function-ref`.
+
+Transfer functions
+------------------
+The :class:`TransferFunction` class is used to represent input/output
+transfer functions
+
+.. math::
+
+  G(s) = \frac{\text{num}(s)}{\text{den}(s)}
+       = \frac{a_0 s^n + a_1 s^{n-1} + \cdots + a_n}
+              {b_0 s^m + b_1 s^{m-1} + \cdots + b_m},
+
+where n is generally greater than or equal to m (for a proper transfer
+function).
+
+To create a transfer function, use the :class:`TransferFunction`
+constructor:
+
+  sys = TransferFunction(num, den)
+
+Transfer functions can be manipulated using standard arithmetic operations
+as well as the :func:`feedback`, :func:`parallel`, and :func:`series`
+function.  A full list of functions can be found in :ref:`function-ref`.
+
+FRD (frequency response data) systems
+-------------------------------------
+The :class:`FRD` class is used to represent systems in frequency response
+data form.
+
+The main data members are `omega` and `fresp`, where `omega` is a 1D array
+with the frequency points of the response, and `fresp` is a 3D array, with
+the first dimension corresponding to the output index of the FRD, the second
+dimension corresponding to the input index, and the 3rd dimension
+corresponding to the frequency points in omega.
+
+FRD systems have a somewhat more limited set of functions that are
+available, although all of the standard algebraic manipulations can be
+performed.
+
+Discrete time systems
+---------------------
+By default, all systems are considered to be continuous time systems.  A
+discrete time system is created by specifying the 'time base' dt.  The time
+base argument can be given when a system is constructed:
+
+* dt = None: continuous time
+* dt = number: discrete time system with sampling period 'dt'
+* dt = True: discrete time with unspecified sampling period
+
+Only the :class:`StateSpace` and :class:`TransferFunction` classes allow
+explicit representation of discrete time systems.
+
+Systems must have the same time base in order to be combined.  For
+continuous time systems, the :func:`sample_system` function or the
+:meth:`StateSpace.sample` and :meth:`TransferFunction.sample` methods can be
+used to create a discrete time system from a continuous time system.  See
+:ref:`utility-and-conversions`.
+
+Conversion between representations
+----------------------------------
+LTI systems can be converted between representations either by calling the
+constructor for the desired data type using the original system as the sole
+argument or using the explicit conversion functions :func:`ss2tf` and
+:func:`tf2ss`.
+
 .. _time-series-convention:
 
 Time series data

--- a/make_version.py
+++ b/make_version.py
@@ -1,3 +1,24 @@
+# make_version.py - generate version information
+#
+# Author: Clancy Rowley
+# Date: 2 Apr 2015
+# Modified: Richard M. Murray, 28 Dec 2017
+#
+# This script is used to create the version information for the python-
+# control package.  The version information is now generated directly from
+# tags in the git repository.  Now, *before* running setup.py, one runs
+#
+#   python make_version.py
+#
+# and this generates a file with the version information.  This is copied
+# from binstar (https://github.com/Binstar/binstar) and seems to work well.
+#
+# The original version of this script also created version information for
+# conda, but this stopped working when conda v3 was released.  Instead, we
+# now use jinja templates in conda-recipe to create the conda information.
+# The current version information is used in setup.py, control/__init__.py,
+# and doc/conf.py (for sphinx).
+
 from subprocess import check_output
 import os
 
@@ -32,20 +53,6 @@ def main():
         else:
             fd.write('__version__ = "%s.post%s"\n' % (version, build))
         fd.write('__commit__ = "%s"\n' % (commit))
-
-    # Write files for conda version number
-    SRC_DIR = os.environ.get('SRC_DIR', '.')
-    conda_version_path = os.path.join(SRC_DIR, '__conda_version__.txt')
-    print("Writing %s" % conda_version_path)
-    with open(conda_version_path, 'w') as conda_version:
-        conda_version.write(version)
-
-    conda_buildnum_path = os.path.join(SRC_DIR, '__conda_buildnum__.txt')
-    print("Writing %s" % conda_buildnum_path)
-
-    with open(conda_buildnum_path, 'w') as conda_buildnum:
-        conda_buildnum.write(build)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This pull request addresses issue [#116](https://github.com/python-control/python-control/issues/116).

It uses the (relatively) newly wrapped [TB05AD](https://github.com/python-control/Slycot/pull/10) function from Slycot, when Slycot is available. If slycot is not available, I instead use the state space built-in method `horner`, rather than converting to a transfer function for the evaluation. 


This passes the unit tests on my machine (python 2.7), but currently it looks like the travis build is [failing](https://travis-ci.org/python-control/python-control/builds/323626585) so I'm not sure what happens with other versions.
