### PR TITLE
Add support for discrete systems to lti/damp

### DIFF
--- a/control/lti.py
+++ b/control/lti.py
@@ -86,8 +86,13 @@ class LTI:
 
     def damp(self):
         poles = self.pole()
-        wn = absolute(poles)
-        Z = -real(poles)/wn
+
+        if isdtime(self, strict=True):
+            splane_poles = np.log(poles)/self.dt
+        else:
+            splane_poles = poles
+        wn = absolute(splane_poles)
+        Z = -real(splane_poles)/wn
         return wn, Z, poles
 
     def dcgain(self):
@@ -279,6 +284,20 @@ def damp(sys, doprint=True):
         Damping values
     poles: array
         Pole locations
+
+
+    Algorithm
+    --------
+        If the system is continuous,
+           wn = abs(poles)
+           Z  = -real(poles)/poles.
+
+        If the system is discrete, the discrete poles are mapped to their
+        equivalent location in the s-plane via
+           s = log10(poles)/dt
+        and
+          wn = abs(s)
+          Z = -real(s)/wn.
 
     See Also
     --------

--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 from control.lti import *
 from control.xferfcn import tf
+from control import c2d
 import numpy as np
 
 class TestUtils(unittest.TestCase):
@@ -18,6 +19,7 @@ class TestUtils(unittest.TestCase):
         np.testing.assert_equal(zero(sys), 42)
 
     def test_damp(self):
+        # Test the continuous time case.
         zeta = 0.1
         wn = 42
         p = -wn * zeta + 1j * wn * np.sqrt(1 - zeta**2)
@@ -25,6 +27,15 @@ class TestUtils(unittest.TestCase):
         expected = ([wn, wn], [zeta, zeta], [p, p.conjugate()])
         np.testing.assert_equal(sys.damp(), expected)
         np.testing.assert_equal(damp(sys), expected)
+
+        # Also test the discrete time case.
+        dt = 0.001
+        sys_dt = c2d(sys, dt, method='matched')
+        p_zplane = np.exp(p*dt)
+        expected_dt = ([wn, wn], [zeta, zeta],
+                       [p_zplane, p_zplane.conjugate()])
+        np.testing.assert_almost_equal(sys_dt.damp(), expected_dt)
+        np.testing.assert_almost_equal(damp(sys_dt), expected_dt)
 
     def test_dcgain(self):
         sys = tf(84, [1, 2])


### PR DESCRIPTION
This PR fixes issue [#174](https://github.com/python-control/python-control/issues/174) by adding support for discrete time systems to `lti.damp`.

I have also augmented the unit test in `lti_test.test_temp` to check the discrete time case. 