### PR TITLE
Update place to use scipy.signal.place_poles

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -87,6 +87,10 @@ def place(A, B, p):
     >>> A = [[-1, -1], [0, 1]]
     >>> B = [[0], [1]]
     >>> K = place(A, B, [-2, -5])
+
+    See Also
+    --------
+    place_varga, acker
     """
     from scipy.signal import place_poles
 
@@ -142,6 +146,10 @@ def place_varga(A, B, p):
     >>> A = [[-1, -1], [0, 1]]
     >>> B = [[0], [1]]
     >>> K = place(A, B, [-2, -5])
+
+    See Also:
+    --------
+    place, acker
     """
 
     # Make sure that SLICOT is installed

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -400,9 +400,8 @@ class TestMatlab(unittest.TestCase):
         modred(self.siso_ss3, [1], 'matchdc')
         modred(self.siso_ss3, [1], 'truncate')
 
-    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace(self):
-        place(self.siso_ss1.A, self.siso_ss1.B, [-2, -2])
+        place(self.siso_ss1.A, self.siso_ss1.B, [-2, -2.5])
 
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testLQR(self):

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -400,8 +400,16 @@ class TestMatlab(unittest.TestCase):
         modred(self.siso_ss3, [1], 'matchdc')
         modred(self.siso_ss3, [1], 'truncate')
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
+    def testPlace_varga(self):
+        place_varga(self.siso_ss1.A, self.siso_ss1.B, [-2, -2])
+
     def testPlace(self):
         place(self.siso_ss1.A, self.siso_ss1.B, [-2, -2.5])
+
+    def testAcker(self):
+        acker(self.siso_ss1.A, self.siso_ss1.B, [-2, -2.5])
+
 
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testLQR(self):

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -180,6 +180,27 @@ class TestStatefbk(unittest.TestCase):
         np.testing.assert_raises(ControlDimension, place, A[1:, :], B, P)
         np.testing.assert_raises(ControlDimension, place, A, B[1:, :], P)
 
+        # Check that we get an error if we ask for too many poles in the same
+        # location. Here, rank(B) = 2, so lets place three at the same spot.
+        P_repeated = np.array([-0.5, -0.5, -0.5, -8.6659])
+        np.testing.assert_raises(ValueError, place, A, B, P_repeated)
+
+    def testPlace_varga(self):
+        A = np.array([[1., -2.], [3., -4.]])
+        B = np.array([[5.], [7.]])
+
+        P = np.array([-2., -2.])
+        K = place_varga(A, B, P)
+        P_placed = np.linalg.eigvals(A - B.dot(K))
+        # No guarantee of the ordering, so sort them
+        P.sort()
+        P_placed.sort()
+        np.testing.assert_array_almost_equal(P, P_placed)
+
+        # Test that the dimension checks work.
+        np.testing.assert_raises(ControlDimension, place, A[1:, :], B, P)
+        np.testing.assert_raises(ControlDimension, place, A, B[1:, :], P)
+
     def check_LQR(self, K, S, poles, Q, R):
         S_expected = np.array(np.sqrt(Q * R))
         K_expected = S_expected / R

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -157,6 +157,25 @@ class TestStatefbk(unittest.TestCase):
                 np.testing.assert_array_almost_equal(np.sort(poles),
                                                      np.sort(placed), decimal=4)
 
+    def testPlace(self):
+        # Matrices shamelessly stolen from scipy example code.
+        A = np.array([[1.380,  -0.2077,  6.715, -5.676],
+                      [-0.5814, -4.290,   0,      0.6750],
+                      [1.067,   4.273,  -6.654,  5.893],
+                      [0.0480,  4.273,   1.343, -2.104]])
+
+        B = np.array([[0,      5.679],
+                      [1.136,  1.136],
+                      [0,      0,],
+                      [-3.146,  0]])
+        P = np.array([-0.2, -0.5, -5.0566, -8.6659])
+        K = place(A, B, P)
+        P_placed = np.linalg.eigvals(A - B.dot(K))
+        # No guarantee of the ordering, so sort them
+        P.sort()
+        P_placed.sort()
+        np.testing.assert_array_almost_equal(P, P_placed)
+
     def check_LQR(self, K, S, poles, Q, R):
         S_expected = np.array(np.sqrt(Q * R))
         K_expected = S_expected / R

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 from control.statefbk import ctrb, obsv, place, lqr, gram, acker
 from control.matlab import *
-from control.exception import slycot_check
+from control.exception import slycot_check, ControlDimension
 
 class TestStatefbk(unittest.TestCase):
     """Test state feedback functions"""
@@ -168,13 +168,17 @@ class TestStatefbk(unittest.TestCase):
                       [1.136,  1.136],
                       [0,      0,],
                       [-3.146,  0]])
-        P = np.array([-0.2, -0.5, -5.0566, -8.6659])
+        P = np.array([-0.5+1j, -0.5-1j, -5.0566, -8.6659])
         K = place(A, B, P)
         P_placed = np.linalg.eigvals(A - B.dot(K))
         # No guarantee of the ordering, so sort them
         P.sort()
         P_placed.sort()
         np.testing.assert_array_almost_equal(P, P_placed)
+
+        # Test that the dimension checks work.
+        np.testing.assert_raises(ControlDimension, place, A[1:, :], B, P)
+        np.testing.assert_raises(ControlDimension, place, A, B[1:, :], P)
 
     def check_LQR(self, K, S, poles, Q, R):
         S_expected = np.array(np.sqrt(Q * R))

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -185,6 +185,7 @@ class TestStatefbk(unittest.TestCase):
         P_repeated = np.array([-0.5, -0.5, -0.5, -8.6659])
         np.testing.assert_raises(ValueError, place, A, B, P_repeated)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace_varga(self):
         A = np.array([[1., -2.], [3., -4.]])
         B = np.array([[5.], [7.]])


### PR DESCRIPTION
This PR addresses issue [#117](https://github.com/python-control/python-control/issues/117) by using the `place_poles` function in `scipy.signals`.

Aside from just being run in `matlab_test.py`, there wasn't, as far as I could tell,  a unit test for `place` previously, so I added one. 

The one limitation of the algorithm used in scipy.signals is that it can't place multiple poles at the same location for SISO systems, which made the "test" in `matlab_tests.place` fail, so I modified the requested pole location there. 

Also worth pointing that the previous implementation would fail for discrete time systems because the slycot function needed to be called with a different flag and the `alpha` parameter needed to be computed differently. 