### PR TITLE
Fix place varga

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -113,11 +113,11 @@ def place(A, B, p):
     return K
 
 
-def place_varga(A, B, p):
+def place_varga(A, B, p, DICO='C', alpha=None):
     """Place closed loop eigenvalues
-    K = place_varga(A, B, p)
+    K = place_varga(A, B, p, DICO='C', alpha=None)
 
-    Parameters
+    Required Parameters
     ----------
     A : 2-d array
         Dynamics matrix
@@ -125,6 +125,20 @@ def place_varga(A, B, p):
         Input matrix
     p : 1-d list
         Desired eigenvalue locations
+
+    Optional Parameters
+    ---------------
+    DICO : 'C' for continuous time pole placement or 'D' for discrete time.
+            The default is DICO='C'.
+    alpha: double scalar
+           If DICO='C', then place_varga will leave the eigenvalues with real
+           real part less than alpha untouched.
+           If DICO='D', the place_varga will leave eigenvalues with modulus
+           less than alpha untouched.
+
+           By default (alpha=None), place_varga computes alpha such that all
+           poles will be placed.
+
     Returns
     -------
     K : 2-d array
@@ -160,24 +174,39 @@ def place_varga(A, B, p):
         raise ControlSlycot("can't find slycot module 'sb01bd'")
 
     # Convert the system inputs to NumPy arrays
-    A_mat = np.array(A);
-    B_mat = np.array(B);
+    A_mat = np.array(A)
+    B_mat = np.array(B)
     if (A_mat.shape[0] != A_mat.shape[1] or
         A_mat.shape[0] != B_mat.shape[0]):
         raise ControlDimension("matrix dimensions are incorrect")
 
     # Compute the system eigenvalues and convert poles to numpy array
     system_eigs = np.linalg.eig(A_mat)[0]
-    placed_eigs = np.array(p);
+    placed_eigs = np.array(p)
 
-    # SB01BD sets eigenvalues with real part less than alpha
-    # We want to place all poles of the system => set alpha to minimum
-    alpha = min(system_eigs.real);
+    if alpha is None:
+        # SB01BD ignores eigenvalues with real part less than alpha
+        # (if DICO='C') or with modulus less than alpha
+        # (if DICO = 'D').
+        if DICO == 'C':
+            # Choosing alpha=min_eig is insufficient and can lead to an
+            # error or not having all the eigenvalues placed that we wanted.
+            # Evidently, what python thinks are the eigs is not precisely
+            # the same as what slicot thinks are the eigs. So we need some
+            # numerical breathing room. The following is pretty heuristic,
+            # but does the trick
+            alpha = -2*abs(min(system_eigs.real))
+        elif DICO == 'D':
+            # For discrete time, slycot only cares about modulus, so just make
+            # alpha the smallest it can be.
+            alpha = 0.0
+    elif DICO == 'D' and alpha < 0.0:
+        raise ValueError("Need alpha > 0 when DICO='D'")
 
     # Call SLICOT routine to place the eigenvalues
     A_z,w,nfp,nap,nup,F,Z = \
         sb01bd(B_mat.shape[0], B_mat.shape[1], len(placed_eigs), alpha,
-               A_mat, B_mat, placed_eigs, 'C');
+               A_mat, B_mat, placed_eigs, DICO)
 
     # Return the gain matrix, with MATLAB gain convention
     return -F

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -113,9 +113,9 @@ def place(A, B, p):
     return K
 
 
-def place_varga(A, B, p, DICO='C', alpha=None):
+def place_varga(A, B, p, dtime=False, alpha=None):
     """Place closed loop eigenvalues
-    K = place_varga(A, B, p, DICO='C', alpha=None)
+    K = place_varga(A, B, p, dtime=False, alpha=None)
 
     Required Parameters
     ----------
@@ -128,8 +128,8 @@ def place_varga(A, B, p, DICO='C', alpha=None):
 
     Optional Parameters
     ---------------
-    DICO : 'C' for continuous time pole placement or 'D' for discrete time.
-            The default is DICO='C'.
+    dtime: False for continuous time pole placement or True for discrete time.
+            The default is dtime=False.
     alpha: double scalar
            If DICO='C', then place_varga will leave the eigenvalues with real
            real part less than alpha untouched.
@@ -160,7 +160,7 @@ def place_varga(A, B, p, DICO='C', alpha=None):
     --------
     >>> A = [[-1, -1], [0, 1]]
     >>> B = [[0], [1]]
-    >>> K = place(A, B, [-2, -5])
+    >>> K = place_varga(A, B, [-2, -5])
 
     See Also:
     --------
@@ -184,11 +184,21 @@ def place_varga(A, B, p, DICO='C', alpha=None):
     system_eigs = np.linalg.eig(A_mat)[0]
     placed_eigs = np.array(p)
 
+    # Need a character parameter for SB01BD
+    if dtime:
+        DICO = 'D'
+    else:
+        DICO = 'C'
+
     if alpha is None:
         # SB01BD ignores eigenvalues with real part less than alpha
         # (if DICO='C') or with modulus less than alpha
         # (if DICO = 'D').
-        if DICO == 'C':
+        if dtime:
+            # For discrete time, slycot only cares about modulus, so just make
+            # alpha the smallest it can be.
+            alpha = 0.0
+        else:
             # Choosing alpha=min_eig is insufficient and can lead to an
             # error or not having all the eigenvalues placed that we wanted.
             # Evidently, what python thinks are the eigs is not precisely
@@ -196,12 +206,9 @@ def place_varga(A, B, p, DICO='C', alpha=None):
             # numerical breathing room. The following is pretty heuristic,
             # but does the trick
             alpha = -2*abs(min(system_eigs.real))
-        elif DICO == 'D':
-            # For discrete time, slycot only cares about modulus, so just make
-            # alpha the smallest it can be.
-            alpha = 0.0
-    elif DICO == 'D' and alpha < 0.0:
+    elif dtime and alpha < 0.0:
         raise ValueError("Need alpha > 0 when DICO='D'")
+
 
     # Call SLICOT routine to place the eigenvalues
     A_z,w,nfp,nap,nup,F,Z = \

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -218,6 +218,7 @@ class TestStatefbk(unittest.TestCase):
         P_placed.sort()
         np.testing.assert_array_almost_equal(P, P_placed)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace_varga_continuous_partial_eigs(self):
         """
         Check that we are able to use the alpha parameter to only place
@@ -239,6 +240,7 @@ class TestStatefbk(unittest.TestCase):
         P_placed.sort()
         np.testing.assert_array_almost_equal(P_expected, P_placed)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace_varga_discrete(self):
         """
         Check that we can place poles using DICO='D' (discrete time)
@@ -254,6 +256,7 @@ class TestStatefbk(unittest.TestCase):
         P_placed.sort()
         np.testing.assert_array_almost_equal(P, P_placed)
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace_varga_discrete_partial_eigs(self):
         """"
         Check that we can only assign a single eigenvalue in the discrete

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -188,7 +188,7 @@ class TestStatefbk(unittest.TestCase):
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace_varga_continuous(self):
         """
-        Check that we can place eigenvalues for DICO='C'
+        Check that we can place eigenvalues for dtime=False
         """
         A = np.array([[1., -2.], [3., -4.]])
         B = np.array([[5.], [7.]])
@@ -243,13 +243,13 @@ class TestStatefbk(unittest.TestCase):
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testPlace_varga_discrete(self):
         """
-        Check that we can place poles using DICO='D' (discrete time)
+        Check that we can place poles using dtime=True (discrete time)
         """
         A = np.array([[1., 0], [0, 0.5]])
         B = np.array([[5.], [7.]])
 
         P = np.array([0.5, 0.5])
-        K = place_varga(A, B, P, DICO='D')
+        K = place_varga(A, B, P, dtime=True)
         P_placed = np.linalg.eigvals(A - B.dot(K))
         # No guarantee of the ordering, so sort them
         P.sort()
@@ -269,7 +269,7 @@ class TestStatefbk(unittest.TestCase):
         P = np.array([0.2, 0.6])
         P_expected = np.array([0.5, 0.6])
         alpha = 0.51
-        K = place_varga(A, B, P, DICO='D', alpha=alpha)
+        K = place_varga(A, B, P, dtime=True, alpha=alpha)
         P_placed = np.linalg.eigvals(A - B.dot(K))
         P_expected.sort()
         P_placed.sort()


### PR DESCRIPTION
This pull request address issue [#177 ](https://github.com/python-control/python-control/issues/177).

Summary of Changes:
1. Calculate the alpha parameter such it is always twice as small as the smallest (real part) open-loop eigenvalue. 

2. Add support for discrete time systems by exposing the DICO parameter

3. Expose the alpha parameter to the user, since it seems like interesting functionality to be able to place only the slowest eigenvalues.

4. Add tests to exercise these changes, including a test against the example in issue #177 .


