### PR TITLE
use openblas instead of lapack for slycot testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,9 @@ env:
 before_install:
   # Install gfortran for testing slycot; use apt-get instead of conda in
   # order to include the proper CXXABI dependency (updated in GCC 4.9)
-  # Also need to include liblapack here, to make sure paths are right
   - if [[ "$SLYCOT" != "" ]]; then
       sudo apt-get update -qq;
-      sudo apt-get install gfortran liblapack-dev;
+      sudo apt-get install gfortran;
     fi
   # Install display manager to allow testing of plotting functions
   - export DISPLAY=:99.0
@@ -51,6 +50,10 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage
   - source activate test-environment
+  # Install openblas if slycot is being used
+  - if [[ "$SLYCOT" != "" ]]; then
+        conda install openblas;
+    fi
   # Make sure to look in the right place for python libraries (for slycot)
   - export LIBRARY_PATH="$HOME/miniconda/envs/test-environment/lib"
   # coveralls not in conda repos => install via pip instead


### PR DESCRIPTION
This PR fixes a problem in Travis CI testing against the slycot test case.  In the latest version of `slycot` (0.3.3), we switched to use OpenBLAS as the default in `slycot/setup.py` and so the previous code (which used `lapack`) was failing its tests.  The change is just to add installation of `openblas` for the slycot test case.
