### PR TITLE
Fix slycot zero

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -525,7 +525,11 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
             out = ab08nd(self.A.shape[0], self.B.shape[1], self.C.shape[0],
                          self.A, self.B, self.C, self.D)
             nu = out[0]
-            return sp.linalg.eigvals(out[8][0:nu,0:nu], out[9][0:nu,0:nu])
+            if nu == 0:
+                return np.array([])
+            else:
+                return sp.linalg.eigvals(out[8][0:nu,0:nu], out[9][0:nu,0:nu])
+            
         except ImportError:  # Slycot unavailable. Fall back to scipy.
             if self.C.shape[0] != self.D.shape[1]:
                 raise NotImplementedError("StateSpace.zero only supports "

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -42,6 +42,11 @@ class TestStateSpace(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(p, true_p)
 
+    def testEmptyZero(self):
+        """Test to make sure zero() works with no zeros in system"""
+        sys = _convertToStateSpace(TransferFunction([1], [1,2,1]))
+        np.testing.assert_array_equal(sys.zero(), np.array([]))
+
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testMIMOZero_nonsquare(self):
         """Evaluate the zeros of a MIMO system."""


### PR DESCRIPTION
Add a unit test to make sure that `StateSpace.zero()` works for systems with no transmission zeros and add a fix for a bug in the `slycot` version that did not work for this case.
