### PR TITLE
update minreal unit test to use poles/zeros instead of num/den

### DIFF
--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1162,8 +1162,7 @@ def tf(*args):
     tf2ss
 
     Notes
-    --------
-
+    -----
     ``num[i][j]`` contains the polynomial coefficients of the numerator
     for the transfer function from the (j+1)st input to the (i+1)st output.
     ``den[i][j]`` works the same way.


### PR DESCRIPTION
This PR fixes issue #217 by using a better test to see if `minreal()` is operating correctly: instead of checking whether transfer functions are the same, we check whether poles and zeros are the same.  (This avoids some simplifications than can happen in the transformation of state space objects to transfer function objects.)
