### PR TITLE
Fix pzmap not showing zeroes

### DIFF
--- a/control/pzmap.py
+++ b/control/pzmap.py
@@ -79,8 +79,8 @@ def pzmap(sys, Plot=True, title='Pole Zero Map'):
         if len(poles) > 0:
             plt.scatter(real(poles), imag(poles), s=50, marker='x')
         if len(zeros) > 0:
-            plt.scatter(real(zeros), imag(zeros), s=50, marker='o',
-                        facecolors='none')
+            plt.scatter(real(zeros), imag(zeros), s=50, marker='o')
+
         # Add axes
         #Somewhat silly workaround
         plt.axhline(y=0, color='black')


### PR DESCRIPTION
`pzmap` does not show the transfer function's zeroes, as the internal plotting argument has `facecolors='none'`:
```
   if len(zeros) > 0:
        plt.scatter(real(zeros), imag(zeros), s=50, marker='o',
                    facecolors='none')
```
Removing this argument solves the issue.