### PR TITLE
Fix numpy generated warnings that are breaking unit tests

### DIFF
--- a/control/tests/freqresp_test.py
+++ b/control/tests/freqresp_test.py
@@ -141,6 +141,11 @@ class TestFreqresp(unittest.TestCase):
          import warnings
          warnings.simplefilter('always', UserWarning)   # don't supress
          with warnings.catch_warnings(record=True) as w:
+            # Set up warnings filter to only show warnings in control module
+            warnings.filterwarnings("ignore")
+            warnings.filterwarnings("always", module="control")
+
+            # Look for a warning about sampling above Nyquist frequency
             omega_bad = np.linspace(10e-4,1.1,10) * np.pi/sys.dt
             ret = sys.freqresp(omega_bad)
             print("len(w) =", len(w))

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -148,7 +148,11 @@ class TestStateSpace(unittest.TestCase):
         # Deprecated version of the call (should generate warning)
         import warnings
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+            # Set up warnings filter to only show warnings in control module
+            warnings.filterwarnings("ignore")
+            warnings.filterwarnings("always", module="control")
+            
+            # Make sure that we get a pending deprecation warning
             sys.evalfr(1.)
             assert len(w) == 1
             assert issubclass(w[-1].category, PendingDeprecationWarning)


### PR DESCRIPTION
The latest version of `numpy` marks the `matrix` class as something that is pending deprecation.  The warnings generated by `numpy` were breaking some of the `python-control` unit tests (see [numpy-discussion thread](http://numpy-discussion.10968.n7.nabble.com/Deprecate-matrices-in-1-15-and-remove-in-1-17-td44968.html)).  This PR fixes the unit tests that were causing problems by filtering the warning messages to only include those from `python-control`.