### PR TITLE
fix issue #240: _common_den was not padding properly

### DIFF
--- a/control/tests/convert_test.py
+++ b/control/tests/convert_test.py
@@ -245,6 +245,29 @@ class TestConvert(unittest.TestCase):
         except ImportError:
             print("Slycot not present, skipping")
 
+    @unittest.skipIf(not slycot_check(), "slycot not installed")
+    def test_tf2ss_robustness(self):
+        """Unit test to make sure that tf2ss is working correctly.
+         Source: https://github.com/python-control/python-control/issues/240
+        """
+        import control
+        
+        num =  [ [[0], [1]],           [[1],   [0]] ]
+        den1 = [ [[1], [1,1]],         [[1,4], [1]] ]
+        sys1tf = control.tf(num, den1)
+        sys1ss = control.tf2ss(sys1tf)
+
+        # slight perturbation
+        den2 = [ [[1], [1e-10, 1, 1]], [[1,4], [1]] ]
+        sys2tf = control.tf(num, den2)
+        sys2ss = control.tf2ss(sys2tf)
+
+        # Make sure that the poles match for StateSpace and TransferFunction
+        np.testing.assert_array_almost_equal(np.sort(sys1tf.pole()),
+                                             np.sort(sys1ss.pole()))
+        np.testing.assert_array_almost_equal(np.sort(sys2tf.pole()),
+                                             np.sort(sys2ss.pole()))
+
 def suite():
    return unittest.TestLoader().loadTestsFromTestCase(TestConvert)
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -800,9 +800,13 @@ only implemented for SISO functions.")
                     num[i,j,0] = poleset[i][j][2]
             else:
                 # create the denominator matching this input
+                # polyfromroots gives coeffs in opposite order from what we use
+                # coefficients should be padded on right, ending at np
                 np = len(poles[j])
                 den[j,np::-1] = polyfromroots(poles[j]).real
                 denorder[j] = np
+
+                # now create the numerator, also padded on the right
                 for i in range(self.outputs):
                     # start with the current set of zeros for this output
                     nwzeros = list(poleset[i][j][0])
@@ -811,14 +815,15 @@ only implemented for SISO functions.")
                     for ip in chain(poleset[i][j][3],
                                     range(poleset[i][j][4],np)):
                         nwzeros.append(poles[j][ip])
-                    
+
                     numpoly = poleset[i][j][2] * polyfromroots(nwzeros).real 
-                    m = npmax - len(numpoly)
-                    #print(j,i,m,len(numpoly),len(poles[j]))
-                    if m < 0:
-                        num[i,j,::-1] = numpoly
-                    else:
-                        num[i,j,:m:-1] = numpoly   
+                    # print(numpoly, den[j])
+                    # polyfromroots gives coeffs in opposite order => invert
+                    # numerator polynomial should be padded on left and right
+                    #   ending at np to line up with what td04ad expects...
+                    num[i, j, np+1-len(numpoly):np+1] = numpoly[::-1]
+                    # print(num[i, j])
+
         if (abs(den.imag) > epsnm).any():
             print("Warning: The denominator has a nontrivial imaginary part: %f"
                       % abs(den.imag).max())


### PR DESCRIPTION
This PR fixes a problem where `xferfcn._common_den` was not properly padding the numerator coefficients and this was causing an apparent bug in `tf2ss` for MIMO systems (see issue #240).  The issue occurred in the following code in `xferfcn.py`:
```
m = npmax - len(numpoly)
if m < 0:
    num[i,j,::-1] = numpoly
else:
    num[i,j,:m:-1] = numpoly
```
where `npmax` is the maximum number of poles across all inputs.

What this code is doing is putting the coefficients for `numpoly` at the right end of the array `num[i,j]`, which has length `npmax+1`.  However, what `td04ad` looks at is only the portion of the numerator array that is the order of the denominator array for that *particular* input (not the max across all inputs).  So this code was shifting things too far to the right in the case where you had an input that had less than the maximum number of poles (discovered in issue #240, as part of a simulation bug).

The new code is
```
num[i, j, np+1-len(numpoly):np+1] = numpoly[::-1]
```
where `np` is the number of poles for this input (and hence `np+1` is the portion of the input array that `td04ad` will use.

In addition to fixing this bug, two unit tests were added:
* `control/tests/convert_test.py` has a test to make sure that `_common_den` does the right thing.
* `control/tests/timeresp_test.py` has a test that corresponds to the original bug identified in issue #240.

@repagh should have a look at this since it is in a section of code that he wrote.