### PR TITLE
Fixing bug in xferfcn._evalfr that caused ValueError for discrete systems

### DIFF
--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -510,7 +510,7 @@ has %i row(s)\n(output(s))." % (other.inputs, self.outputs))
             # Convert the frequency to discrete time
             dt = timebase(self)
             s = exp(1.j * omega * dt)
-            if (omega * dt > pi):
+            if np.any(omega * dt > pi):
                 warn("_evalfr: frequency evaluation above Nyquist frequency")
         else:
             s = 1.j * omega


### PR DESCRIPTION
Minor change to xfenrfcn._evafr to prevent unhandled exception being raised for discrete systems when list of angular frequencies contains more than one element.  

The exception raised in this case:
`ValueError: The truth value of an array with more than one element is ambiguous. 
Use a.any() or a.all()`

