### PR TITLE
Fix Travis CI failure (lqr bad argument)

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -385,7 +385,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         with input value s = i * omega.
 
         """
-        warn("StateSpace.evalfr(omega) will be depracted in a future "
+        warn("StateSpace.evalfr(omega) will be deprecated in a future "
              "release of python-control; use evalfr(sys, omega*1j) instead",
              PendingDeprecationWarning)
         return self._evalfr(omega)

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -414,6 +414,14 @@ class TestMatlab(unittest.TestCase):
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def testLQR(self):
         (K, S, E) = lqr(self.siso_ss1.A, self.siso_ss1.B, np.eye(2), np.eye(1))
+
+        # Should work if [Q N;N' R] is positive semi-definite
+        (K, S, E) = lqr(self.siso_ss2.A, self.siso_ss2.B, 10*np.eye(3), \
+                            np.eye(1), [[1], [1], [2]])
+
+    @unittest.skip("check not yet implemented")
+    def testLQR_checks(self):
+        # Make sure we get a warning if [Q N;N' R] is not positive semi-definite
         (K, S, E) = lqr(self.siso_ss2.A, self.siso_ss2.B, np.eye(3), \
                             np.eye(1), [[1], [1], [2]])
 


### PR DESCRIPTION
Fix for the Travis CI bug identified in PR #242 regarding LQR test.  The problem was that one of the test cases used in `tests/matlab_test.py` was incorrect.  It used a set of weighting matrices that did not give a positive definite cost function for the LQR problem.  This *should* have generated a error, but that case is not tested in the code (see issue #252, created to track this).

The fix here is to change the state space weighting matrix (multiplying it by 10) so that the overall weighting function is now positive definite.  In addition, a skipped unit test has been put in with the original test case.

The reason this was generating spurious errors is because the `slycot` LQR function (`sb0md`) was creating a closed loop system whose eigenvalues had very small realparts (on order 1e-16) and apparently these were sometimes positive and sometimes negative.

Also fixed a small typo in a docstring while I was at it.