### PR TITLE
Fix ss2tf in case state space matrices are made of int values.

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -84,7 +84,7 @@ def _matrix(a):
     module.
     """
     from numpy import matrix
-    am = matrix(a)
+    am = matrix(a, dtype=float)
     if (1, 0) == am.shape:
         am.shape = (0, 0)
     return am

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -600,6 +600,16 @@ class TestXferFcn(unittest.TestCase):
         sys = TransferFunction([1,-1], [1], True)
         np.testing.assert_equal(sys.dcgain(), 0)
 
+    def test_ss2tf(self):
+        A = np.array([[-4, -1], [-1, -4]])
+        B = np.array([[1], [3]])
+        C = np.array([[3, 1]])
+        D = 0
+        sys = ss2tf(A, B, C, D)
+        true_sys = TransferFunction([6., 14.], [1., 8., 15.])
+        np.testing.assert_almost_equal(sys.num, true_sys.num)
+        np.testing.assert_almost_equal(sys.den, true_sys.den)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(TestXferFcn)


### PR DESCRIPTION
PR to fix issue https://github.com/python-control/python-control/issues/272

The problem comes from the fact that in python2, division between ints returns an int... Which is not the case in Python 3.