### PR TITLE
Fix sphinx warnings and use readthedocs theme for local doc generation

### DIFF
--- a/control/lti.py
+++ b/control/lti.py
@@ -54,8 +54,9 @@ class LTI:
 
         Parameters
         ----------
-        strict: bool (default = False)
-            If strict is True, make sure that timebase is not None
+        strict: bool, optional
+            If strict is True, make sure that timebase is not None.  Default 
+            is False. 
         """
 
         # If no timebase is given, answer depends on strict flag
@@ -73,8 +74,9 @@ class LTI:
         ----------
         sys : LTI system
             System to be checked
-        strict: bool (default = False)
-            If strict is True, make sure that timebase is not None
+        strict: bool, optional
+            If strict is True, make sure that timebase is not None.  Default 
+            is False. 
         """
         # If no timebase is given, answer depends on strict flag
         if self.dt is None:

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -125,9 +125,12 @@ def modred(sys, ELIM, method='matchdc'):
     Raises
     ------
     ValueError
-        - if `method` is not either ``'matchdc'`` or ``'truncate'``
-        - if eigenvalues of `sys.A` are not all in left half plane
-          (`sys` must be stable)
+        Raised under the following conditions:
+
+            * if `method` is not either ``'matchdc'`` or ``'truncate'``
+
+            * if eigenvalues of `sys.A` are not all in left half plane
+              (`sys` must be stable)
 
     Examples
     --------

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -118,7 +118,7 @@ def phase_plot(odefun, X=None, Y=None, scale=1, X0=None, T=None,
 
     See also
     --------
-    box_grid(X, Y): construct box-shaped grid of initial conditions
+    box_grid : construct box-shaped grid of initial conditions
 
     Examples
     --------

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -424,8 +424,8 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
 
              G(exp(j*omega*dt)) = mag*exp(j*phase).
 
-        Inputs
-        ------
+        Parameters
+        ----------
         omega: A list of frequencies in radians/sec at which the system
             should be evaluated. The list can be either a python list
             or a numpy array and will be sorted before evaluation.

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -410,8 +410,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
 
     # Method for generating the frequency response of the system
     def freqresp(self, omega):
-        """
-        Evaluate the system's transfer func. at a list of freqs, omega.
+        """Evaluate the system's transfer func. at a list of freqs, omega.
 
         mag, phase, omega = self.freqresp(omega)
 
@@ -426,20 +425,23 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
 
         Parameters
         ----------
-        omega: A list of frequencies in radians/sec at which the system
-            should be evaluated. The list can be either a python list
-            or a numpy array and will be sorted before evaluation.
+        omega : array
+            A list of frequencies in radians/sec at which the system should be
+            evaluated. The list can be either a python list or a numpy array
+            and will be sorted before evaluation.
 
         Returns
         -------
-        mag: The magnitude (absolute value, not dB or log10) of the system
+        mag : float
+            The magnitude (absolute value, not dB or log10) of the system
             frequency response.
 
-        phase: The wrapped phase in radians of the system frequency
-            response.
+        phase : float
+            The wrapped phase in radians of the system frequency response.
 
-        omega: The list of sorted frequencies at which the response
-            was evaluated.
+        omega : array
+            The list of sorted frequencies at which the response was
+            evaluated.
 
         """
 
@@ -614,11 +616,11 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
 
         Parameters
         ----------
-        other: LTI
+        other : LTI
             The lower LTI system
-        ny: int, optional
+        ny : int, optional
             Dimension of (plant) measurement output.
-        nu: int, optional
+        nu : int, optional
             Dimension of (plant) control input.
 
         """
@@ -793,19 +795,21 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         method :  {"gbt", "bilinear", "euler", "backward_diff", "zoh"}
             Which method to use:
 
-               * gbt: generalized bilinear transformation
-               * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
-               * euler: Euler (or forward differencing) method ("gbt" with alpha=0)
-               * backward_diff: Backwards differencing ("gbt" with alpha=1.0)
-               * zoh: zero-order hold (default)
+            * gbt: generalized bilinear transformation
+            * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
+            * euler: Euler (or forward differencing) method ("gbt" with 
+              alpha=0)
+            * backward_diff: Backwards differencing ("gbt" with alpha=1.0)
+            * zoh: zero-order hold (default)
 
         alpha : float within [0, 1]
             The generalized bilinear transformation weighting parameter, which
-            should only be specified with method="gbt", and is ignored otherwise
+            should only be specified with method="gbt", and is ignored
+            otherwise
 
         Returns
         -------
-        sysd : StateSpace system
+        sysd : StateSpace
             Discrete time system, with sampling rate Ts
 
         Notes
@@ -1079,18 +1083,18 @@ def _mimo2siso(sys, input, output, warn_conversion=False):
 
     Parameters
     ----------
-    sys: StateSpace
+    sys : StateSpace
         Linear (MIMO) system that should be converted.
-    input: int
+    input : int
         Index of the input that will become the SISO system's only input.
-    output: int
+    output : int
         Index of the output that will become the SISO system's only output.
-    warn_conversion: bool
-        If True: print a warning message when sys is a MIMO system.
-        Warn that a conversion will take place.
+    warn_conversion : bool, optional
+        If `True`, print a message when sys is a MIMO system,
+        warning that a conversion will take place.  Default is False.
 
     Returns
-    sys: StateSpace
+    sys : StateSpace
         The converted (SISO) system.
     """
     if not (isinstance(input, int) and isinstance(output, int)):
@@ -1341,16 +1345,16 @@ def rss(states=1, outputs=1, inputs=1):
 
     Parameters
     ----------
-    states: integer
+    states : integer
         Number of state variables
-    inputs: integer
+    inputs : integer
         Number of system inputs
-    outputs: integer
+    outputs : integer
         Number of system outputs
 
     Returns
     -------
-    sys: StateSpace
+    sys : StateSpace
         The randomly created linear system
 
     Raises
@@ -1379,16 +1383,16 @@ def drss(states=1, outputs=1, inputs=1):
 
     Parameters
     ----------
-    states: integer
+    states : integer
         Number of state variables
-    inputs: integer
+    inputs : integer
         Number of system inputs
-    outputs: integer
+    outputs : integer
         Number of system outputs
 
     Returns
     -------
-    sys: StateSpace
+    sys : StateSpace
         The randomly created linear system
 
     Raises
@@ -1417,7 +1421,7 @@ def ssdata(sys):
 
     Parameters
     ----------
-    sys: LTI (StateSpace, or TransferFunction)
+    sys : LTI (StateSpace, or TransferFunction)
         LTI system whose data will be returned
 
     Returns

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,5 @@
 numpy
 scipy
 matplotlib
+sphinx_rtd_theme
 numpydoc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,15 +30,15 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # -- Project information -----------------------------------------------------
 
 project = u'Python Control Systems Library'
-copyright = u'2018, python-control.org'
+copyright = u'2019, python-control.org'
 author = u'Python Control Developers'
 
 # Version information - read from the source code
 import re
 import control
 
-# The short X.Y version
-version = re.sub(r'(\d+\.\d+)\.(.*)', r'\1', control.__version__)
+# The short X.Y.Z version
+version = re.sub(r'(\d+\.\d+\.\d+)(.*)', r'\1', control.__version__)
 
 # The full version, including alpha/beta/rc tags
 release = control.__version__
@@ -109,7 +109,7 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -120,7 +120,7 @@ todo_include_todos = True
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -16,7 +16,7 @@ System creation
 
     ss
     tf
-    FRD
+    frd
     rss
     drss
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -23,7 +23,7 @@ Some differences from MATLAB
 The python-control package makes use of `NumPy <http://www.numpy.org>`_ and
 `SciPy <https://www.scipy.org>`_.  A list of general differences between
 NumPy and MATLAB can be found `here
-<http://www.scipy.org/NumPy_for_Matlab_Users>`_.
+<https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html>`_.
 
 In terms of the python-control package more specifically, here are
 some thing to keep in mind:

--- a/doc/matlab.rst
+++ b/doc/matlab.rst
@@ -15,7 +15,7 @@ Creating linear models
 
    tf
    ss
-   frd
+   FRD
    rss
    drss
 

--- a/doc/matlab.rst
+++ b/doc/matlab.rst
@@ -15,7 +15,7 @@ Creating linear models
 
    tf
    ss
-   FRD
+   frd
    rss
    drss
 


### PR DESCRIPTION
This PR fixes up some warnings that were being generated by `sphinx` and changes the default theme used for generated the documentation on a local machine to match the ReadTheDocs theme that is used online (handy so that you know what things will look like when rendered on ReadTheDocs).

In fixing up one of the warning messages in `statesp.py`, I also took the opportunity to update other docstrings to be numpydoc compatible.