### PR TITLE
Change to code for ctrb and obsv

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -421,7 +421,7 @@ def obsv(A, C):
     n = np.shape(amat)[0]
 
     # Construct the observability matrix
-    obsv = np.hstack([cmat] + [cmat*amat**i for i in range(1, n)])
+    obsv = np.vstack([cmat] + [cmat*amat**i for i in range(1, n)])
     return obsv
 
 def gram(sys,type):

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -368,7 +368,7 @@ def lqr(*args, **keywords):
 
     return K, S, E
 
-def ctrb(A,B):
+def ctrb(A, B):
     """Controllabilty matrix
 
     Parameters
@@ -391,10 +391,9 @@ def ctrb(A,B):
     amat = np.mat(A)
     bmat = np.mat(B)
     n = np.shape(amat)[0]
+
     # Construct the controllability matrix
-    ctrb = bmat
-    for i in range(1, n):
-        ctrb = np.hstack((ctrb, amat**i*bmat))
+    ctrb = np.hstack([bmat] + [amat**i*bmat for i in range(1, n)])
     return ctrb
 
 def obsv(A, C):
@@ -421,10 +420,8 @@ def obsv(A, C):
     cmat = np.mat(C)
     n = np.shape(amat)[0]
 
-    # Construct the controllability matrix
-    obsv = cmat
-    for i in range(1, n):
-        obsv = np.vstack((obsv, cmat*amat**i))
+    # Construct the observability matrix
+    obsv = np.hstack([cmat] + [cmat*amat**i for i in range(1, n)])
     return obsv
 
 def gram(sys,type):


### PR DESCRIPTION
This is not a bug fix.  It's a minor speed improvement to `statefbk.ctrb` and `statefbk.obsv`.

[It's the first time I have contributed to someone else's project so welcome feedback and advice if I'm not doing this correctly]

### Summary

I noticed that you can avoid multiple hstack operations by creating a list first.

I've done some testing and I think the behaviour of these methods is unchanged.  See my test outputs below.

I realise this is a very minor improvement so feel free to ignore.

### 1. Testing `ctrb()`

```
Python 3.7.3 | packaged by conda-forge | (default, Mar 27 2019, 15:43:19) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import numpy as np                                                      

In [2]: import control                                                          

In [3]: np.random.seed(1)                                                       

In [4]: cum = 0                                                                 

In [5]: for i in range(10): 
   ...:     A = np.random.randn(i, i) 
   ...:     B = np.random.randn(i, 1) 
   ...:     cum += control.ctrb(A, B).sum() 
   ...:                                                                         

In [6]: cum                                                                     
Out[6]: -10066.24518631401

In [7]: control.__file__                                                        
Out[7]: '/Users/billtubbs/python-control/python-control/control/__init__.py'
```

Results with official control package for comparison 

```
Python 3.6.7 | packaged by conda-forge | (default, Feb 28 2019, 02:16:08) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import numpy as np                                                                         

In [2]: import control                                                                             

In [3]: np.random.seed(1)                                                                          

In [4]: cum = 0.                                                                                   

In [5]: for i in range(10): 
   ...:     A = np.random.randn(i, i) 
   ...:     B = np.random.randn(i, 1) 
   ...:     cum += control.ctrb(A, B).sum() 
   ...:                                                                                            

In [6]: cum                                                                                        
Out[6]: -10066.245186314005

In [7]: control.__file__                                                                           
Out[7]: '/Users/billtubbs/anaconda3/envs/torch/lib/python3.6/site-packages/control/__init__.py'
```

### 2. Testing `obsv()`

```
In [1]: import numpy as np                                                      

In [2]: import control                                                          

In [3]: control.__file__                                                        
Out[3]: '/Users/billtubbs/python-control/python-control/control/__init__.py'

In [4]: np.random.seed(1)                                                       

In [5]: cum = 0.                                                                

In [6]: for i in range(10): 
   ...:     A = np.random.randn(i, i) 
   ...:     C = np.random.randn(1, i) 
   ...:     cum += control.obsv(A, C).sum() 
   ...:                                                                         

In [7]: cum                                                                     
Out[7]: -7589.3515984634905
```

Results with official control package for comparison 

```
In [12]: np.random.seed(1)                                                                         

In [13]: cum = 0.                                                                                  

In [14]: for i in range(10): 
    ...:     A = np.random.randn(i, i) 
    ...:     C = np.random.randn(1, i) 
    ...:     cum += control.obsv(A, C).sum() 
    ...:                                                                                           

In [15]: cum                                                                                       
Out[15]: -7589.351598463492

In [16]: control.__file__                                                                          
Out[16]: '/Users/billtubbs/anaconda3/envs/torch/lib/python3.6/site-packages/control/__init__.py'
```

### 3. Speed Tests (In Python 3.7 on a 2013 MacBook Pro)

```
In [8]: def ctrb1(A, B):  
   ...:      amat = np.mat(A)  
   ...:      bmat = np.mat(B)  
   ...:      n = np.shape(amat)[0]  
   ...:      ctrb = bmat  
   ...:      for i in range(1, n):  
   ...:          ctrb = np.hstack((ctrb, amat**i*bmat))  
   ...:      return ctrb 
   ...:                                                                         

In [9]: def ctrb2(A, B):  
   ...:      amat = np.mat(A)  
   ...:      bmat = np.mat(B)  
   ...:      n = np.shape(amat)[0]  
   ...:      ctrb = np.hstack([bmat] + [amat**i*bmat for i in range(1, n)])  
   ...:      return ctrb 
   ...:                                                                         

In [11]: np.random.seed(1)                                                      

In [12]: A = np.random.randn(8, 8)                                              

In [13]: B = np.random.randn(8, 1)                                              

In [14]: %timeit ctrb1(A, B)                                                    
456 µs ± 18 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [15]: %timeit ctrb2(A, B)                                                    
378 µs ± 13.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [16]: 1-378/456                                                              
Out[16]: 0.17105263157894735
```