### PR TITLE
Return errors from examples/run_examples.sh correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,11 @@ script:
   # set PYTHONPATH for examples
   # pmw needed for examples/tfvis.py
   # future is needed for Python 2, also for examples/tfvis.py
-
   - if [[ "$SLYCOT" != "" ]]; then
       export PYTHONPATH=$PWD;
       conda install -c conda-forge pmw future;
-      cd examples; bash run_examples.sh; cd ..;
+      (cd examples; bash run_examples.sh);
     fi
-
-# arbitrary change to try to trigger travis build
 
 after_success:
   - coveralls


### PR DESCRIPTION
The PR fixes an error in `.travis.yml` that was not checking for errors in `examples/run_examples.sh` correctly, so any errors in the examples files were not being caught. 

Details: the original code used a command of the form
```
if [condition]
    cd examples; bash run_examples.sh; cd ..
fi
```
The `if` command returns the status of the last command, which in this case is `cd ..`, which is always true. The fix uses the construct 
```
if [condition]
    (cd examples; bash run_examples.sh);
fi
```
which still leaves the script in the main directory but returns the exit status of the bash command. 