### PR TITLE
allow single string as signal list for I/O system

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -363,7 +363,11 @@ class InputOutputSystem(object):
 
         elif isinstance(signals, int):
             # Number of signals given; make up the names
-            return signals, {'x[%d]' % i: i for i in range(signals)}
+            return signals, {'%s[%d]' % (prefix, i): i for i in range(signals)}
+
+        elif isinstance(signals, str):
+            # Single string given => single signal with given name
+            return 1, {signals: 0}
 
         elif all(isinstance(s, str) for s in signals):
             # Use the list of strings as the signal names


### PR DESCRIPTION
While use the `iosys` module, I noticed that the following construct did something unexpected:
```
lateral = ct.NonlinearIOSystem(vehicle_update, vehicle_output,
    states=2, name='lateral', inputs=('phi'), outputs=('y', 'theta')
)
```
This is supposed to be a single input, multi-output system, but I got a system with 3 (?) inputs.  Turns out that the string `'phi'` was being interpreted as an array of length three since I didn't write it explicitly as a tuple, `('phi',)` and hence it was an `array` of length 3.

This PR checks to see if inputs, outputs, or states are a single string object, in which case it assumes you want are specifying a single signal with the string as the name.

I also fixed a small bug where the prefix for setting the default name (if no name string is given for a single) was being ignored.

