### PR TITLE
Add similarity transformation function

### DIFF
--- a/control/tests/canonical_test.py
+++ b/control/tests/canonical_test.py
@@ -222,8 +222,8 @@ class TestCanonical(unittest.TestCase):
         """Test similarty transform"""
 
         # Single input, single output systems
-        siso_ini = tf2ss(tf([1, 1], [1, 2, 1]))
-        for form in 'reachable', 'observable', 'modal':
+        siso_ini = tf2ss(tf([1, 1], [1, 1, 1]))
+        for form in 'reachable', 'observable':
             # Convert the system to one of the canonical forms
             siso_can, T_can = canonical_form(siso_ini, form)
 


### PR DESCRIPTION
This PR adds a function `similarity_transform` that performs a similarity transformation on a state space system.  In addition, an optional `timescale` option can be used to scale the timebase for the system.

This function is used in FBS to convert a state space system into normalized coordinates (which includes both state space scaling and time scaling).
