### PR TITLE
Travis py37 scipy0.19.1 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
 # Exclude combinations that are very unlikely (and don't work)
 matrix:
   exclude:
-    - python: 3.7			# python3.7 should use latest scipy
+    - python: "3.7"			# python3.7 should use latest scipy
       env: SCIPY="scipy==0.19.1" SLYCOT=
 
 # install required system libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ env:
   - SCIPY=scipy SLYCOT=			# default, w/out slycot
   - SCIPY="scipy==0.19.1" SLYCOT=	# legacy support, w/out slycot
 
+# Exclude combinations that are very unlikely (and don't work)
+matrix:
+  exlude:
+    - python: 3.7			# python3.7 should use latest scipy
+      env: SCIPY="scipy==0.19.1" SLYCOT=
+
 # install required system libraries
 before_install:
   # Install gfortran for testing slycot; use apt-get instead of conda in

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
 
 # Exclude combinations that are very unlikely (and don't work)
 matrix:
-  exlude:
+  exclude:
     - python: 3.7			# python3.7 should use latest scipy
       env: SCIPY="scipy==0.19.1" SLYCOT=
 


### PR DESCRIPTION
This PR fixes issue #321, in which Travis CI is failing for the python-3.7, scipy-0.19.1 build.  Still not completely sure what the issue is or why it is just starting to fail now, but since scipy 0.19.1 only supports python 2.7-3.6, I am removing this test from the build matrix.

I had to play around with things to figure out how to get this to work (could only test by pushing to github), but I'll squash the commits when I merge.
