### PR TITLE
Fix slycot link error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ jobs:
       dist: xenial
       services: xvfb
       python: "2.7"
-      env: SCIPY=scipy SLCOT=source
+      env: SCIPY=scipy SLYCOT=source
     - name: "linux, Python 3.7, slycot=source"
       os: linux
       dist: xenial
       services: xvfb
       python: "3.7"
-      env: SCIPY=scipy SLCOT=source
+      env: SCIPY=scipy SLYCOT=source
 
 matrix:
   # Exclude combinations that are very unlikely (and don't work)
@@ -56,13 +56,13 @@ matrix:
       dist: xenial
       services: xvfb
       python: "2.7"
-      env: SCIPY=scipy SLCOT=source
+      env: SCIPY=scipy SLYCOT=source
     - name: "linux, Python 3.7, slycot=source"
       os: linux
       dist: xenial
       services: xvfb
       python: "3.7"
-      env: SCIPY=scipy SLCOT=source
+      env: SCIPY=scipy SLYCOT=source
 
 # install required system libraries
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
   - if [[ "$SLYCOT" = "source" ]]; then
       git clone https://github.com/python-control/Slycot.git slycot;
       cd slycot; python setup.py install -G "Unix Makefiles"; cd ..;
-    else if [[ "$SLYCOT" = "conda" ]]; then
+    elif [[ "$SLYCOT" = "conda" ]]; then
       conda install -c conda-forge slycot;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,12 @@ matrix:
 before_install:
   # Install gfortran for testing slycot; use apt-get instead of conda in
   # order to include the proper CXXABI dependency (updated in GCC 4.9)
+  # Note: these commands should match the slycot .travis.yml configuration
   - if [[ "$SLYCOT" != "" ]]; then
       sudo apt-get update -qq;
+      sudo apt-get install liblapack-dev libblas-dev;
       sudo apt-get install gfortran;
+      sudo apt-get install cmake;
     fi
   # use miniconda to install numpy/scipy, to avoid lengthy build from source
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install:
 install:
   # Install packages needed by python-control
   - conda install $SCIPY matplotlib
-  
+
   # Figure out how to build slycot
   #   source: use "Unix Makefiles" as generator; Ninja cannot handle Fortran
   #   conda: use pre-compiled version of slycot on conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,40 @@ env:
   - SCIPY=scipy SLYCOT=			# default, w/out slycot
   - SCIPY="scipy==0.19.1" SLYCOT=	# legacy support, w/out slycot
 
+# Add optional builds that test against latest version of slycot
+jobs:
+  include:
+    - name: "linux, Python 2.7, slycot=source"
+      os: linux
+      dist: xenial
+      services: xvfb
+      python: "2.7"
+      env: SCIPY=scipy SLCOT=source
+    - name: "linux, Python 3.7, slycot=source"
+      os: linux
+      dist: xenial
+      services: xvfb
+      python: "3.7"
+      env: SCIPY=scipy SLCOT=source
+
 matrix:
   # Exclude combinations that are very unlikely (and don't work)
   exclude:
     - python: "3.7"			# python3.7 should use latest scipy
       env: SCIPY="scipy==0.19.1" SLYCOT=
 
-  # Add optional builds that test against latest version of slycot
   allow_failures:
+    - name: "linux, Python 2.7, slycot=source"
+      os: linux
+      dist: xenial
+      services: xvfb
+      python: "2.7"
+      env: SCIPY=scipy SLCOT=source
     - name: "linux, Python 3.7, slycot=source"
       os: linux
       dist: xenial
       services: xvfb
+      python: "3.7"
       env: SCIPY=scipy SLCOT=source
 
 # install required system libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,13 +82,14 @@ before_install:
 install:
   # Install packages needed by python-control
   - conda install $SCIPY matplotlib
+  
+  # Figure out how to build slycot
+  #   source: use "Unix Makefiles" as generator; Ninja cannot handle Fortran
+  #   conda: use pre-compiled version of slycot on conda-forge
   - if [[ "$SLYCOT" = "source" ]]; then
-      # Build slycot from source
-      # Use "Unix Makefiles" as generator, because Ninja cannot handle Fortran
       git clone https://github.com/python-control/Slycot.git slycot;
       cd slycot; python setup.py install -G "Unix Makefiles"; cd ..;
     else if [[ "$SLYCOT" = "conda" ]]; then
-      # Use version of slycot on conda-forge
       conda install -c conda-forge slycot;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,30 @@ python:
 #
 # We also want to test with and without slycot
 env:
-  - SCIPY=scipy SLYCOT=slycot		# default, with slycot
+  - SCIPY=scipy SLYCOT=conda		# default, with slycot via conda
   - SCIPY=scipy SLYCOT=			# default, w/out slycot
   - SCIPY="scipy==0.19.1" SLYCOT=	# legacy support, w/out slycot
 
-# Exclude combinations that are very unlikely (and don't work)
 matrix:
+  # Exclude combinations that are very unlikely (and don't work)
   exclude:
     - python: "3.7"			# python3.7 should use latest scipy
       env: SCIPY="scipy==0.19.1" SLYCOT=
+
+  # Add optional builds that test against latest version of slycot
+  allow_failures:
+    - name: "linux, Python 3.7, slycot=source"
+      os: linux
+      dist: xenial
+      services: xvfb
+      env: SCIPY=scipy SLCOT=source
 
 # install required system libraries
 before_install:
   # Install gfortran for testing slycot; use apt-get instead of conda in
   # order to include the proper CXXABI dependency (updated in GCC 4.9)
   # Note: these commands should match the slycot .travis.yml configuration
-  - if [[ "$SLYCOT" != "" ]]; then
+  - if [[ "$SLYCOT" = "source" ]]; then
       sudo apt-get update -qq;
       sudo apt-get install liblapack-dev libblas-dev;
       sudo apt-get install gfortran;
@@ -60,9 +68,8 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage
   - source activate test-environment
-  # Install openblas if slycot is being used
-  # also install scikit-build for the build process
-  - if [[ "$SLYCOT" != "" ]]; then
+  # Install scikit-build for the build process if slycot is being used
+  - if [[ "$SLYCOT" = "source" ]]; then
       conda install openblas;
       conda install -c conda-forge scikit-build;
     fi
@@ -75,13 +82,14 @@ before_install:
 install:
   # Install packages needed by python-control
   - conda install $SCIPY matplotlib
-  # Build slycot from source
-  # For python 3, need to provide pointer to python library
-  # Use "Unix Makefiles" as generator, because Ninja cannot handle Fortran
-  #! git clone https://github.com/repagh/Slycot.git slycot;
-  - if [[ "$SLYCOT" != "" ]]; then
+  - if [[ "$SLYCOT" = "source" ]]; then
+      # Build slycot from source
+      # Use "Unix Makefiles" as generator, because Ninja cannot handle Fortran
       git clone https://github.com/python-control/Slycot.git slycot;
       cd slycot; python setup.py install -G "Unix Makefiles"; cd ..;
+    else if [[ "$SLYCOT" = "conda" ]]; then
+      # Use version of slycot on conda-forge
+      conda install -c conda-forge slycot;
     fi
 
 # command to run tests


### PR DESCRIPTION
This PR address a problem in the `slycot` build process (documented [here](https://github.com/python-control/Slycot/pull/85)) in which building `slycot` from source is currently failing.  This is related to issue #349 where coveralls was reporting a decrease in coverage (because `slycot` was not present => some code was not being tested).

To fix this, I changed the `.travis.yml` file to use the `conda-forge` version of `slycot` by default.  This is probably the better thing to do in any case, since that  is how most users are likely to get `slycot`.  I also added two "optional" (allowed to fail) builds that create the `slycot` package from source code, as was originally done.  I put in one for python-2.7 (still working) and one for python-3.7 (failing).

I didn't squash the commits when  I created this PR, but suggest doing that when it is merged.