### PR TITLE
Fix iosys errors for unspecified # of inputs/outputs

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -212,12 +212,12 @@ class InputOutputSystem(object):
 
     def __str__(self):
         """String representation of an input/output system"""
-        str = "System: " + (self.name if self.name else "(none)") + "\n"
-        str += "Inputs (%d): " % self.ninputs
+        str = "System: " + (self.name if self.name else "(None)") + "\n"
+        str += "Inputs (%s): " % self.ninputs
         for key in self.input_index: str += key + ", "
-        str += "\nOutputs (%d): " % self.noutputs
+        str += "\nOutputs (%s): " % self.noutputs
         for key in self.output_index: str += key + ", "
-        str += "\nStates (%d): " % self.nstates
+        str += "\nStates (%s): " % self.nstates
         for key in self.state_index: str += key + ", "
         return str
 
@@ -317,13 +317,8 @@ class InputOutputSystem(object):
         ninputs = sys1.ninputs
         noutputs = sys1.noutputs
 
-        # Make sure timebase are compatible
-        dt = _find_timebase(sys1, sys2)
-        if dt is False:
-            raise ValueError("System timebases are not compabile")
-
         # Create a new system to handle the composition
-        newsys = InterconnectedSystem((sys1, sys2), dt=dt)
+        newsys = InterconnectedSystem((sys1, sys2))
 
         # Set up the input map
         newsys.set_input_map(np.concatenate(
@@ -937,6 +932,7 @@ class InterconnectedSystem(InputOutputSystem):
         system_count = 0
         for sys in syslist:
             # Make sure time bases are consistent
+            # TODO: Use lti._find_timebase() instead?
             if dt is None and sys.dt is not None:
                 # Timebase was not specified; set to match this system
                 dt = sys.dt
@@ -948,7 +944,7 @@ class InterconnectedSystem(InputOutputSystem):
                sys.nstates is None:
                 raise TypeError("System '%s' must define number of inputs, "
                                 "outputs, states in order to be connected" %
-                                sys)
+                                sys.name)
 
             # Keep track of the offsets into the states, inputs, outputs
             self.input_offset.append(ninputs)

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -100,6 +100,32 @@ class TestIOSys(unittest.TestCase):
         np.testing.assert_array_equal(linsys.C, iosys_named.C)
         np.testing.assert_array_equal(linsys.D, iosys_named.D)
 
+    # Make sure unspecified inputs/outputs/states are handled properly
+    def test_iosys_unspecified(self):
+        # System with unspecified inputs and outputs
+        sys = ios.NonlinearIOSystem(secord_update, secord_output)
+        np.testing.assert_raises(TypeError, sys.__mul__, sys)
+
+    # Make sure we can print various types of I/O systems
+    def test_iosys_print(self):
+        # Send the output to /dev/null
+        import os
+        f = open(os.devnull,"w")
+
+        # Simple I/O system
+        iosys = ct.ss2io(self.siso_linsys)
+        print(iosys, file=f)
+
+        # I/O system without ninputs, noutputs
+        ios_unspecified = ios.NonlinearIOSystem(secord_update, secord_output)
+        print(ios_unspecified, file=f)
+
+        # I/O system with derived inputs and outputs
+        ios_linearized = ios.linearize(ios_unspecified, [0, 0], [0])
+        print(ios_linearized, file=f)
+
+        f.close()
+
     @unittest.skipIf(StrictVersion(sp.__version__) < "1.0",
                      "requires SciPy 1.0 or greater")
     def test_nonlinear_iosys(self):
@@ -831,7 +857,6 @@ class TestIOSys(unittest.TestCase):
         np.testing.assert_array_equal(io_feedback.B, ss_feedback.B)
         np.testing.assert_array_equal(io_feedback.C, ss_feedback.C)
         np.testing.assert_array_equal(io_feedback.D, ss_feedback.D)
-
 
     def test_duplicates(self):
         nlios =  ios.NonlinearIOSystem(None, \

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -8,6 +8,7 @@
 # operations on input/output systems.  Separate unit tests should be
 # created for that purpose.
 
+from __future__ import print_function
 import unittest
 import warnings
 import numpy as np


### PR DESCRIPTION
Addresses the bug in issue #329 by fixing the `__str__()` method to handle the case where `ninputs`, `noutputs`, or `nstates` is `None`.  Also added some unit tests.

Travis CI fails due to issues addressed in PR #353 (OK to merge).
