### PR TITLE
Fixed tabs in yaml and python files to only use spaces.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ python:
 #
 # We also want to test with and without slycot
 env:
-  - SCIPY=scipy SLYCOT=conda		# default, with slycot via conda
-  - SCIPY=scipy SLYCOT=			# default, w/out slycot
-  - SCIPY="scipy==0.19.1" SLYCOT=	# legacy support, w/out slycot
+  - SCIPY=scipy SLYCOT=conda       # default, with slycot via conda
+  - SCIPY=scipy SLYCOT=            # default, w/out slycot
+  - SCIPY="scipy==0.19.1" SLYCOT=  # legacy support, w/out slycot
 
 # Add optional builds that test against latest version of slycot
 jobs:
@@ -47,7 +47,7 @@ jobs:
 matrix:
   # Exclude combinations that are very unlikely (and don't work)
   exclude:
-    - python: "3.7"			# python3.7 should use latest scipy
+    - python: "3.7"            # python3.7 should use latest scipy
       env: SCIPY="scipy==0.19.1" SLYCOT=
 
   allow_failures:

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -291,7 +291,7 @@ def phase_plot(odefun, X=None, Y=None, scale=1, X0=None, T=None,
         # set(xy, 'AutoScaleFactor', 0);
 
     if (scale < 0):
-        bp = mpl.plot(x1, x2, 'b.');		# add dots at base
+        bp = mpl.plot(x1, x2, 'b.');        # add dots at base
         # set(bp, 'MarkerSize', PP_arrow_markersize);
 
     return;

--- a/control/tests/phaseplot_test.py
+++ b/control/tests/phaseplot_test.py
@@ -46,7 +46,7 @@ class TestPhasePlot(unittest.TestCase):
                   [[-2.3056, 2.1], [2.3056, -2.1]], T=6, verbose=False)
 
     def testOscillatorParams(self):
-        m = 1; b = 1; k = 1;			# default values
+        m = 1; b = 1; k = 1;            # default values
         phase_plot(self.oscillator_ode, timepts = [0.3, 1, 2, 3], X0 =
                   [[-1,1], [-0.3,1], [0,1], [0.25,1], [0.5,1], [0.7,1],
                    [1,1], [1.3,1], [1,-1], [0.3,-1], [0,-1], [-0.25,-1],


### PR DESCRIPTION
There were some tabs before comments in 3 files. On the travis.yml file it caused [pre-commit](https://pre-commit.com/hooks.html)'s yaml-checker to fail.

There were a few python files that had tabs before comments. 

Both 'worked' but aren't considered best practices of not mixing tabs and spaces.