### PR TITLE
Bugfix in matrix multiplication in output computation in iosys.LinearIOSystem

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -656,8 +656,10 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
         return np.array(xdot).reshape((-1,))
 
     def _out(self, t, x, u):
-        y = self.C * np.reshape(x, (-1, 1)) + self.D * np.reshape(u, (-1, 1))
-        return np.array(y).reshape((self.noutputs,))
+        # Convert input to column vector and then change output to 1D array
+        y = np.dot(self.C, np.reshape(x, (-1, 1))) \
+            + np.dot(self.D, np.reshape(u, (-1, 1)))
+        return np.array(y).reshape((-1,))
 
 
 class NonlinearIOSystem(InputOutputSystem):


### PR DESCRIPTION
Hi,
I believe the `_out` method in `iosys.LinearIOSystem` does not perform the matrix multiplication correctly when not using the numpy matrix class, since it uses `*` instead of `dot()`.
The following snippet reproduces the incorrect behavior:

```
import numpy as np
import control as ct
if __name__ == '__main__':	
	ct.use_numpy_matrix(flag=False);
	A = np.array([[0.5, 0.7], [0, -0.8]]);
	B = np.array([[0], [1]]);
	C = np.array([[1, 0]]);
	D = np.array([[0]]);
	iosys = ct.iosys.LinearIOSystem(ct.StateSpace(A, B, C, D));
	x0 = np.array([1.1,-0.9]);
	u0 = np.array([0.5]);
	ct.iosys.linearize(iosys, x0, u0);
```

The change implemented is consistent with what performed by the `_rhs` method a few lines above, and works with both `matrix` and `ndarray`.

Thanks
Francesco