### PR TITLE
Enter Function which can act similar to Matlab input function and can handle integer, float or arrays 

### DIFF
--- a/control/pzmap.py
+++ b/control/pzmap.py
@@ -81,7 +81,7 @@ def pzmap(sys, Plot=True, grid=False, title='Pole Zero Map'):
         The system's zeros.
     """
     # Get parameter values
-    Plot = config._get_param('rlocus', 'Plot', grid, True)
+    Plot = config._get_param('rlocus', 'Plot', Plot, True)
     grid = config._get_param('rlocus', 'grid', grid, False)
     
     if not isinstance(sys, LTI):


### PR DESCRIPTION
## Enter Function
A simple function replicating the Matlab input function.
In Matlab the built-in input function handles integer, float or arrays and treat all of then as arrays.
But in python there is no such built-in function. In control system analysis this function can be helpful.
### Demo
     a = enter()
### Input format: 
- Single Integer or float
  Eg: 5
- Integers or floats seperated by comma
 Eg: 8,9  
 - List of integers or floats
  Eg: [6,7]