### PR TITLE
small corrections for continuous-to-discrete approximations

### DIFF
--- a/control/dtime.py
+++ b/control/dtime.py
@@ -49,7 +49,7 @@ $Id: dtime.py 185 2012-08-30 05:44:32Z murrayrm $
 from .lti import isctime
 from .statesp import StateSpace, _convertToStateSpace
 
-__all__ = ['sample_system', 'c2d']
+__all__ = ['sample_system']
 
 # Sample a continuous time system
 def sample_system(sysc, Ts, method='zoh', alpha=None):
@@ -65,7 +65,7 @@ def sample_system(sysc, Ts, method='zoh', alpha=None):
     Ts : real
         Sampling period
     method : string
-        Method to use for conversion, e.g. 'matched', 'zoh' (default)
+        Method to use for conversion, e.g. 'zoh' (default)
 
     Returns
     -------
@@ -80,7 +80,7 @@ def sample_system(sysc, Ts, method='zoh', alpha=None):
     Examples
     --------
     >>> sysc = TransferFunction([1], [1, 2, 1])
-    >>> sysd = sample_system(sysc, 1, method='matched')
+    >>> sysd = sample_system(sysc, 1, method='zoh')
     """
 
     # Make sure we have a continuous time system
@@ -88,5 +88,3 @@ def sample_system(sysc, Ts, method='zoh', alpha=None):
         raise ValueError("First argument must be continuous time system")
 
     return sysc.sample(Ts, method, alpha)
-
-c2d = sample_system 

--- a/control/dtime.py
+++ b/control/dtime.py
@@ -52,7 +52,7 @@ from .statesp import StateSpace, _convertToStateSpace
 __all__ = ['sample_system', 'c2d']
 
 # Sample a continuous time system
-def sample_system(sysc, dt, method='zoh', alpha=None):
+def sample_system(sysc, Ts, method='zoh', alpha=None):
     """Convert a continuous time system to discrete time
 
     Creates a discrete time system from a continuous time system by
@@ -62,10 +62,10 @@ def sample_system(sysc, dt, method='zoh', alpha=None):
     ----------
     sysc : linsys
         Continuous time system to be converted
-    dt : real
+    Ts : real
         Sampling period
     method : string
-        Method to use for conversion, e.g. 'matched', 'tustin', 'zoh' (default)
+        Method to use for conversion, e.g. 'matched', 'zoh' (default)
 
     Returns
     -------

--- a/control/dtime.py
+++ b/control/dtime.py
@@ -46,10 +46,12 @@ $Id: dtime.py 185 2012-08-30 05:44:32Z murrayrm $
 
 """
 
+from warnings import warn
 from .lti import isctime
 from .statesp import StateSpace, _convertToStateSpace
 
-__all__ = ['sample_system']
+__all__ = ['sample_system', 'c2d']
+
 
 # Sample a continuous time system
 def sample_system(sysc, Ts, method='zoh', alpha=None):
@@ -88,3 +90,19 @@ def sample_system(sysc, Ts, method='zoh', alpha=None):
         raise ValueError("First argument must be continuous time system")
 
     return sysc.sample(Ts, method, alpha)
+
+
+def c2d(sysc, Ts, method='zoh'):
+    """(Deprecated) Return a discrete-time system; use sample_system instead"""
+    warn("The function `c2d` will be deprecated in a future release.  Use"
+         "`sample_system` (or `matlab.c2d`) instead.",
+         PendingDeprecationWarning)
+
+    #  Call the sample_system() function to do the work
+    sysd = sample_system(sysc, Ts, method)
+
+    # TODO: is this check needed?  If sysc is  StateSpace, sysd is too?
+    if isinstance(sysc, StateSpace) and not isinstance(sysd, StateSpace):
+        return _convertToStateSpace(sysd)       # pragma: no cover
+
+    return sysd

--- a/control/dtime.py
+++ b/control/dtime.py
@@ -52,7 +52,7 @@ from .statesp import StateSpace, _convertToStateSpace
 __all__ = ['sample_system', 'c2d']
 
 # Sample a continuous time system
-def sample_system(sysc, Ts, method='zoh', alpha=None):
+def sample_system(sysc, dt, method='zoh', alpha=None):
     """Convert a continuous time system to discrete time
 
     Creates a discrete time system from a continuous time system by
@@ -62,10 +62,10 @@ def sample_system(sysc, Ts, method='zoh', alpha=None):
     ----------
     sysc : linsys
         Continuous time system to be converted
-    Ts : real
+    dt : real
         Sampling period
     method : string
-        Method to use for conversion: 'matched', 'tustin', 'zoh' (default)
+        Method to use for conversion, e.g. 'matched', 'tustin', 'zoh' (default)
 
     Returns
     -------
@@ -89,32 +89,4 @@ def sample_system(sysc, Ts, method='zoh', alpha=None):
 
     return sysc.sample(Ts, method, alpha)
 
-
-def c2d(sysc, Ts, method='zoh'):
-    '''
-    Return a discrete-time system
-
-    Parameters
-    ----------
-    sysc: LTI (StateSpace or TransferFunction), continuous
-        System to be converted
-
-    Ts: number
-        Sample time for the conversion
-
-    method: string, optional
-        Method to be applied,
-        'zoh'        Zero-order hold on the inputs (default)
-        'foh'        First-order hold, currently not implemented
-        'impulse'    Impulse-invariant discretization, currently not implemented
-        'tustin'     Bilinear (Tustin) approximation, only SISO
-        'matched'    Matched pole-zero method, only SISO
-    '''
-    #  Call the sample_system() function to do the work
-    sysd = sample_system(sysc, Ts, method)
-
-    # TODO: is this check needed?  If sysc is  StateSpace, sysd is too?
-    if isinstance(sysc, StateSpace) and not isinstance(sysd, StateSpace):
-        return _convertToStateSpace(sysd)       # pragma: no cover
-
-    return sysd
+c2d = sample_system 

--- a/control/matlab/__init__.py
+++ b/control/matlab/__init__.py
@@ -80,7 +80,6 @@ from ..modelsimp import *
 from ..mateqn import *
 from ..margins import margin
 from ..rlocus import rlocus
-from ..dtime import c2d
 from ..sisotool import sisotool
 
 # Import functions specific to Matlab compatibility package

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -161,6 +161,7 @@ def dcgain(*args):
         raise ValueError("Function ``dcgain`` needs either 1, 2, 3 or 4 "
                          "arguments.")
 
+
 c2d = sample_system
 c2d.__doc__ = \
     """Convert a continuous time system to discrete time
@@ -174,7 +175,7 @@ c2d.__doc__ = \
         A linear system to be converted
     Ts : real
         Sampling period
-    method : {"gbt", "bilinear", "euler", "backward_diff", "foh", 
+    method : {"gbt", "bilinear", "euler", "backward_diff", "foh",
                 "impulse", "matched", "zoh"}
         Method to use for sampling:
 

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -5,9 +5,10 @@ Wrappers for the Matlab compatibility module
 import numpy as np
 from ..statesp import ss
 from ..xferfcn import tf
+from ..dtime import sample_system
 from scipy.signal import zpk2tf
 
-__all__ = ['bode', 'ngrid', 'dcgain']
+__all__ = ['bode', 'ngrid', 'dcgain', 'c2d']
 
 def bode(*args, **keywords):
     """bode(syslist[, omega, dB, Hz, deg, ...])
@@ -159,3 +160,59 @@ def dcgain(*args):
     else:
         raise ValueError("Function ``dcgain`` needs either 1, 2, 3 or 4 "
                          "arguments.")
+
+c2d = sample_system
+c2d.__doc__ = \
+    """Convert a continuous time system to discrete time
+
+    Creates a discrete time system from a continuous time system by
+    sampling.  Multiple methods of conversion are supported.
+
+    Parameters
+    ----------
+    sysc : LTI (StateSpace or TransferFunction)
+        A linear system to be converted
+    Ts : real
+        Sampling period
+    method : {"gbt", "bilinear", "euler", "backward_diff", "foh", 
+                "impulse", "matched", "zoh"}
+        Method to use for sampling:
+
+        * gbt: generalized bilinear transformation
+        * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
+        * euler: Euler (or forward difference) method ("gbt" with alpha=0)
+        * backward_diff: Backwards difference ("gbt" with alpha=1.0)
+        * foh: first-order hold
+        * impulse: equivalent impulse response
+        * matched: pole-zero matched
+        * zoh: zero-order hold (default)
+
+    alpha : float within [0, 1], optional
+        The generalized bilinear transformation weighting parameter, which
+        should only be specified with method="gbt", and is ignored
+        otherwise.
+
+    Returns
+    -------
+    sysd : LTI (TransferFunction or StateSpace) system
+        Discrete time system, with sampling rate Ts
+
+    Notes
+    -----
+    1. if system is a TransferFunction, only available for SISO
+
+    2. 'matched' is only available for TransferFunction systems
+
+    3. Uses the command `cont2discrete` from `scipy.signal`
+
+
+    Returns
+    -------
+    sysd : LTI (StateSpace or TransferFunction)
+        A discrete time linear system with sampling rate Ts
+
+    Examples
+    --------
+    >>> sysc = tf([1], [1, 2, 1])
+    >>> sysd = c2d(sysc, 1, method='zoh')
+    """

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -851,17 +851,19 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
         ----------
         Ts : float
             Sampling period
-        method :  {"gbt", "bilinear", "euler", "backward_diff", "zoh"}
-            Which method to use:
+        method : {"gbt", "bilinear", "euler", "backward_diff", "foh", 
+                  "impulse", zoh"}
+            Method to use for sampling:
 
             * gbt: generalized bilinear transformation
             * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
-            * euler: Euler (or forward differencing) method ("gbt" with
-              alpha=0)
-            * backward_diff: Backwards differencing ("gbt" with alpha=1.0)
+            * euler: Euler (or forward difference) method ("gbt" with alpha=0)
+            * backward_diff: Backwards difference ("gbt" with alpha=1.0)
+            * foh: first-order hold
+            * impulse: equivalent impulse response
             * zoh: zero-order hold (default)
-
-        alpha : float within [0, 1]
+        
+        alpha : float within [0, 1], optional
             The generalized bilinear transformation weighting parameter, which
             should only be specified with method="gbt", and is ignored
             otherwise
@@ -873,7 +875,7 @@ but B has %i row(s)\n(output(s))." % (self.inputs, other.outputs))
 
         Notes
         -----
-        Uses the command 'cont2discrete' from scipy.signal
+        Uses the command 'cont2discrete' from `scipy.signal`
 
         Examples
         --------

--- a/control/tests/discrete_test.py
+++ b/control/tests/discrete_test.py
@@ -384,6 +384,15 @@ class TestDiscrete(unittest.TestCase):
         np.testing.assert_array_almost_equal(mag_out, np.absolute(H_z))
         np.testing.assert_array_almost_equal(phase_out, np.angle(H_z))
 
+    def test_c2d_deprecated(self):
+        from control import c2d
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            c2d(self.siso_ss1, 1)
+            assert issubclass(w[0].category, PendingDeprecationWarning)
+            assert "c2d" in str(w[0].message)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1013,7 +1013,7 @@ class TransferFunction(LTI):
         if method == "matched":
             return _c2d_matched(self, Ts)
         sys = (self.num[0][0], self.den[0][0])
-        numd, dend, dt2 = cont2discrete(sys, Ts, method, alpha)
+        numd, dend, _ = cont2discrete(sys, Ts, method, alpha)
         return TransferFunction(numd[0, :], dend, Ts)
 
     def dcgain(self):

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -971,24 +971,27 @@ class TransferFunction(LTI):
         ----------
         Ts : float
             Sampling period
-        method : {"gbt", "bilinear", "euler", "backward_diff",
-                  "zoh", "matched"}
+        method : {"gbt", "bilinear", "euler", "backward_diff", "foh", 
+                  "impulse", "matched", "zoh"}
             Method to use for sampling:
 
             * gbt: generalized bilinear transformation
             * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
             * euler: Euler (or forward difference) method ("gbt" with alpha=0)
             * backward_diff: Backwards difference ("gbt" with alpha=1.0)
+            * foh: first-order hold
+            * impulse: equivalent impulse response
+            * matched: pole-zero matched
             * zoh: zero-order hold (default)
 
-        alpha : float within [0, 1]
+        alpha : float within [0, 1], optional
             The generalized bilinear transformation weighting parameter, which
             should only be specified with method="gbt", and is ignored
             otherwise.
 
         Returns
         -------
-        sysd : StateSpace system
+        sysd : TransferFunction system
             Discrete time system, with sampling rate Ts
 
         Notes
@@ -1010,8 +1013,8 @@ class TransferFunction(LTI):
         if method == "matched":
             return _c2d_matched(self, Ts)
         sys = (self.num[0][0], self.den[0][0])
-        numd, dend, dt = cont2discrete(sys, Ts, method, alpha)
-        return TransferFunction(numd[0, :], dend, dt)
+        numd, dend, dt2 = cont2discrete(sys, Ts, method, alpha)
+        return TransferFunction(numd[0, :], dend, Ts)
 
     def dcgain(self):
         """Return the zero-frequency (or DC) gain


### PR DESCRIPTION
This PR replaces #403.

From sawyerbfuller:

* combined dtime/sample_system and dtime/c2d into the same function because they do the same thing. old c2d also had an unnecessary test

* fixed TransferFunction.sample and StateSpace.sample to have updated docstring that adds recent methods added to scipy.signal.cont2discrete (except for 'matched', which is only available for TransferFunction and only for python-control)

Additional modifications (murrayrm):

* Added `c2d` back into `dtime.py` with a `PendingDeprecationWarning` to fix unit tests.

* Fixed up a few PEP8 problem along the way

