### PR TITLE
changes to rlocus to be compatible with discrete-time systems

### DIFF
--- a/control/grid.py
+++ b/control/grid.py
@@ -136,11 +136,12 @@ def nogrid():
     return ax, f
 
 
-def zgrid(zetas=None, wns=None):
+def zgrid(zetas=None, wns=None, ax=None):
     '''Draws discrete damping and frequency grid'''
 
     fig = plt.gcf()
-    ax = fig.gca()
+    if ax is None:
+        ax = fig.gca()
 
     # Constant damping lines
     if zetas is None:
@@ -154,11 +155,11 @@ def zgrid(zetas=None, wns=None):
         # Draw upper part in retangular coordinates
         xret = mag*cos(ang)
         yret = mag*sin(ang)
-        ax.plot(xret, yret, 'k:', lw=1)
+        ax.plot(xret, yret, ':', color='grey', lw=0.75)
         # Draw lower part in retangular coordinates
         xret = mag*cos(-ang)
         yret = mag*sin(-ang)
-        ax.plot(xret, yret, 'k:', lw=1)
+        ax.plot(xret, yret, ':', color='grey', lw=0.75)
         # Annotation
         an_i = int(len(xret)/2.5)
         an_x = xret[an_i]
@@ -177,7 +178,7 @@ def zgrid(zetas=None, wns=None):
         # Draw in retangular coordinates
         xret = mag*cos(ang)
         yret = mag*sin(ang)
-        ax.plot(xret, yret, 'k:', lw=1)
+        ax.plot(xret, yret, ':', color='grey', lw=0.75)
         # Annotation
         an_i = -1
         an_x = xret[an_i]

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -2,7 +2,7 @@ __all__ = ['sisotool']
 
 from .freqplot import bode_plot
 from .timeresp import step_response
-from .lti import issiso
+from .lti import issiso, isdtime
 import matplotlib
 import matplotlib.pyplot as plt
 import warnings
@@ -139,7 +139,10 @@ def _SisotoolUpdate(sys,fig,K,bode_plot_params,tvect=None):
         tvect, yout = step_response(sys_closed, T_num=100)
     else:
         tvect, yout = step_response(sys_closed,tvect)
-    ax_step.plot(tvect, yout)
+    if isdtime(sys_closed, strict=True):
+        ax_step.plot(tvect, yout, 'o')
+    else:
+        ax_step.plot(tvect, yout)
     ax_step.axhline(1.,linestyle=':',color='k',zorder=-20)
 
     # Manually adjust the spacing and draw the canvas

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -117,6 +117,7 @@ Control system synthesis
     h2syn
     hinfsyn
     lqr
+    lqe
     mixsyn
     place
 


### PR DESCRIPTION
* give correct z-plane damping ratio on mouse click 
* auto zoom into unit circle
* show zgrid with lines of constant damping ratio and natural frequency if desired
* sisotool now plots dots instead of a continuous line for discrete-time systems 
* fixed spelling of variables in a couple of places
