### PR TITLE
pytest: do not ignore warnings but filter matrix and scipy deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ install:
 # command to run tests
 script:
   - 'if [ $SLYCOT != "" ]; then python -c "import slycot"; fi'
-  - coverage run -m pytest --disable-warnings control/tests
+  - coverage run -m pytest control/tests
 
   # only run examples if Slycot is install
   # set PYTHONPATH for examples

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+filterwarnings =
+    ignore:.*matrix subclass:PendingDeprecationWarning
+    ignore:.*scipy:DeprecationWarning
+


### PR DESCRIPTION
Reenable warnings but filter out the expected numpy matrix and scipy deprecations (follow up to https://github.com/python-control/python-control/pull/380#discussion_r396036776)