### PR TITLE
print(sys) / str(sys) for StateSpace and TransferFunction

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -267,18 +267,18 @@ class StateSpace(LTI):
         self.outputs = self.C.shape[0]
 
     def __str__(self):
-        """String representation of the state space."""
-
-        str = "A = " + self.A.__str__() + "\n\n"
-        str += "B = " + self.B.__str__() + "\n\n"
-        str += "C = " + self.C.__str__() + "\n\n"
-        str += "D = " + self.D.__str__() + "\n"
+        """Return string representation of the state space system."""
+        string = "\n".join([
+            "{} = {}\n".format(Mvar,
+                               "\n    ".join(str(M).splitlines()))
+            for Mvar, M in zip(["A", "B", "C", "D"],
+                               [self.A, self.B, self.C, self.D])])
         # TODO: replace with standard calls to lti functions
         if (type(self.dt) == bool and self.dt is True):
-            str += "\ndt unspecified\n"
+            string += "\ndt unspecified\n"
         elif (not (self.dt is None) and type(self.dt) != bool and self.dt > 0):
-            str += "\ndt = " + self.dt.__str__() + "\n"
-        return str
+            string += "\ndt = " + self.dt.__str__() + "\n"
+        return string
 
     # represent as string, makes display work for IPython
     __repr__ = __str__

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -519,6 +519,29 @@ class TestStateSpace(unittest.TestCase):
         np.testing.assert_allclose(np.array(pk.C).reshape(-1), Cmatlab)
         np.testing.assert_allclose(np.array(pk.D).reshape(-1), Dmatlab)
 
+    def test_str(self):
+        """Test that printing the system works"""
+        tsys = self.sys322
+        tref = ("A = [[-3.  4.  2.]\n"
+                "     [-1. -3.  0.]\n"
+                "     [ 2.  5.  3.]]\n"
+                "\n"
+                "B = [[ 1.  4.]\n"
+                "     [-3. -3.]\n"
+                "     [-2.  1.]]\n"
+                "\n"
+                "C = [[ 4.  2. -3.]\n"
+                "     [ 1.  4.  3.]]\n"
+                "\n"
+                "D = [[-2.  4.]\n"
+                "     [ 0.  1.]]\n")
+        assert str(tsys) == tref
+        tsysdtunspec = StateSpace(tsys.A, tsys.B, tsys.C, tsys.D, True)
+        assert str(tsysdtunspec) == tref + "\ndt unspecified\n"
+        sysdt1 = StateSpace(tsys.A, tsys.B, tsys.C, tsys.D, 1.)
+        assert str(sysdt1) == tref + "\ndt = 1.0\n"
+
+
 class TestRss(unittest.TestCase):
     """These are tests for the proper functionality of statesp.rss."""
 

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -819,9 +819,11 @@ class TestXferFcn(unittest.TestCase):
                                      [None, True, 1],
                                      ['', '', '\ndt = 1\n']):
             assert str(TransferFunction([1, 0], [2, 1], dt)) == \
-                f"\n   {var}\n-------\n2 {var} + 1\n{dtstring}"
+                "\n   {var}\n-------\n2 {var} + 1\n{dtstring}".format(
+                    var=var, dtstring=dtstring)
             assert str(TransferFunction([2, 0, -1], [1, 0, 0, 1.2], dt)) == \
-                f"\n2 {var}^2 - 1\n---------\n{var}^3 + 1.2\n{dtstring}"
+                "\n2 {var}^2 - 1\n---------\n{var}^3 + 1.2\n{dtstring}".format(
+                    var=var, dtstring=dtstring)
 
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def test_printing_mimo(self):

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -806,6 +806,23 @@ class TestXferFcn(unittest.TestCase):
         self.assertTrue(isinstance(str(sys), str))
         self.assertTrue(isinstance(sys._repr_latex_(), str))
 
+    def test_printing_polynomial(self):
+        """Cover all _tf_polynomial_to_string code branches"""
+        # Note: the assertions below use plain assert statements instead of
+        # unittest methods so that debugging with pytest is easier
+
+        assert str(TransferFunction([0], [1])) == "\n0\n-\n1\n"
+        assert str(TransferFunction([1.0001], [-1.1111])) == \
+            "\n  1\n------\n-1.111\n"
+        assert str(TransferFunction([0, 1], [0, 1.])) == "\n1\n-\n1\n"
+        for var, dt, dtstring in zip(["s", "z", "z"],
+                                     [None, True, 1],
+                                     ['', '', '\ndt = 1\n']):
+            assert str(TransferFunction([1, 0], [2, 1], dt)) == \
+                f"\n   {var}\n-------\n2 {var} + 1\n{dtstring}"
+            assert str(TransferFunction([2, 0, -1], [1, 0, 0, 1.2], dt)) == \
+                f"\n2 {var}^2 - 1\n---------\n{var}^3 + 1.2\n{dtstring}"
+
     @unittest.skipIf(not slycot_check(), "slycot not installed")
     def test_printing_mimo(self):
         # MIMO, continuous time

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -264,11 +264,9 @@ class TransferFunction(LTI):
 
                 # Center the numerator or denominator
                 if len(numstr) < dashcount:
-                    numstr = (' ' * int(round((dashcount - len(numstr)) / 2)) +
-                              numstr)
+                    numstr = ' ' * ((dashcount - len(numstr)) // 2) + numstr
                 if len(denstr) < dashcount:
-                    denstr = (' ' * int(round((dashcount - len(denstr)) / 2)) +
-                              denstr)
+                    denstr = ' ' * ((dashcount - len(denstr)) // 2) + denstr
 
                 outstr += "\n" + numstr + "\n" + dashes + "\n" + denstr + "\n"
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1087,8 +1087,6 @@ def _tf_polynomial_to_string(coeffs, var='s'):
 
     for k in range(len(coeffs)):
         coefstr = '%.4g' % abs(coeffs[k])
-        if coefstr[-4:] == '0000':
-            coefstr = coefstr[:-5]
         power = (N - k)
         if power == 0:
             if coefstr != '0':


### PR DESCRIPTION
PR #425 removes the coverage of some code due to not printing into the void during unit tests. So here are some new tests for the  `.__str__()` methods of the `StateSpace` and `TransferFunction` objects. `FrequencyResponseData` seems to be covered by #416.

I also fixed the indentation for the state space matrices and removed some obsolete check for trailing `0000` that would never be produced by the general format `%.4g`.