### PR TITLE
Default dt is 0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": "${workspaceFolder}/doc"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": "${workspaceFolder}/doc"
-}

--- a/control/config.py
+++ b/control/config.py
@@ -59,6 +59,9 @@ def reset_defaults():
     from .statesp import _statesp_defaults
     defaults.update(_statesp_defaults)
 
+    from .iosys import _iosys_defaults
+    defaults.update(_iosys_defaults)
+
 
 def _get_param(module, param, argval=None, defval=None, pop=False):
     """Return the default value for a configuration option.
@@ -170,5 +173,8 @@ def use_legacy_defaults(version):
     """
     if version == '0.8.3': 
         use_numpy_matrix(True) # alternatively: set_defaults('statesp', use_numpy_matrix=True)
+        set_defaults('statesp', default_dt=None)
+        set_defaults('xferfcn', default_dt=None)
+        set_defaults('iosys', default_dt=None)
     else:
         raise ValueError('''version number not recognized. Possible values are: ['0.8.3']''') 

--- a/control/config.py
+++ b/control/config.py
@@ -15,7 +15,7 @@ __all__ = ['defaults', 'set_defaults', 'reset_defaults',
 
 # Package level default values
 _control_defaults = {
-    # No package level defaults (yet)
+    'control.default_dt':0
 }
 defaults = dict(_control_defaults)
 
@@ -173,8 +173,6 @@ def use_legacy_defaults(version):
     """
     if version == '0.8.3': 
         use_numpy_matrix(True) # alternatively: set_defaults('statesp', use_numpy_matrix=True)
-        set_defaults('statesp', default_dt=None)
-        set_defaults('xferfcn', default_dt=None)
-        set_defaults('iosys', default_dt=None)
+        set_defaults('control', default_dt=None)
     else:
         raise ValueError('''version number not recognized. Possible values are: ['0.8.3']''') 

--- a/control/dtime.py
+++ b/control/dtime.py
@@ -53,21 +53,19 @@ __all__ = ['sample_system', 'c2d']
 
 # Sample a continuous time system
 def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None):
-    """Convert a continuous time system to discrete time
-
-    Creates a discrete time system from a continuous time system by
-    sampling.  Multiple methods of conversion are supported.
+    """
+    Convert a continuous time system to discrete time by sampling
 
     Parameters
     ----------
-    sysc : linsys
+    sysc : LTI (StateSpace or TransferFunction)
         Continuous time system to be converted
-    Ts : real
+    Ts : real > 0
         Sampling period
     method : string
-        Method to use for conversion: 'matched', 'tustin', 'zoh' (default)
+        Method to use for conversion, e.g. 'bilinear', 'zoh' (default)
 
-    prewarp_frequency : float within [0, infinity)
+    prewarp_frequency : real within [0, infinity)
         The frequency [rad/s] at which to match with the input continuous-
         time system's magnitude and phase
 
@@ -78,13 +76,13 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None):
 
     Notes
     -----
-    See `TransferFunction.sample` and `StateSpace.sample` for
+    See :meth:`StateSpace.sample` or :meth:`TransferFunction.sample`` for
     further details.
 
     Examples
     --------
     >>> sysc = TransferFunction([1], [1, 2, 1])
-    >>> sysd = sample_system(sysc, 1, method='matched')
+    >>> sysd = sample_system(sysc, 1, method='bilinear')
     """
 
     # Make sure we have a continuous time system
@@ -95,35 +93,39 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None):
 
 
 def c2d(sysc, Ts, method='zoh', prewarp_frequency=None):
-    '''
-    Return a discrete-time system
+    """
+    Convert a continuous time system to discrete time by sampling
 
     Parameters
     ----------
-    sysc: LTI (StateSpace or TransferFunction), continuous
-        System to be converted
+    sysc : LTI (StateSpace or TransferFunction)
+        Continuous time system to be converted
+    Ts : real > 0
+        Sampling period
+    method : string
+        Method to use for conversion, e.g. 'bilinear', 'zoh' (default)
 
-    Ts: number
-        Sample time for the conversion
+    prewarp_frequency : real within [0, infinity)
+        The frequency [rad/s] at which to match with the input continuous-
+        time system's magnitude and phase
 
-    method: string, optional
-        Method to be applied,
-        'zoh'        Zero-order hold on the inputs (default)
-        'foh'        First-order hold, currently not implemented
-        'impulse'    Impulse-invariant discretization, currently not implemented
-        'tustin'     Bilinear (Tustin) approximation, only SISO
-        'matched'    Matched pole-zero method, only SISO
+    Returns
+    -------
+    sysd : linsys
+        Discrete time system, with sampling rate Ts
 
-    prewarp_frequency : float within [0, infinity)
-            The frequency [rad/s] at which to match with the input continuous-
-            time system's magnitude and phase
+    Notes
+    -----
+    See :meth:`StateSpace.sample` or :meth:`TransferFunction.sample`` for
+    further details.
 
-    '''
+    Examples
+    --------
+    >>> sysc = TransferFunction([1], [1, 2, 1])
+    >>> sysd = sample_system(sysc, 1, method='bilinear')
+    """
+
     #  Call the sample_system() function to do the work
     sysd = sample_system(sysc, Ts, method, prewarp_frequency)
-
-    # TODO: is this check needed?  If sysc is  StateSpace, sysd is too?
-    if isinstance(sysc, StateSpace) and not isinstance(sysd, StateSpace):
-        return _convertToStateSpace(sysd)       # pragma: no cover
 
     return sysd

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -72,9 +72,11 @@ class InputOutputSystem(object):
     states : int, list of str, or None
         Description of the system states.  Same format as `inputs`.
     dt : None, True or float, optional
-        System timebase.  None (default) indicates continuous time, True
-        indicates discrete time with undefined sampling time, positive number
-        is discrete time with specified sampling time.
+        System timebase. 0 (default) indicates continuous
+        time, True indicates discrete time with unspecified sampling
+        time, positive number is discrete time with specified
+        sampling time, None indicates unspecified timebase (either  
+        continuous or discrete time).
     params : dict, optional
         Parameter values for the systems.  Passed to the evaluation functions
         for the system as default values, overriding internal defaults.
@@ -89,9 +91,11 @@ class InputOutputSystem(object):
         Dictionary of signal names for the inputs, outputs and states and the
         index of the corresponding array
     dt : None, True or float
-        System timebase.  None (default) indicates continuous time, True
-        indicates discrete time with undefined sampling time, positive number
-        is discrete time with specified sampling time.
+        System timebase. 0 (default) indicates continuous
+        time, True indicates discrete time with unspecified sampling
+        time, positive number is discrete time with specified
+        sampling time, None indicates unspecified timebase (either  
+        continuous or discrete time).
     params : dict, optional
         Parameter values for the systems.  Passed to the evaluation functions
         for the system as default values, overriding internal defaults.
@@ -137,10 +141,11 @@ class InputOutputSystem(object):
         states : int, list of str, or None
             Description of the system states.  Same format as `inputs`.
         dt : None, True or float, optional
-            System timebase.  None (default) indicates continuous
-            time, True indicates discrete time with undefined sampling
+            System timebase. 0 (default) indicates continuous
+            time, True indicates discrete time with unspecified sampling
             time, positive number is discrete time with specified
-            sampling time.
+            sampling time, None indicates unspecified timebase (either  
+            continuous or discrete time).
         params : dict, optional
             Parameter values for the systems.  Passed to the evaluation
             functions for the system as default values, overriding internal
@@ -600,10 +605,11 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
         states : int, list of str, or None, optional
             Description of the system states.  Same format as `inputs`.
         dt : None, True or float, optional
-            System timebase.  None (default) indicates continuous
-            time, True indicates discrete time with undefined sampling
+            System timebase. 0 (default) indicates continuous
+            time, True indicates discrete time with unspecified sampling
             time, positive number is discrete time with specified
-            sampling time.
+            sampling time, None indicates unspecified timebase (either  
+            continuous or discrete time).
         params : dict, optional
             Parameter values for the systems.  Passed to the evaluation
             functions for the system as default values, overriding internal
@@ -722,10 +728,10 @@ class NonlinearIOSystem(InputOutputSystem):
             operating in continuous or discrete time.  It can have the
             following values:
 
-            * dt = None       No timebase specified
-            * dt = 0          Continuous time system
-            * dt > 0          Discrete time system with sampling time dt
-            * dt = True       Discrete time with unspecified sampling time
+            * dt = 0: continuous time system (default)
+            * dt > 0: discrete time system with sampling period 'dt'
+            * dt = True: discrete time with unspecified sampling period
+            * dt = None: no timebase specified 
 
         name : string, optional
             System name (used for specifying signals).
@@ -866,10 +872,10 @@ class InterconnectedSystem(InputOutputSystem):
             operating in continuous or discrete time.  It can have the
             following values:
 
-            * dt = None       No timebase specified
-            * dt = 0          Continuous time system
-            * dt > 0          Discrete time system with sampling time dt
-            * dt = True       Discrete time with unspecified sampling time
+            * dt = 0: continuous time system (default)
+            * dt > 0: discrete time system with sampling period 'dt'
+            * dt = True: discrete time with unspecified sampling period
+            * dt = None: no timebase specified 
 
         name : string, optional
             System name (used for specifying signals).

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -46,8 +46,7 @@ __all__ = ['InputOutputSystem', 'LinearIOSystem', 'NonlinearIOSystem',
            'linearize', 'ss2io', 'tf2io']
 
 # Define module default parameter values
-_iosys_defaults = {
-    'iosys.default_dt': 0}
+_iosys_defaults = {}
 
 class InputOutputSystem(object):
     """A class for representing input/output systems.
@@ -157,7 +156,7 @@ class InputOutputSystem(object):
         """
         # Store the input arguments
         self.params = params.copy()     # default parameters
-        self.dt = kwargs.get('dt', config.defaults['iosys.default_dt'])                    # timebase
+        self.dt = kwargs.get('dt', config.defaults['control.default_dt'])                    # timebase
         self.name = name                # system name
 
         # Parse and store the number of inputs, outputs, and states
@@ -742,7 +741,7 @@ class NonlinearIOSystem(InputOutputSystem):
         self.outfcn = outfcn
 
         # Initialize the rest of the structure
-        dt = kwargs.get('dt', config.defaults['iosys.default_dt'])
+        dt = kwargs.get('dt', config.defaults['control.default_dt'])
         super(NonlinearIOSystem, self).__init__(
             inputs=inputs, outputs=outputs, states=states,
             params=params, dt=dt, name=name

--- a/control/lti.py
+++ b/control/lti.py
@@ -14,9 +14,11 @@ common_timebase()
 
 import numpy as np
 from numpy import absolute, real
+from warnings import warn
 
-__all__ = ['issiso', 'timebase', 'common_timebase', 'isdtime', 'isctime',
-           'pole', 'zero', 'damp', 'evalfr', 'freqresp', 'dcgain']
+__all__ = ['issiso', 'timebase', 'common_timebase', 'timebaseEqual', 
+           'isdtime', 'isctime', 'pole', 'zero', 'damp', 'evalfr', 
+           'freqresp', 'dcgain']
 
 class LTI:
     """LTI is a parent class to linear time-invariant (LTI) system objects.
@@ -158,12 +160,35 @@ def timebase(sys, strict=True):
     return sys.dt
 
 def common_timebase(dt1, dt2):
-    """Find the common timebase when interconnecting systems."""
-    # cases: 
+    """
+    Find the common timebase when interconnecting systems
+    
+    Parameters
+    ----------
+    dt1, dt2: number or system with a 'dt' attribute (e.g. TransferFunction 
+        or StateSpace system)
+
+    Returns
+    -------
+    dt: number
+        The common timebase of dt1 and dt2, as specified in 
+        :ref:`conventions-ref`. 
+        
+    Raises
+    ------
+    ValueError
+        when no compatible time base can be found
+    """
+    # explanation: 
     # if either dt is None, they are compatible with anything
     # if either dt is True (discrete with unspecified time base), 
     #   use the timebase of the other, if it is also discrete
-    # otherwise they must be equal (holds for both cont and discrete systems)
+    # otherwise both dts must be equal 
+    if hasattr(dt1, 'dt'):
+        dt1 = dt1.dt
+    if hasattr(dt2, 'dt'):
+        dt2 = dt2.dt
+
     if dt1 is None: 
         return dt2
     elif dt2 is None: 
@@ -182,6 +207,32 @@ def common_timebase(dt1, dt2):
         return dt1
     else: 
         raise ValueError("Systems have incompatible timebases")
+
+# Check to see if two timebases are equal
+def timebaseEqual(sys1, sys2):
+    """
+    Check to see if two systems have the same timebase
+
+    timebaseEqual(sys1, sys2)
+
+    returns True if the timebases for the two systems are compatible.  By
+    default, systems with timebase 'None' are compatible with either
+    discrete or continuous timebase systems.  If two systems have a discrete
+    timebase (dt > 0) then their timebases must be equal.
+    """
+    warn("timebaseEqual will be deprecated in a future release of "
+         "python-control; use :func:`common_timebase` instead", 
+         PendingDeprecationWarning)
+        
+    if (type(sys1.dt) == bool or type(sys2.dt) == bool):
+        # Make sure both are unspecified discrete timebases
+        return type(sys1.dt) == type(sys2.dt) and sys1.dt == sys2.dt
+    elif (sys1.dt is None or sys2.dt is None):
+        # One or the other is unspecified => the other can be anything
+        return True
+    else:
+        return sys1.dt == sys2.dt
+
 
 # Check to see if a system is a discrete time system
 def isdtime(sys, strict=False):

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -142,15 +142,22 @@ class StateSpace(LTI):
     `numpy.ndarray` objects.  The :func:`~control.use_numpy_matrix` function
     can be used to set the storage type.
 
-    Discrete-time state space system are implemented by using the 'dt'
-    instance variable and setting it to the sampling period.  If 'dt' is not
-    None, then it must match whenever two state space systems are combined.
-    Setting dt = 0 specifies a continuous system, while leaving dt = None
-    means the system timebase is not specified.  If 'dt' is set to True, the
-    system will be treated as a discrete time system with unspecified sampling
-    time. The default value of 'dt' is None and can be changed by changing the 
-    value of ``control.config.defaults['control.default_dt']``.
+    A discrete time system is created by specifying a nonzero 'timebase', dt 
+    when the system is constructed:
 
+    * dt = 0: continuous time system (default)
+    * dt > 0: discrete time system with sampling period 'dt'
+    * dt = True: discrete time with unspecified sampling period
+    * dt = None: no timebase specified 
+
+    Systems must have compatible timebases in order to be combined. A discrete 
+    time system with unspecified sampling time (`dt = True`) can be combined 
+    with a system having a specified sampling time; the result will be a 
+    discrete time system with the sample time of the latter system. Similarly, 
+    a system with timebase `None` can be combined with a system having any 
+    timebase; the result will have the timebase of the latter system. 
+    The default value of dt can be changed by changing the value of 
+    ``control.config.defaults['control.default_dt']``.
     """
 
     # Allow ndarray * StateSpace to give StateSpace._rmul_() priority
@@ -1270,8 +1277,7 @@ def ss(*args):
         Output matrix
     D: array_like or string
         Feed forward matrix
-    dt: If present, specifies the sampling period and a discrete time
-        system is created
+    dt: If present, specifies the timebase of the system
 
     Returns
     -------

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -71,7 +71,7 @@ __all__ = ['StateSpace', 'ss', 'rss', 'drss', 'tf2ss', 'ssdata']
 # Define module default parameter values
 _statesp_defaults = {
     'statesp.use_numpy_matrix': True,
-    'statesp.default_dt': None,
+    'statesp.default_dt': 0,
     'statesp.remove_useless_states': True, 
     }
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -226,7 +226,7 @@ class StateSpace(LTI):
         elif len(args) == 5:
             dt = args[4]
             if 'dt' in kwargs:
-                warn('received multiple dt arguments, using positional arg'%dt)
+                warn('received multiple dt arguments, using positional arg dt=%s'%dt)
         elif len(args) == 1:
             try:
                 dt = args[0].dt
@@ -1243,7 +1243,7 @@ def _mimo2simo(sys, input, warn_conversion=False):
 
     return sys
 
-def ss(*args):
+def ss(*args, **kwargs):
     """ss(A, B, C, D[, dt])
 
     Create a state space system.
@@ -1319,7 +1319,7 @@ def ss(*args):
     """
 
     if len(args) == 4 or len(args) == 5:
-        return StateSpace(*args)
+        return StateSpace(*args, **kwargs)
     elif len(args) == 1:
         from .xferfcn import TransferFunction
         sys = args[0]
@@ -1331,7 +1331,7 @@ def ss(*args):
             raise TypeError("ss(sys): sys must be a StateSpace or \
 TransferFunction object.  It is %s." % type(sys))
     else:
-        raise ValueError("Needs 1 or 4 arguments; received %i." % len(args))
+        raise ValueError("Needs 1, 4, or 5 arguments; received %i." % len(args))
 
 
 def tf2ss(*args):

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -164,7 +164,7 @@ class StateSpace(LTI):
     __array_priority__ = 11     # override ndarray and matrix types
 
 
-    def __init__(self, *args, **kw):
+    def __init__(self, *args, **kwargs):
         """
         StateSpace(A, B, C, D[, dt])
 
@@ -177,16 +177,13 @@ class StateSpace(LTI):
         call StateSpace(sys), where sys is a StateSpace object.
 
         """
+        # first get A, B, C, D matrices
         if len(args) == 4:
             # The user provided A, B, C, and D matrices.
             (A, B, C, D) = args
-            if _isstaticgain(A, B, C, D): 
-                dt = None
-            else:
-                dt = config.defaults['control.default_dt']
         elif len(args) == 5:
             # Discrete time system
-            (A, B, C, D, dt) = args
+            (A, B, C, D, _) = args
         elif len(args) == 1:
             # Use the copy constructor.
             if not isinstance(args[0], StateSpace):
@@ -196,18 +193,11 @@ class StateSpace(LTI):
             B = args[0].B
             C = args[0].C
             D = args[0].D
-            try:
-                dt = args[0].dt
-            except NameError:
-                if _isstaticgain(A, B, C, D): 
-                    dt = None
-                else:
-                    dt = config.defaults['control.default_dt']
         else:
             raise ValueError("Expected 1, 4, or 5 arguments; received %i." % len(args))
 
         # Process keyword arguments
-        remove_useless = kw.get('remove_useless', config.defaults['statesp.remove_useless_states'])
+        remove_useless = kwargs.get('remove_useless', config.defaults['statesp.remove_useless_states'])
 
         # Convert all matrices to standard form
         A = _ssmatrix(A)
@@ -219,12 +209,33 @@ class StateSpace(LTI):
         D = _ssmatrix(D)
 
         # TODO: use super here?
-        LTI.__init__(self, inputs=D.shape[1], outputs=D.shape[0], dt=dt)
+        LTI.__init__(self, inputs=D.shape[1], outputs=D.shape[0])
         self.A = A
         self.B = B
         self.C = C
         self.D = D
 
+        # now set dt
+        if len(args) == 4: 
+            if 'dt' in kwargs:
+                dt = kwargs['dt']
+            elif self.is_static_gain(): 
+                dt = None
+            else:
+                dt = config.defaults['control.default_dt']
+        elif len(args) == 5:
+            dt = args[4]
+            if 'dt' in kwargs:
+                warn('received multiple dt arguments, using positional arg'%dt)
+        elif len(args) == 1:
+            try:
+                dt = args[0].dt
+            except NameError:
+                if self.is_static_gain(): 
+                    dt = None
+                else:
+                    dt = config.defaults['control.default_dt']
+        self.dt = dt
         self.states = A.shape[1]
 
         if 0 == self.states:
@@ -909,6 +920,12 @@ class StateSpace(LTI):
             # eigenvalue at DC
             gain = np.tile(np.nan, (self.outputs, self.inputs))
         return np.squeeze(gain)
+    
+    def is_static_gain(self):
+        """True if and only if the system has no dynamics, that is, 
+        if A and B are zero. """
+        return not np.any(self.A) and not np.any(self.B)
+
 
 
 # TODO: add discrete time check
@@ -1225,12 +1242,6 @@ def _mimo2simo(sys, input, warn_conversion=False):
         sys = StateSpace(sys.A, new_B, sys.C, new_D, sys.dt)
 
     return sys
-
-def _isstaticgain(A, B, C, D):
-    """returns True if and only if the system has no dynamics, that is, 
-    if A and B are zero. """
-    return not np.any(np.matrix(A, dtype=float)) \
-        and not np.any(np.matrix(B, dtype=float))
 
 def ss(*args):
     """ss(A, B, C, D[, dt])

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -71,7 +71,6 @@ __all__ = ['StateSpace', 'ss', 'rss', 'drss', 'tf2ss', 'ssdata']
 # Define module default parameter values
 _statesp_defaults = {
     'statesp.use_numpy_matrix': True,
-    'statesp.default_dt': 0,
     'statesp.remove_useless_states': True, 
     }
 
@@ -150,7 +149,7 @@ class StateSpace(LTI):
     means the system timebase is not specified.  If 'dt' is set to True, the
     system will be treated as a discrete time system with unspecified sampling
     time. The default value of 'dt' is None and can be changed by changing the 
-    value of ``control.config.defaults['statesp.default_dt']``.
+    value of ``control.config.defaults['control.default_dt']``.
 
     """
 
@@ -177,7 +176,7 @@ class StateSpace(LTI):
             if _isstaticgain(A, B, C, D): 
                 dt = None
             else:
-                dt = config.defaults['statesp.default_dt']
+                dt = config.defaults['control.default_dt']
         elif len(args) == 5:
             # Discrete time system
             (A, B, C, D, dt) = args
@@ -196,7 +195,7 @@ class StateSpace(LTI):
                 if _isstaticgain(A, B, C, D): 
                     dt = None
                 else:
-                    dt = config.defaults['statesp.default_dt']
+                    dt = config.defaults['control.default_dt']
         else:
             raise ValueError("Expected 1, 4, or 5 arguments; received %i." % len(args))
 

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -218,29 +218,28 @@ class TestConfig(unittest.TestCase):
         assert(isinstance(ct.ss(0,0,0,1).D, np.ndarray))
     
     def test_change_default_dt(self):
-        # TransferFunction
         # test that system with dynamics uses correct default dt
-        ct.set_defaults('xferfcn', default_dt=0)
+        ct.set_defaults('control', default_dt=0)
         self.assertEqual(ct.tf(1, [1,1]).dt, 0)
-        ct.set_defaults('xferfcn', default_dt=None)
-        self.assertEqual(ct.tf(1, [1,1]).dt, None)
-        # test that a static gain transfer function always has dt=None
-        ct.set_defaults('xferfcn', default_dt=0)
-        self.assertEqual(ct.tf(1, 1).dt, None)
-
-        # StateSpace
-        # test that system with dynamics uses correct default dt
-        ct.set_defaults('statesp', default_dt=0)
         self.assertEqual(ct.ss(1,0,0,1).dt, 0)
-        ct.set_defaults('statesp', default_dt=None)
+        self.assertEqual(ct.iosys.NonlinearIOSystem(
+            lambda t, x, u: u*x*x, 
+            lambda t, x, u: x, inputs=1, outputs=1).dt, 0)
+        ct.set_defaults('control', default_dt=None)
+        self.assertEqual(ct.tf(1, [1,1]).dt, None)
         self.assertEqual(ct.ss(1,0,0,1).dt, None)
-        # test that a static gain state space system always has dt=None
-        ct.set_defaults('statesp', default_dt=0)
-        self.assertEqual(ct.ss(0,0,0,1).dt, None)
+        self.assertEqual(ct.iosys.NonlinearIOSystem(
+            lambda t, x, u: u*x*x, 
+            lambda t, x, u: x, inputs=1, outputs=1).dt, None)
+        
+        # test that static gain systems always have dt=None
+        ct.set_defaults('control', default_dt=0)
+        self.assertEqual(ct.tf(1, 1).dt, None)
+        self.assertEqual(ct.ss(0,0,0,1).dt, None)        
+        # TODO: add in test for static gain iosys
 
         ct.reset_defaults()
         
-
     def tearDown(self):
         # Get rid of any figures that we created
         plt.close('all')

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -218,14 +218,27 @@ class TestConfig(unittest.TestCase):
         assert(isinstance(ct.ss(0,0,0,1).D, np.ndarray))
     
     def test_change_default_dt(self):
-        ct.set_defaults('statesp', default_dt=0)
-        self.assertEqual(ct.ss(0,0,0,1).dt, 0)
-        ct.set_defaults('statesp', default_dt=None)
-        self.assertEqual(ct.ss(0,0,0,1).dt, None)
+        # TransferFunction
+        # test that system with dynamics uses correct default dt
         ct.set_defaults('xferfcn', default_dt=0)
-        self.assertEqual(ct.tf(1, 1).dt, 0)
+        self.assertEqual(ct.tf(1, [1,1]).dt, 0)
         ct.set_defaults('xferfcn', default_dt=None)
+        self.assertEqual(ct.tf(1, [1,1]).dt, None)
+        # test that a static gain transfer function always has dt=None
+        ct.set_defaults('xferfcn', default_dt=0)
         self.assertEqual(ct.tf(1, 1).dt, None)
+
+        # StateSpace
+        # test that system with dynamics uses correct default dt
+        ct.set_defaults('statesp', default_dt=0)
+        self.assertEqual(ct.ss(1,0,0,1).dt, 0)
+        ct.set_defaults('statesp', default_dt=None)
+        self.assertEqual(ct.ss(1,0,0,1).dt, None)
+        # test that a static gain state space system always has dt=None
+        ct.set_defaults('statesp', default_dt=0)
+        self.assertEqual(ct.ss(0,0,0,1).dt, None)
+
+        ct.reset_defaults()
         
 
     def tearDown(self):

--- a/control/tests/discrete_test.py
+++ b/control/tests/discrete_test.py
@@ -135,13 +135,18 @@ class TestDiscrete(unittest.TestCase):
         self.assertEqual(timebase(feedback(tf3, tf4)), timebase(tf4))
 
         # Make sure all other combinations are errors
-        self.assertRaises(ValueError, tf2.__mul__, tf3)
-        self.assertRaises(ValueError, tf2.__mul__, tf4)
-        self.assertRaises(ValueError, tf2.__add__, tf3)
-        self.assertRaises(ValueError, tf2.__add__, tf4)
-        self.assertRaises(ValueError, tf2.feedback, tf3)
-        self.assertRaises(ValueError, tf2.feedback, tf4)
-        
+        with self.assertRaises(ValueError): tf2*tf3
+        with self.assertRaises(ValueError): tf3*tf2
+        with self.assertRaises(ValueError): tf2*tf4
+        with self.assertRaises(ValueError): tf4*tf2
+        with self.assertRaises(ValueError): tf2+tf3
+        with self.assertRaises(ValueError): tf3+tf2
+        with self.assertRaises(ValueError): tf2+tf4
+        with self.assertRaises(ValueError): tf4+tf2
+        with self.assertRaises(ValueError): feedback(tf2, tf3)
+        with self.assertRaises(ValueError): feedback(tf3, tf2)
+        with self.assertRaises(ValueError): feedback(tf2, tf4)
+        with self.assertRaises(ValueError): feedback(tf4, tf2)        
         
     def testisdtime(self):
         # Constant

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -613,20 +613,20 @@ class TestMatlab(unittest.TestCase):
         # margin command should remove the solution for w = nearly zero
 
         # Example is a concocted two-body satellite with flexible link
-        Jb = 400;
-        Jp = 1000;
-        k = 10;
-        b = 5;
+        Jb = 400
+        Jp = 1000
+        k = 10
+        b = 5
 
         # can now define an "s" variable, to make TF's
-        s = tf([1, 0], [1]);
-        hb1 = 1/(Jb*s);
-        hb2 = 1/s;
-        hp1 = 1/(Jp*s);
-        hp2 = 1/s;
+        s = tf([1, 0], [1])
+        hb1 = 1/(Jb*s)
+        hb2 = 1/s
+        hp1 = 1/(Jp*s)
+        hp2 = 1/s
 
         # convert to ss and append
-        sat0 = append(ss(hb1), ss(hb2), k, b, ss(hp1), ss(hp2));
+        sat0 = append(ss(hb1), ss(hb2), k, b, ss(hp1), ss(hp2))
 
         # connection of the elements with connect call
         Q = [[1, -3, -4],  # link moment (spring, damper), feedback to body
@@ -635,9 +635,9 @@ class TestMatlab(unittest.TestCase):
              [4,  1, -5],  # damper input
              [5,  3,  4],  # link moment, acting on payload
              [6,  5,  0]]
-        inputs = [1];
-        outputs = [1, 2, 5, 6];
-        sat1 = connect(sat0, Q, inputs, outputs);
+        inputs = [1]
+        outputs = [1, 2, 5, 6]
+        sat1 = connect(sat0, Q, inputs, outputs)
 
         # matched notch filter
         wno = 0.19

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -349,7 +349,7 @@ class TestXferFcn(unittest.TestCase):
 
     def test_div(self):
         # Make sure that sampling times work correctly
-        sys1 = TransferFunction([1., 3., 5], [1., 6., 2., -1])
+        sys1 = TransferFunction([1., 3., 5], [1., 6., 2., -1], None)
         sys2 = TransferFunction([[[-1., 3.]]], [[[1., 0., -1.]]], True)
         sys3 = sys1 / sys2
         self.assertEqual(sys3.dt, True)
@@ -659,7 +659,7 @@ class TestXferFcn(unittest.TestCase):
         g = TransferFunction([1,1],[1,1]).minreal()
         np.testing.assert_array_almost_equal(1.0, g.num[0][0])
         np.testing.assert_array_almost_equal(1.0, g.den[0][0])
-        np.testing.assert_equal(None, g.dt)
+        np.testing.assert_equal(0, g.dt)
 
     def test_minreal_4(self):
         """Check minreal on discrete TFs."""

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -659,7 +659,6 @@ class TestXferFcn(unittest.TestCase):
         g = TransferFunction([1,1],[1,1]).minreal()
         np.testing.assert_array_almost_equal(1.0, g.num[0][0])
         np.testing.assert_array_almost_equal(1.0, g.den[0][0])
-        np.testing.assert_equal(0, g.dt)
 
     def test_minreal_4(self):
         """Check minreal on discrete TFs."""

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -72,7 +72,6 @@ __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
 _xferfcn_defaults = {}
 
 class TransferFunction(LTI):
-
     """TransferFunction(num, den[, dt])
 
     A class for representing transfer functions
@@ -88,12 +87,21 @@ class TransferFunction(LTI):
     means that the numerator of the transfer function from the 6th input to the
     3rd output is set to s^2 + 4s + 8.
 
-    Discrete-time transfer functions are implemented by using the 'dt'
-    instance variable and setting it to something other than 'None'.  If 'dt'
-    has a non-zero value, then it must match whenever two transfer functions
-    are combined.  If 'dt' is set to True, the system will be treated as a
-    discrete time system with unspecified sampling time. The default value of 
-    'dt' is None and can be changed by changing the value of 
+    A discrete time transfer function is created by specifying a nonzero 
+    'timebase' dt when the system is constructed:
+
+    * dt = 0: continuous time system (default)
+    * dt > 0: discrete time system with sampling period 'dt'
+    * dt = True: discrete time with unspecified sampling period
+    * dt = None: no timebase specified 
+
+    Systems must have compatible timebases in order to be combined. A discrete 
+    time system with unspecified sampling time (`dt = True`) can be combined 
+    with a system having a specified sampling time; the result will be a 
+    discrete time system with the sample time of the latter system. Similarly, 
+    a system with timebase `None` can be combined with a system having any 
+    timebase; the result will have the timebase of the latter system. 
+    The default value of dt can be changed by changing the value of 
     ``control.config.defaults['control.default_dt']``.
 
     The TransferFunction class defines two constants ``s`` and ``z`` that
@@ -103,8 +111,8 @@ class TransferFunction(LTI):
 
     >>> s = TransferFunction.s
     >>> G  = (s + 1)/(s**2 + 2*s + 1)
-
     """
+    
     def __init__(self, *args):
         """TransferFunction(num, den[, dt])
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -70,7 +70,7 @@ __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
 
 # Define module default parameter values
 _xferfcn_defaults = {
-    'xferfcn.default_dt': None}
+    'xferfcn.default_dt': 0}
 
 class TransferFunction(LTI):
 
@@ -1564,6 +1564,20 @@ def _clean_part(data):
 
     return data
 
+def _isstaticgain(num, den):
+    """returns true if and only if all of the numerator and denominator 
+    polynomials of the (possibly MIMO) transfer funnction are zeroth order, 
+    that is, if the system has no dynamics. """
+    num, den = _clean_part(num), _clean_part(den)
+    for m in range(len(num)):
+        for n in range(len(num[m])):
+            if len(num[m][n]) > 1: 
+                return False
+    for m in range(len(den)):
+        for n in range(len(den[m])):
+            if len(den[m][n]) > 1: 
+                return False
+    return True
 
 # Define constants to represent differentiation, unit delay
 TransferFunction.s = TransferFunction([1, 0], [1], 0)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -69,8 +69,7 @@ __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
 
 
 # Define module default parameter values
-_xferfcn_defaults = {
-    'xferfcn.default_dt': 0}
+_xferfcn_defaults = {}
 
 class TransferFunction(LTI):
 
@@ -95,7 +94,7 @@ class TransferFunction(LTI):
     are combined.  If 'dt' is set to True, the system will be treated as a
     discrete time system with unspecified sampling time. The default value of 
     'dt' is None and can be changed by changing the value of 
-    ``control.config.defaults['xferfcn.default_dt']``.
+    ``control.config.defaults['control.default_dt']``.
 
     The TransferFunction class defines two constants ``s`` and ``z`` that
     represent the differentiation and delay operators in continuous and
@@ -127,7 +126,7 @@ class TransferFunction(LTI):
             if _isstaticgain(num, den):
                 dt = None
             else: 
-                dt = config.defaults['xferfcn.default_dt']
+                dt = config.defaults['control.default_dt']
         elif len(args) == 3:
             # Discrete time transfer function
             (num, den, dt) = args
@@ -146,7 +145,7 @@ class TransferFunction(LTI):
                 if _isstaticgain(num, den):
                     dt = None
                 else: 
-                    dt = config.defaults['xferfcn.default_dt']
+                    dt = config.defaults['control.default_dt']
         else:
             raise ValueError("Needs 1, 2 or 3 arguments; received %i."
                              % len(args))

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -113,7 +113,7 @@ class TransferFunction(LTI):
     >>> G  = (s + 1)/(s**2 + 2*s + 1)
     """
     
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         """TransferFunction(num, den[, dt])
 
         Construct a transfer function.
@@ -131,10 +131,6 @@ class TransferFunction(LTI):
         if len(args) == 2:
             # The user provided a numerator and a denominator.
             (num, den) = args
-            if _isstaticgain(num, den):
-                dt = None
-            else: 
-                dt = config.defaults['control.default_dt']
         elif len(args) == 3:
             # Discrete time transfer function
             (num, den, dt) = args
@@ -146,14 +142,6 @@ class TransferFunction(LTI):
                                 % type(args[0]))
             num = args[0].num
             den = args[0].den
-            # TODO: not sure this can ever happen since dt is always present
-            try:
-                dt = args[0].dt
-            except NameError:   # pragma: no coverage
-                if _isstaticgain(num, den):
-                    dt = None
-                else: 
-                    dt = config.defaults['control.default_dt']
         else:
             raise ValueError("Needs 1, 2 or 3 arguments; received %i."
                              % len(args))
@@ -211,11 +199,35 @@ class TransferFunction(LTI):
                 if zeronum:
                     den[i][j] = ones(1)
 
-        LTI.__init__(self, inputs, outputs, dt)
+        LTI.__init__(self, inputs, outputs)
         self.num = num
         self.den = den
 
         self._truncatecoeff()
+
+        # get dt
+        if len(args) == 2:
+            # no dt given in positional arguments
+            if 'dt' in kwargs:
+                dt = kwargs['dt']
+            elif self.is_static_gain():
+                dt = None
+            else: 
+                dt = config.defaults['control.default_dt']
+        elif len(args) == 3:
+            # Discrete time transfer function
+            if 'dt' in kwargs:
+                warn('received multiple dt arguments, using positional arg'%dt)
+        elif len(args) == 1:
+            # TODO: not sure this can ever happen since dt is always present
+            try:
+                dt = args[0].dt
+            except NameError:   # pragma: no coverage
+                if self.is_static_gain():
+                    dt = None
+                else: 
+                    dt = config.defaults['control.default_dt']
+        self.dt = dt
 
     def __call__(self, s):
         """Evaluate the system's transfer function for a complex variable
@@ -1066,6 +1078,18 @@ class TransferFunction(LTI):
                         gain[i][j] = np.nan
         return np.squeeze(gain)
 
+    def is_static_gain(self):
+        """returns True if and only if all of the numerator and denominator 
+        polynomials of the (possibly MIMO) transfer funnction are zeroth order, 
+        that is, if the system has no dynamics. """
+        for list_of_polys in self.num, self.den: 
+            for row in list_of_polys:
+                for poly in row:
+                    if len(poly) > 1: 
+                        return False
+        return True
+
+
 
 # c2d function contributed by Benjamin White, Oct 2012
 def _c2d_matched(sysC, Ts):
@@ -1538,19 +1562,6 @@ def _clean_part(data):
                     data[i][j][k] = float(data[i][j][k])
 
     return data
-
-def _isstaticgain(num, den):
-    """returns True if and only if all of the numerator and denominator 
-    polynomials of the (possibly MIMO) transfer funnction are zeroth order, 
-    that is, if the system has no dynamics. """
-    num, den = _clean_part(num), _clean_part(den)
-    for list_of_polys in num, den: 
-        for row in list_of_polys:
-            for poly in row:
-                poly_trimmed = np.trim_zeros(poly, 'f') # trim leading zeros
-                if len(poly_trimmed) > 1: 
-                    return False
-    return True
 
 # Define constants to represent differentiation, unit delay
 TransferFunction.s = TransferFunction([1, 0], [1], 0)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -62,7 +62,7 @@ from copy import deepcopy
 from warnings import warn
 from itertools import chain
 from re import sub
-from .lti import LTI, timebaseEqual, timebase, isdtime
+from .lti import LTI, common_timebase, isdtime
 from . import config
 
 __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
@@ -124,7 +124,10 @@ class TransferFunction(LTI):
         if len(args) == 2:
             # The user provided a numerator and a denominator.
             (num, den) = args
-            dt = config.defaults['xferfcn.default_dt']
+            if _isstaticgain(num, den):
+                dt = None
+            else: 
+                dt = config.defaults['xferfcn.default_dt']
         elif len(args) == 3:
             # Discrete time transfer function
             (num, den, dt) = args
@@ -140,7 +143,10 @@ class TransferFunction(LTI):
             try:
                 dt = args[0].dt
             except NameError:   # pragma: no coverage
-                dt = config.defaults['xferfcn.default_dt']
+                if _isstaticgain(num, den):
+                    dt = None
+                else: 
+                    dt = config.defaults['xferfcn.default_dt']
         else:
             raise ValueError("Needs 1, 2 or 3 arguments; received %i."
                              % len(args))
@@ -369,14 +375,7 @@ class TransferFunction(LTI):
                 "The first summand has %i output(s), but the second has %i."
                 % (self.outputs, other.outputs))
 
-        # Figure out the sampling time to use
-        if self.dt is None and other.dt is not None:
-            dt = other.dt       # use dt from second argument
-        elif (other.dt is None and self.dt is not None) or \
-             (timebaseEqual(self, other)):
-            dt = self.dt        # use dt from first argument
-        else:
-            raise ValueError("Systems have different sampling times")
+        dt = common_timebase(self.dt, other.dt)
 
         # Preallocate the numerator and denominator of the sum.
         num = [[[] for j in range(self.inputs)] for i in range(self.outputs)]
@@ -420,15 +419,8 @@ class TransferFunction(LTI):
         inputs = other.inputs
         outputs = self.outputs
 
-        # Figure out the sampling time to use
-        if self.dt is None and other.dt is not None:
-            dt = other.dt       # use dt from second argument
-        elif (other.dt is None and self.dt is not None) or \
-             (self.dt == other.dt):
-            dt = self.dt        # use dt from first argument
-        else:
-            raise ValueError("Systems have different sampling times")
-
+        dt = common_timebase(self.dt, other.dt)
+        
         # Preallocate the numerator and denominator of the sum.
         num = [[[0] for j in range(inputs)] for i in range(outputs)]
         den = [[[1] for j in range(inputs)] for i in range(outputs)]
@@ -471,14 +463,7 @@ class TransferFunction(LTI):
         inputs = self.inputs
         outputs = other.outputs
 
-        # Figure out the sampling time to use
-        if self.dt is None and other.dt is not None:
-            dt = other.dt       # use dt from second argument
-        elif (other.dt is None and self.dt is not None) \
-                or (self.dt == other.dt):
-            dt = self.dt        # use dt from first argument
-        else:
-            raise ValueError("Systems have different sampling times")
+        dt = common_timebase(self.dt, other.dt)
 
         # Preallocate the numerator and denominator of the sum.
         num = [[[0] for j in range(inputs)] for i in range(outputs)]
@@ -518,14 +503,7 @@ class TransferFunction(LTI):
                 "TransferFunction.__truediv__ is currently \
                 implemented only for SISO systems.")
 
-        # Figure out the sampling time to use
-        if self.dt is None and other.dt is not None:
-            dt = other.dt       # use dt from second argument
-        elif (other.dt is None and self.dt is not None) or \
-             (self.dt == other.dt):
-            dt = self.dt        # use dt from first argument
-        else:
-            raise ValueError("Systems have different sampling times")
+        dt = common_timebase(self.dt, other.dt)
 
         num = polymul(self.num[0][0], other.den[0][0])
         den = polymul(self.den[0][0], other.num[0][0])
@@ -625,8 +603,7 @@ class TransferFunction(LTI):
         # TODO: implement for discrete time systems
         if isdtime(self, strict=True):
             # Convert the frequency to discrete time
-            dt = timebase(self)
-            s = exp(1.j * omega * dt)
+            s = exp(1.j * omega * self.dt)
             if np.any(omega * dt > pi):
                 warn("_evalfr: frequency evaluation above Nyquist frequency")
         else:
@@ -691,9 +668,8 @@ class TransferFunction(LTI):
         # Figure out the frequencies
         omega.sort()
         if isdtime(self, strict=True):
-            dt = timebase(self)
-            slist = np.array([exp(1.j * w * dt) for w in omega])
-            if max(omega) * dt > pi:
+            slist = np.array([exp(1.j * w * self.dt) for w in omega])
+            if max(omega) * self.dt > pi:
                 warn("freqresp: frequency evaluation above Nyquist frequency")
         else:
             slist = np.array([1j * w for w in omega])
@@ -736,15 +712,7 @@ class TransferFunction(LTI):
             raise NotImplementedError(
                 "TransferFunction.feedback is currently only implemented "
                 "for SISO functions.")
-
-        # Figure out the sampling time to use
-        if self.dt is None and other.dt is not None:
-            dt = other.dt       # use dt from second argument
-        elif (other.dt is None and self.dt is not None) or \
-             (self.dt == other.dt):
-            dt = self.dt        # use dt from first argument
-        else:
-            raise ValueError("Systems have different sampling times")
+        dt = common_timebase(self.dt, other.dt)
 
         num1 = self.num[0][0]
         den1 = self.den[0][0]
@@ -1025,7 +993,7 @@ class TransferFunction(LTI):
 
         Returns
         -------
-        sysd : StateSpace system
+        sysd : TransferFunction system
             Discrete time system, with sampling rate Ts
 
         Notes
@@ -1565,18 +1533,16 @@ def _clean_part(data):
     return data
 
 def _isstaticgain(num, den):
-    """returns true if and only if all of the numerator and denominator 
+    """returns True if and only if all of the numerator and denominator 
     polynomials of the (possibly MIMO) transfer funnction are zeroth order, 
     that is, if the system has no dynamics. """
     num, den = _clean_part(num), _clean_part(den)
-    for m in range(len(num)):
-        for n in range(len(num[m])):
-            if len(num[m][n]) > 1: 
-                return False
-    for m in range(len(den)):
-        for n in range(len(den[m])):
-            if len(den[m][n]) > 1: 
-                return False
+    for list_of_polys in num, den: 
+        for row in list_of_polys:
+            for poly in row:
+                poly_trimmed = np.trim_zeros(poly, 'f') # trim leading zeros
+                if len(poly_trimmed) > 1: 
+                    return False
     return True
 
 # Define constants to represent differentiation, unit delay

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -604,7 +604,7 @@ class TransferFunction(LTI):
         if isdtime(self, strict=True):
             # Convert the frequency to discrete time
             s = exp(1.j * omega * self.dt)
-            if np.any(omega * dt > pi):
+            if np.any(omega * self.dt > pi):
                 warn("_evalfr: frequency evaluation above Nyquist frequency")
         else:
             s = 1.j * omega

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -217,7 +217,7 @@ class TransferFunction(LTI):
         elif len(args) == 3:
             # Discrete time transfer function
             if 'dt' in kwargs:
-                warn('received multiple dt arguments, using positional arg'%dt)
+                warn('received multiple dt arguments, using positional arg dt=%s'%dt)
         elif len(args) == 1:
             # TODO: not sure this can ever happen since dt is always present
             try:
@@ -1301,7 +1301,7 @@ def _convert_to_transfer_function(sys, **kw):
     raise TypeError("Can't convert given type to TransferFunction system.")
 
 
-def tf(*args):
+def tf(*args, **kwargs):
     """tf(num, den[, dt])
 
     Create a transfer function system. Can create MIMO systems.
@@ -1391,7 +1391,7 @@ def tf(*args):
     """
 
     if len(args) == 2 or len(args) == 3:
-        return TransferFunction(*args)
+        return TransferFunction(*args, **kwargs)
     elif len(args) == 1:
         # Look for special cases defining differential/delay operator
         if args[0] == 's':
@@ -1412,7 +1412,7 @@ def tf(*args):
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
 
 
-def ss2tf(*args):
+def ss2tf(*args, **kwargs):
     """ss2tf(sys)
 
     Transform a state space system to a transfer function.
@@ -1477,7 +1477,7 @@ def ss2tf(*args):
     from .statesp import StateSpace
     if len(args) == 4 or len(args) == 5:
         # Assume we were given the A, B, C, D matrix and (optional) dt
-        return _convert_to_transfer_function(StateSpace(*args))
+        return _convert_to_transfer_function(StateSpace(*args, **kwargs))
 
     elif len(args) == 1:
         sys = args[0]

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -80,27 +80,24 @@ Discrete time systems
 A discrete time system is created by specifying a nonzero 'timebase', dt.
 The timebase argument can be given when a system is constructed:
 
-* dt = None: no timebase specified (default)
-* dt = 0: continuous time system
+* dt = 0: continuous time system (default)
 * dt > 0: discrete time system with sampling period 'dt'
 * dt = True: discrete time with unspecified sampling period
+* dt = None: no timebase specified 
 
 Only the :class:`StateSpace`, :class:`TransferFunction`, and
 :class:`InputOutputSystem` classes allow explicit representation of
 discrete time systems.
 
-Systems must have compatible timebases in order to be combined.  A system
-with timebase `None` can be combined with a system having a specified
-timebase; the result will have the timebase of the latter system.
-Similarly, a discrete time system with unspecified sampling time (`dt =
-True`) can be combined with a system having a specified sampling time;
-the result will be a discrete time system with the sample time of the latter
-system.  For continuous time systems, the :func:`sample_system` function or
-the :meth:`StateSpace.sample` and :meth:`TransferFunction.sample` methods
+Systems must have compatible timebases in order to be combined. A discrete time 
+system with unspecified sampling time (`dt = True`) can be combined with a system 
+having a specified sampling time; the result will be a discrete time system with the sample time of the latter
+system.  Similarly, a system with timebase `None` can be combined with a system having a specified
+timebase; the result will have the timebase of the latter system. For continuous 
+time systems, the :func:`sample_system` function or the :meth:`StateSpace.sample` and :meth:`TransferFunction.sample` methods
 can be used to create a discrete time system from a continuous time system.
 See :ref:`utility-and-conversions`. The default value of 'dt' can be changed by
-changing the values of ``control.config.defaults['statesp.default_dt']`` and 
-``control.config.defaults['xferfcn.default_dt']``.
+changing the value of ``control.config.defaults['control.default_dt']``.
 
 Conversion between representations
 ----------------------------------


### PR DESCRIPTION
Changes the new default to be ``dt=0`` (continuous-time), rather than ``dt=None`` (timebase unspecified) for state space, transfer function, and input output systems. This follows matlab convention as discussed in issue #422
* new default is ``dt=0`` in these three modules (edit: setting now is in a single location: ``defaults['control.default_dt']``)
* to make interconnection behavior match what is described in [conventions](https://python-control.readthedocs.io/en/0.8.3/conventions.html#discrete-time-systems), a new function: ``lti.common_timebase(dt1, dt2)`` was introduced. It performs logic to correctly combine timebases of combined systems.  The new function now correctly allows discrete-time systems with unspecified sampling time (``dt=True``) to be combined with systems with specified sampling time (``dt!=0``, ``dt!=None``, eg ``dt=0.1``). 
* new functions ``_isstaticgain`` (edit: now is a method ``is_static_gain``) were added to detect upon initialization whether a state space or transfer function is a static gain. If so, ``dt=None`` for such systems so they may be combined with either discrete- or continuous-time systems. 
* I needed to take dt out of the arguments list in ``iosys`` init functions because library-wide defaults are not available when modules are first imported, which is when default values in function declarations are evaluated. My solution was to move the dt keyword in the ``**kwargs`` dict.  
* fixes to unit tests
* ``use_legacy_defaults('0.8.3')`` reverts to old default behavior of ``dt=None``