### PR TITLE
fixes to unit tests so that they pass when the default array type is ndarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ jobs:
       services: xvfb
       python: "3.8"
       env: SCIPY=scipy SLYCOT=source
+    - name: "use numpy matrix"
+      dist: xenial
+      services: xvfb
+      python: "3.8"
+      env: SCIPY=scipy SLYCOT=source PYTHON_CONTROL_STATESPACE_ARRAY=1
 
   # Exclude combinations that are very unlikely (and don't work)
   exclude:

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -70,7 +70,7 @@ __all__ = ['StateSpace', 'ss', 'rss', 'drss', 'tf2ss', 'ssdata']
 
 # Define module default parameter values
 _statesp_defaults = {
-    'statesp.use_numpy_matrix': False,
+    'statesp.use_numpy_matrix': True,
     'statesp.default_dt': None,
     'statesp.remove_useless_states': True, 
     }

--- a/control/tests/canonical_test.py
+++ b/control/tests/canonical_test.py
@@ -22,13 +22,13 @@ class TestCanonical(unittest.TestCase):
         D_true = 42.0
 
         # Perform a coordinate transform with a random invertible matrix
-        T_true = np.matrix([[-0.27144004, -0.39933167,  0.75634684,  0.44135471],
+        T_true =  np.array([[-0.27144004, -0.39933167,  0.75634684,  0.44135471],
                             [-0.74855725, -0.39136285, -0.18142339, -0.50356997],
                             [-0.40688007,  0.81416369,  0.38002113, -0.16483334],
                             [-0.44769516,  0.15654653, -0.50060858,  0.72419146]])
-        A = np.linalg.solve(T_true, A_true)*T_true
+        A = np.linalg.solve(T_true, A_true).dot(T_true)
         B = np.linalg.solve(T_true, B_true)
-        C = C_true*T_true
+        C = C_true.dot(T_true)
         D = D_true
 
         # Create a state space system and convert it to the reachable canonical form
@@ -69,11 +69,11 @@ class TestCanonical(unittest.TestCase):
         D_true = 42.0
 
         # Perform a coordinate transform with a random invertible matrix
-        T_true = np.matrix([[-0.27144004, -0.39933167,  0.75634684,  0.44135471],
+        T_true =  np.array([[-0.27144004, -0.39933167,  0.75634684,  0.44135471],
                             [-0.74855725, -0.39136285, -0.18142339, -0.50356997],
                             [-0.40688007,  0.81416369,  0.38002113, -0.16483334],
                             [-0.44769516,  0.15654653, -0.50060858,  0.72419146]])
-        A = np.linalg.solve(T_true, A_true)*T_true
+        A = np.linalg.solve(T_true, A_true).dot(T_true)
         B = np.linalg.solve(T_true, B_true)
         C = C_true*T_true
         D = D_true
@@ -98,9 +98,9 @@ class TestCanonical(unittest.TestCase):
         C_true = np.array([[1, 0, 0, 1]])
         D_true = np.array([[0]])
 
-        A = np.linalg.solve(T_true, A_true) * T_true
+        A = np.linalg.solve(T_true, A_true).dot(T_true)
         B = np.linalg.solve(T_true, B_true)
-        C = C_true * T_true
+        C = C_true.dot(T_true)
         D = D_true
 
         # Create state space system and convert to modal canonical form
@@ -132,9 +132,9 @@ class TestCanonical(unittest.TestCase):
         C_true = np.array([[0, 1, 0, 1]])
         D_true = np.array([[0]])
 
-        A = np.linalg.solve(T_true, A_true) * T_true
+        A = np.linalg.solve(T_true, A_true).dot(T_true)
         B = np.linalg.solve(T_true, B_true)
-        C = C_true * T_true
+        C = C_true.dot(T_true)
         D = D_true
 
         # Create state space system and convert to modal canonical form
@@ -173,13 +173,13 @@ class TestCanonical(unittest.TestCase):
         D_true = 42.0
 
         # Perform a coordinate transform with a random invertible matrix
-        T_true = np.matrix([[-0.27144004, -0.39933167,  0.75634684,  0.44135471],
+        T_true =  np.array([[-0.27144004, -0.39933167,  0.75634684,  0.44135471],
                             [-0.74855725, -0.39136285, -0.18142339, -0.50356997],
                             [-0.40688007,  0.81416369,  0.38002113, -0.16483334],
                             [-0.44769516,  0.15654653, -0.50060858,  0.72419146]])
-        A = np.linalg.solve(T_true, A_true)*T_true
+        A = np.linalg.solve(T_true, A_true).dot(T_true)
         B = np.linalg.solve(T_true, B_true)
-        C = C_true*T_true
+        C = C_true.dot(T_true)
         D = D_true
 
         # Create a state space system and convert it to the observable canonical form

--- a/control/tests/conftest.py
+++ b/control/tests/conftest.py
@@ -1,0 +1,13 @@
+# contest.py - pytest local plugins and fixtures
+
+import control
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def use_numpy_ndarray():
+    """Switch the config to use ndarray instead of matrix"""
+    if os.getenv("PYTHON_CONTROL_STATESPACE_ARRAY") == "1":
+        control.config.defaults['statesp.use_numpy_matrix'] = False

--- a/control/tests/discrete_test.py
+++ b/control/tests/discrete_test.py
@@ -353,7 +353,7 @@ class TestDiscrete(unittest.TestCase):
         for sys in (sys1, sys2):
             for h in (0.1, 0.5, 1, 2):
                 Ad = I + h * sys.A
-                Bd = h * sys.B + 0.5 * h**2 * (sys.A * sys.B)
+                Bd = h * sys.B + 0.5 * h**2 * np.dot(sys.A, sys.B)
                 sysd = sample_system(sys, h, method='zoh')
                 np.testing.assert_array_almost_equal(sysd.A, Ad)
                 np.testing.assert_array_almost_equal(sysd.B, Bd)

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -53,7 +53,7 @@ class TestIOSys(unittest.TestCase):
         for x, u in (([0, 0], 0), ([1, 0], 0), ([0, 1], 0), ([0, 0], 1)):
             np.testing.assert_array_almost_equal(
                 np.reshape(iosys._rhs(0, x, u), (-1,1)),
-                linsys.A * np.reshape(x, (-1, 1)) + linsys.B * u)
+                np.dot(linsys.A, np.reshape(x, (-1, 1))) + np.dot(linsys.B, u))
 
         # Make sure that simulations also line up
         T, U, X0 = self.T, self.U, self.X0

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -151,9 +151,9 @@ class TestIOSys(unittest.TestCase):
 
         # Create a nonlinear system with the same dynamics
         nlupd = lambda t, x, u, params: \
-            np.reshape(linsys.A * np.reshape(x, (-1, 1)) + linsys.B * u, (-1,))
+            np.reshape(np.dot(linsys.A, np.reshape(x, (-1, 1))) + np.dot(linsys.B, u), (-1,))
         nlout = lambda t, x, u, params: \
-            np.reshape(linsys.C * np.reshape(x, (-1, 1)) + linsys.D * u, (-1,))
+            np.reshape(np.dot(linsys.C, np.reshape(x, (-1, 1))) + np.dot(linsys.D, u), (-1,))
         nlsys = ios.NonlinearIOSystem(nlupd, nlout)
 
         # Make sure that simulations also line up
@@ -747,8 +747,8 @@ class TestIOSys(unittest.TestCase):
                 + np.dot(self.mimo_linsys1.B, np.reshape(u, (-1, 1)))
             ).reshape(-1,),
             outfcn = lambda t, x, u, params: np.array(
-                self.mimo_linsys1.C * np.reshape(x, (-1, 1)) \
-                + self.mimo_linsys1.D * np.reshape(u, (-1, 1))
+                np.dot(self.mimo_linsys1.C, np.reshape(x, (-1, 1))) \
+                + np.dot(self.mimo_linsys1.D, np.reshape(u, (-1, 1)))
             ).reshape(-1,),
             inputs = ('u[0]', 'u[1]'),
             outputs = ('y[0]', 'y[1]'),

--- a/control/tests/statesp_array_test.py
+++ b/control/tests/statesp_array_test.py
@@ -13,6 +13,7 @@ from control.xferfcn import TransferFunction, ss2tf
 from control.lti import evalfr
 from control.exception import slycot_check
 from control.config import use_numpy_matrix, reset_defaults
+from control.config import defaults
 
 class TestStateSpace(unittest.TestCase):
     """Tests for the StateSpace class."""
@@ -74,8 +75,12 @@ class TestStateSpace(unittest.TestCase):
         self.assertEqual(sys.B.shape, (2, 1))
         self.assertEqual(sys.C.shape, (1, 2))
         self.assertEqual(sys.D.shape, (1, 1))
-        for X in [sys.A, sys.B, sys.C, sys.D]:
-            self.assertTrue(isinstance(X, np.matrix))
+        if defaults['statesp.use_numpy_matrix']:
+            for X in [sys.A, sys.B, sys.C, sys.D]:
+                self.assertTrue(isinstance(X, np.matrix))
+        else:
+            for X in [sys.A, sys.B, sys.C, sys.D]:
+                self.assertTrue(isinstance(X, np.ndarray))
 
     def test_pole(self):
         """Evaluate the poles of a MIMO system."""

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -323,9 +323,9 @@ class TestStateSpace(unittest.TestCase):
         np.testing.assert_array_almost_equal(sys1_11.A,
                                              sys1.A)
         np.testing.assert_array_almost_equal(sys1_11.B,
-                                             sys1.B[:, 1])
+                                             sys1.B[:, 1:2])
         np.testing.assert_array_almost_equal(sys1_11.C,
-                                             sys1.C[0, :])
+                                             sys1.C[0:1, :])
         np.testing.assert_array_almost_equal(sys1_11.D,
                                              sys1.D[0, 1])
 

--- a/control/tests/test_control_matlab.py
+++ b/control/tests/test_control_matlab.py
@@ -11,7 +11,7 @@ import scipy.signal
 from numpy.testing import assert_array_almost_equal
 from numpy import array, asarray, matrix, asmatrix, zeros, ones, linspace,\
                   all, hstack, vstack, c_, r_
-from matplotlib.pylab import show, figure, plot, legend, subplot2grid
+from matplotlib.pyplot import show, figure, plot, legend, subplot2grid
 from control.matlab import ss, step, impulse, initial, lsim, dcgain, \
                            ss2tf
 from control.statesp import _mimo2siso
@@ -24,29 +24,13 @@ class TestControlMatlab(unittest.TestCase):
     def setUp(self):
         pass
 
-    def plot_matrix(self):
-        #Test: can matplotlib correctly plot matrices?
-        #Yes, but slightly inconvenient
-        figure()
-        t = matrix([[ 1.],
-                    [ 2.],
-                    [ 3.],
-                    [ 4.]])
-        y = matrix([[ 1., 4.],
-                    [ 4., 5.],
-                    [ 9., 6.],
-                    [16., 7.]])
-        plot(t, y)
-        #plot(asarray(t)[0], asarray(y)[0])
-
-
     def make_SISO_mats(self):
         """Return matrices for a SISO system"""
-        A = matrix([[-81.82, -45.45],
+        A =  array([[-81.82, -45.45],
                     [ 10.,    -1.  ]])
-        B = matrix([[9.09],
+        B =  array([[9.09],
                     [0.  ]])
-        C = matrix([[0, 0.159]])
+        C =  array([[0, 0.159]])
         D = zeros((1, 1))
         return A, B, C, D
 
@@ -181,7 +165,7 @@ class TestControlMatlab(unittest.TestCase):
 
         #Test MIMO system
         A, B, C, D = self.make_MIMO_mats()
-        sys = ss(A, B, C, D)
+        sys = ss(A, B, C, D) 
         t, y = impulse(sys)
         plot(t, y, label='MIMO System')
 
@@ -202,7 +186,7 @@ class TestControlMatlab(unittest.TestCase):
 
         #X0=[1,1] : produces a spike
         subplot2grid(plot_shape, (0, 1))
-        t, y = initial(sys, X0=matrix("1; 1"))
+        t, y = initial(sys, X0=array(matrix("1; 1")))
         plot(t, y)
 
         #Test MIMO system
@@ -318,21 +302,11 @@ class TestControlMatlab(unittest.TestCase):
         plot(t, y, label='y')
         legend(loc='best')
 
-        #Test with matrices
-        subplot2grid(plot_shape, (1, 0))
-        t = matrix(linspace(0, 1, 100))
-        u = matrix(r_[1:1:50j, 0:0:50j])
-        x0 = matrix("0.; 0")
-        y, t_out, _x = lsim(sys, u, t, x0)
-        plot(t_out, y, label='y')
-        plot(t_out, asarray(u/10)[0], label='u/10')
-        legend(loc='best')
-
         #Test with MIMO system
         subplot2grid(plot_shape, (1, 1))
         A, B, C, D = self.make_MIMO_mats()
         sys = ss(A, B, C, D)
-        t = matrix(linspace(0, 1, 100))
+        t =  array(linspace(0, 1, 100))
         u = array([r_[1:1:50j, 0:0:50j],
                    r_[0:1:50j, 0:0:50j]])
         x0 = [0, 0, 0, 0]
@@ -404,12 +378,12 @@ class TestControlMatlab(unittest.TestCase):
         #Test with additional systems --------------------------------------------
         #They have crossed inputs and direct feedthrough
         #SISO system
-        As = matrix([[-81.82, -45.45],
+        As =  array([[-81.82, -45.45],
                      [ 10.,    -1.  ]])
-        Bs = matrix([[9.09],
+        Bs =  array([[9.09],
                      [0.  ]])
-        Cs = matrix([[0, 0.159]])
-        Ds = matrix([[0.02]])
+        Cs =  array([[0, 0.159]])
+        Ds =  array([[0.02]])
         sys_siso = ss(As, Bs, Cs, Ds)
         #    t, y = step(sys_siso)
         #    plot(t, y, label='sys_siso d=0.02')
@@ -428,7 +402,7 @@ class TestControlMatlab(unittest.TestCase):
                     [0   , 0   ]])
         Cm = array([[0, 0,     0, 0.159],
                     [0, 0.159, 0, 0    ]])
-        Dm = matrix([[0,   0.02],
+        Dm =  array([[0,   0.02],
                      [0.02, 0  ]])
         sys_mimo = ss(Am, Bm, Cm, Dm)
 


### PR DESCRIPTION
instead of deprecated ``matrix`` class. Changes entailed:
* slicing fixes in code. In particular, if ``A`` is a ``matrix``, ``A[:, 1]`` is still a 2D matrix, but if ``A`` is an ``ndarray``, that slice results in a 1D vector. To fix, this was changed to e.g. A[:, 1:2], which perserves that the array is 2D after slicing. 
* use np.dot instead of * to multiply matrices in a few unit tests
* if B or C are given as 1d arrays, new code in ``statesp.__init__`` attempts to determine whether they should be row or column vectors. 
* completes tasks in #314

I checked on my computer and unit tests also pass when the default array type is ``matrix``. 