### PR TITLE
quick and dirty parser for version number in legacy-defaults

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -168,8 +168,9 @@ def use_legacy_defaults(version):
     version : string
         version number of the defaults desired. ranges from '0.1' to '0.8.4'. 
     """
-    first_digit = int(version[0])
-    second_digit = int(version[2])
+    numbers_list = version.split(".")
+    first_digit = int(numbers_list[0])
+    second_digit = int(numbers_list[1].strip('abcdef')) # remove trailing letters
     if second_digit < 8:
         # TODO: anything for 0.7 and below if needed
         pass

--- a/control/config.py
+++ b/control/config.py
@@ -166,9 +166,16 @@ def use_legacy_defaults(version):
     Parameters
     ----------
     version : string
-        version number of the defaults desired. Currently only supports `0.8.3`. 
+        version number of the defaults desired. ranges from '0.1' to '0.8.4'. 
     """
-    if version == '0.8.3': 
+    first_digit = int(version[0])
+    second_digit = int(version[2])
+    if second_digit < 8:
+        # TODO: anything for 0.7 and below if needed
+        pass
+    elif second_digit == 8:
+        if len(version) > 4:
+            third_digit = int(version[4])
         use_numpy_matrix(True) # alternatively: set_defaults('statesp', use_numpy_matrix=True)
     else:
-        raise ValueError('''version number not recognized. Possible values are: ['0.8.3']''') 
+        raise ValueError('''version number not recognized. Possible values range from '0.1' to '0.8.4'.''') 

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -216,6 +216,12 @@ class TestConfig(unittest.TestCase):
         assert(isinstance(ct.ss(0,0,0,1).D, np.matrix))
         ct.reset_defaults()
         assert(isinstance(ct.ss(0,0,0,1).D, np.ndarray))
+        # test that old versions don't raise a problem
+        ct.use_legacy_defaults('0.6c')
+        ct.use_legacy_defaults('0.8.2')
+        ct.use_legacy_defaults('0.1')
+        ct.config.reset_defaults()
+        
     
     def test_change_default_dt(self):
         ct.set_defaults('statesp', default_dt=0)


### PR DESCRIPTION
follows issue #432 