### PR TITLE
do not override squeeze parameter in forced_response

### DIFF
--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -325,7 +325,7 @@ def forced_response(sys, T=None, U=0., X0=0., transpose=False,
     # Separate out the discrete and continuous time cases
     if isctime(sys):
         # Solve the differential equation, copied from scipy.signal.ltisys.
-        dot, squeeze, = np.dot, np.squeeze  # Faster and shorter code
+        dot = np.dot  # Faster and shorter code
 
         # Faster algorithm if U is zero
         if U is None or (isinstance(U, (int, float)) and U == 0):


### PR DESCRIPTION
`squeeze=False` does not work for `forced_response()` because the parameter is unnecessarily overridden by a shortcut alias to np.squeeze.

The current code timeresp_test.py advertises to test this, but actually does not. (#438 does now, that's how I stumbled over it.)