### PR TITLE
fix impulse size for discrete-time impulse response

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -204,14 +204,15 @@ class TestTimeresp(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             yy, np.vstack((youttrue, np.zeros_like(youttrue))), decimal=4)
 
-        # discrete time
-        self.siso_tf1
+    def test_discrete_time_impulse(self):
+        # discrete time impulse sampled version should match cont time
         dt = 0.1
-        sysdt = self.siso_tf1.sample(dt, 'impulse')
         t = np.arange(0, 3, dt)
-        np.testing.assert_array_almost_equal(control.impulse_response(sys, t)[1],
-                                             control.impulse_response(sysdt, t)[1])
-
+        sys = self.siso_tf1
+        sysdt = sys.sample(dt, 'impulse')
+        np.testing.assert_array_almost_equal(impulse_response(sys, t)[1],
+                                             impulse_response(sysdt, t)[1])
+        
     def test_initial_response(self):
         # Test SISO system
         sys = self.siso_ss1

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -204,6 +204,14 @@ class TestTimeresp(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             yy, np.vstack((youttrue, np.zeros_like(youttrue))), decimal=4)
 
+        # discrete time
+        self.siso_tf1
+        dt = 0.1
+        sysdt = self.siso_tf1.sample(dt, 'impulse')
+        t = np.arange(0, 3, dt)
+        np.testing.assert_array_almost_equal(control.impulse_response(sys, t)[1],
+                                             control.impulse_response(sysdt, t)[1])
+
     def test_initial_response(self):
         # Test SISO system
         sys = self.siso_ss1

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -815,7 +815,7 @@ def impulse_response(sys, T=None, X0=0., input=0, output=None, T_num=None,
         new_X0 = B + X0
     else:
         new_X0 = X0
-        U[0] = 1.
+        U[0] = 1./sys.dt # unit area impulse
 
     T, yout, _xout = forced_response(sys, T, U, new_X0, transpose=transpose,
                                      squeeze=squeeze)


### PR DESCRIPTION
The input impulse used to drive the impulse response of a discrete-time system should be unit *area* rather than unit *height*. With this change, the discrete-time system's impulse response matches the cont-time systems's, if the discrete time system was sampled with 'impulse-equivalent' approximation according to:

``sysd = sys.sample(0.1, 'impulse')``

A new unit test checks this. 

(this is consistent with MATLAB behavior)

Update: rewrote summary, last version was written after a long work session and it shows : ) 