### PR TITLE
Fix pzmap grid (matplotlib angle_helper)

### DIFF
--- a/control/grid.py
+++ b/control/grid.py
@@ -19,10 +19,13 @@ class FormatterDMS(object):
 
 
 class ModifiedExtremeFinderCycle(angle_helper.ExtremeFinderCycle):
-    '''Changed to allow only left hand-side polar grid'''
+    '''Changed to allow only left hand-side polar grid
+
+    https://matplotlib.org/_modules/mpl_toolkits/axisartist/angle_helper.html#ExtremeFinderCycle.__call__
+    '''
     def __call__(self, transform_xy, x1, y1, x2, y2):
-        x_, y_ = np.linspace(x1, x2, self.nx), np.linspace(y1, y2, self.ny)
-        x, y = np.meshgrid(x_, y_)
+        x, y = np.meshgrid(
+            np.linspace(x1, x2, self.nx), np.linspace(y1, y2, self.ny))
         lon, lat = transform_xy(np.ravel(x), np.ravel(y))
 
         with np.errstate(invalid='ignore'):
@@ -41,7 +44,25 @@ class ModifiedExtremeFinderCycle(angle_helper.ExtremeFinderCycle):
         lat_min, lat_max = np.nanmin(lat), np.nanmax(lat)
 
         lon_min, lon_max, lat_min, lat_max = \
-            self._adjust_extremes(lon_min, lon_max, lat_min, lat_max)
+            self._add_pad(lon_min, lon_max, lat_min, lat_max)
+
+        # check cycle
+        if self.lon_cycle:
+            lon_max = min(lon_max, lon_min + self.lon_cycle)
+        if self.lat_cycle:
+            lat_max = min(lat_max, lat_min + self.lat_cycle)
+
+        if self.lon_minmax is not None:
+            min0 = self.lon_minmax[0]
+            lon_min = max(min0, lon_min)
+            max0 = self.lon_minmax[1]
+            lon_max = min(max0, lon_max)
+
+        if self.lat_minmax is not None:
+            min0 = self.lat_minmax[0]
+            lat_min = max(min0, lat_min)
+            max0 = self.lat_minmax[1]
+            lat_max = min(max0, lat_max)
 
         return lon_min, lon_max, lat_min, lat_max
 


### PR DESCRIPTION
CI runs started to fail today with:

```
Traceback (most recent call last):
959  File "pvtol-nested.py", line 169, in <module>
960    P, Z = pzmap(T, plot=True, grid=True)
961  File "/home/travis/build/python-control/python-control/control/pzmap.py", line 106, in pzmap
962    ax, fig = sgrid()
963  File "/home/travis/build/python-control/python-control/control/grid.py", line 82, in sgrid
964    ax.axis["wnxneg"] = axis = ax.new_floating_axis(0, 180)
965  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/axislines.py", line 575, in new_floating_axis
966    axes=self)
967  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/grid_helper_curvelinear.py", line 350, in new_floating_axis
968    axisline = AxisArtist(axes, _helper)
969  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/axis_artist.py", line 746, in __init__
970    self._init_line()
971  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/axis_artist.py", line 887, in _init_line
972    self._axis_artist_helper.get_line(self.axes),
973  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/grid_helper_curvelinear.py", line 270, in get_line
974    self.update_lim(axes)
975  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/grid_helper_curvelinear.py", line 101, in update_lim
976    self.grid_helper.update_lim(axes)
977  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/axislines.py", line 327, in update_lim
978    self._update(x1, x2, y1, y2)
979  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/grid_helper_curvelinear.py", line 319, in _update
980    self._update_grid(x1, y1, x2, y2)
981  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/grid_helper_curvelinear.py", line 367, in _update_grid
982    self.grid_info = self.grid_finder.get_grid_info(x1, y1, x2, y2)
983  File "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/mpl_toolkits/axisartist/grid_finder.py", line 104, in get_grid_info
984    extremes = self.extreme_finder(self.inv_transform_xy, x1, y1, x2, y2)
985  File "/home/travis/build/python-control/python-control/control/grid.py", line 44, in __call__
986    self._adjust_extremes(lon_min, lon_max, lat_min, lat_max)
987AttributeError: 'ModifiedExtremeFinderCycle' object has no attribute '_adjust_extremes'
```

Apparently Matplotlib removed the private function `_adjust_extremes` between [3.2](https://matplotlib.org/3.2.1/_modules/mpl_toolkits/axisartist/angle_helper.html) and [3.3](https://matplotlib.org/_modules/mpl_toolkits/axisartist/angle_helper.html#ExtremeFinderCycle.__call__) (I could not find the commit yet. Clicking blame on github doesn't work. Their git history is weird).

The specific branch of `pzmap` and this portion of `grid.py` are not covered by the unit tests. Hence it was not discovered until now, when conda updated matplotlib and it fails in the `pvtol-nested.py`example.