### PR TITLE
fixed StateSpace for complex inputs

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -70,7 +70,7 @@ __all__ = ['StateSpace', 'ss', 'rss', 'drss', 'tf2ss', 'ssdata']
 
 # Define module default parameter values
 _statesp_defaults = {
-    'statesp.use_numpy_matrix': True,
+    'statesp.use_numpy_matrix': False,
     'statesp.default_dt': None,
     'statesp.remove_useless_states': True,
     }
@@ -98,11 +98,11 @@ def _ssmatrix(data, axis=1):
     # Convert the data into an array or matrix, as configured
     # If data is passed as a string, use (deprecated?) matrix constructor
     if config.defaults['statesp.use_numpy_matrix']:
-        arr = np.matrix(data, dtype=float)
+        arr = np.matrix(data, dtype=complex)
     elif isinstance(data, str):
-        arr = np.array(np.matrix(data, dtype=float))
+        arr = np.array(np.matrix(data, dtype=complex))
     else:
-        arr = np.array(data, dtype=float)
+        arr = np.array(data, dtype=complex)
     ndim = arr.ndim
     shape = arr.shape
 

--- a/examples/diagonalize_space_state.py
+++ b/examples/diagonalize_space_state.py
@@ -1,0 +1,42 @@
+from matplotlib import pyplot as plt
+
+import numpy as np
+from scipy.linalg import eig
+from control import step_response, StateSpace
+# Example of diagonalization of StateSpace representation
+# In this example the diagonalized system has complex values on the matrices
+
+def diagonalize(A, B, C, D):
+    eigenvectors_matrix = eig(A)[1]
+    A = np.matmul(np.matmul(np.linalg.inv(eigenvectors_matrix), A), eigenvectors_matrix)
+    B = np.matmul(np.linalg.inv(eigenvectors_matrix), B)
+    C = np.matmul(C, eigenvectors_matrix)
+    print(A)
+    print(B)
+    print(C)
+    print(D)
+    return A, B, C, D
+
+
+def main():
+    A = np.array([[0, 0, 1000], [0.1, 0, 0], [0, 0.5, 0.5]])
+    B = np.array([[0], [0], [1]])
+    C = np.array([[0, 0, 1]])
+    D = np.array([[0]])
+
+    Aw, Bw, Cw, Dw = diagonalize(A, B, C, D)
+
+    system = StateSpace(A, B, C, D, 1)
+    system_w = StateSpace(Aw, Bw, Cw, Dw, 1)
+
+    length = 20
+    plt.figure(figsize=(14, 9), dpi=100)
+    response_w = step_response(system_w, T=np.arange(length))
+    response = step_response(system, T=np.arange(length))
+    plt.plot(response[0], response[1], color="red", label="System")
+    plt.plot(response_w[0], response_w[1], color="blue", label="System W")
+    plt.xticks(np.arange(length))
+    plt.legend()
+    plt.savefig("diagonalization.png")
+
+main()


### PR DESCRIPTION
The problem was that when trying to simulate a system with complex values in the state space matrices it was by default casting to float, which generated wrong results.

I had to create a pull request to scipy as well as the dlsim function has a similar issue:
https://github.com/scipy/scipy/pull/13075

I also created an example script where this problem showed up and was fixed.