### PR TITLE
updated markov() to add tranpose keyword + default warning

### DIFF
--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -437,7 +437,7 @@ def markov(Y, U, m=None, transpose=None):
     .. [1] J.-N. Juang, M. Phan, L. G.  Horta, and R. W. Longman,
        Identification of observer/Kalman filter Markov parameters - Theory
        and experiments. Journal of Guidance Control and Dynamics, 16(2),
-       320–329, 2012. http://doi.org/10.2514/3.21006
+       320-329, 2012. http://doi.org/10.2514/3.21006
 
     Notes
     -----
@@ -542,7 +542,7 @@ def markov(Y, U, m=None, transpose=None):
     #   J.-N. Juang, M. Phan, L. G. Horta, and R. W. Longman, Identification
     #   of observer/Kalman filter Markov parameters - Theory and
     #   experiments. Journal of Guidance Control and Dynamics, 16(2),
-    #   320–329, 2012. http://doi.org/10.2514/3.21006
+    #   320-329, 2012. http://doi.org/10.2514/3.21006
     #
 
     # Create matrix of (shifted) inputs

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -22,11 +22,19 @@ class TestModelsimp(unittest.TestCase):
         np.testing.assert_array_almost_equal(hsv, hsvtrue)
 
     def testMarkov(self):
-        U = np.matrix("1.; 1.; 1.; 1.; 1.")
+        U = np.matrix("1., 1., 1., 1., 1.")
         Y = U
         M = 3
-        H = markov(Y,U,M)
+        H = markov(Y, U, M, transpose=False)
         Htrue = np.matrix("1.; 0.; 0.")
+        np.testing.assert_array_almost_equal( H, Htrue )
+
+        # Make sure that transposed data also works
+        H = markov(np.transpose(Y), np.transpose(U), M, transpose=True)
+        np.testing.assert_array_almost_equal( H, Htrue )
+
+        # Default (in v0.8.4 and below) should be transpose=True
+        H = markov(np.transpose(Y), np.transpose(U), M)
         np.testing.assert_array_almost_equal( H, Htrue )
 
     def testModredMatchDC(self):

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -22,19 +22,11 @@ class TestModelsimp(unittest.TestCase):
         np.testing.assert_array_almost_equal(hsv, hsvtrue)
 
     def testMarkov(self):
-        U = np.matrix("1., 1., 1., 1., 1.")
+        U = np.matrix("1.; 1.; 1.; 1.; 1.")
         Y = U
         M = 3
-        H = markov(Y, U, M, transpose=False)
+        H = markov(Y, U, M)
         Htrue = np.matrix("1.; 0.; 0.")
-        np.testing.assert_array_almost_equal( H, Htrue )
-
-        # Make sure that transposed data also works
-        H = markov(np.transpose(Y), np.transpose(U), M, transpose=True)
-        np.testing.assert_array_almost_equal( H, Htrue )
-
-        # Default (in v0.8.4 and below) should be transpose=True
-        H = markov(np.transpose(Y), np.transpose(U), M)
         np.testing.assert_array_almost_equal( H, Htrue )
 
     def testModredMatchDC(self):


### PR DESCRIPTION
This PR partially addresses issue #395 by adding a `transpose` keyword to the `markov` function that allows transposed inputs.  In the current release, the `markov` function is not consistent with the normal time-series convention (see discussion in #395) so a warning message is generated if `transpose` is not set explicitly to `True`.

These files will need to be updated again in the 0.9.0 release so that the default for the `transpose` keyword changes from `True` to `False`.
