### PR TITLE
reduce Python 3 testing to speed up Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.local
 
+# Test against earliest supported (Python 3) release and latest stable release
 python:
   - "3.9"
-  - "3.8"
-  - "3.7"
   - "3.6"
 
 env:
@@ -25,9 +24,6 @@ env:
 # Add optional builds that test against latest version of slycot, python
 jobs:
   include:
-    - name: "Python 3.8, slycot=source"
-      python: "3.8"
-      env: SCIPY=scipy SLYCOT=source
     - name: "Python 3.9, slycot=source, array and matrix"
       python: "3.9"
       env: SCIPY=scipy SLYCOT=source PYTHON_CONTROL_ARRAY_AND_MATRIX=1


### PR DESCRIPTION
This commit removes some of the Travis CI tests for intermediate versions of Python, as described in [PR #438 discussion](https://github.com/python-control/python-control/pull/438#discussion_r550261127).  Specifically, we keep testing against the earliest supported (Python 3) release and latest stable release, and remove intermediate versions. 

It would be useful to merge this PR quickly and rebase against it since it will cut down testing times.  Based on the last two builds:

* Current: Ran for 23 min 6 sec, Total time 37 min 18 sec
* Proposed: Ran for 13 min 47 sec, Total time 22 min 26 sec