### PR TITLE
Fix loading of defaults during pytest fixture setup

### DIFF
--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -37,7 +37,7 @@ class TestConfig:
         assert ct.config._get_param('config', 'test1', None) == 1
         assert ct.config._get_param('config', 'test1', None, 1) == 1
 
-        ct.config.defaults['config.test3'] is None
+        ct.config.defaults['config.test3'] = None
         assert ct.config._get_param('config', 'test3') is None
         assert ct.config._get_param('config', 'test3', 1) == 1
         assert ct.config._get_param('config', 'test3', None, 1) is None

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -16,7 +16,7 @@ from control.config import defaults
 from control.dtime import sample_system
 from control.lti import evalfr
 from control.statesp import (StateSpace, _convertToStateSpace, drss, rss, ss,
-                             tf2ss)
+                             tf2ss, _statesp_defaults)
 from control.tests.conftest import ismatarrayout, slycotonly
 from control.xferfcn import TransferFunction, ss2tf
 
@@ -826,3 +826,17 @@ class TestLTIConverter:
         with pytest.raises(ValueError):
             mimoss.returnScipySignalLTI(strict=True)
 
+
+class TestStateSpaceConfig:
+    """Test the configuration of the StateSpace module"""
+
+    @pytest.fixture
+    def matarrayout(self):
+        """Override autoused global fixture within this class"""
+        pass
+
+    def test_statespace_defaults(self, matarrayout):
+        """Make sure the tests are run with the configured defaults"""
+        for k, v in _statesp_defaults.items():
+            assert defaults[k] == v, \
+                "{} is {} but expected {}".format(k, defaults[k], v)


### PR DESCRIPTION
Also make matarrayout and matarrayin function scoped fixtures so
that they can set the warnings filters individually as needed for
each test.

Fixes #488