### PR TITLE
I/O system improvements: linearize, interconnect, docstrings

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -326,6 +326,13 @@ def connect(sys, Q, inputv, outputv):
     >>> Q = [[1, 2], [2, -1]]  # negative feedback interconnection
     >>> sysc = connect(sys, Q, [2], [1, 2])
 
+    Notes
+    -----
+    The :func:`~control.interconnect` function in the
+    :ref:`input/output systems <iosys-module>` module allows the use
+    of named signals and provides an alternative method for
+    interconnecting multiple systems.
+
     """
     inputv, outputv, Q = np.asarray(inputv), np.asarray(outputv), np.asarray(Q)
     # check indices

--- a/control/config.py
+++ b/control/config.py
@@ -222,6 +222,8 @@ def use_legacy_defaults(version):
         # changed iosys naming conventions
         set_defaults('iosys', state_name_delim='.',
                      duplicate_system_name_prefix='copy of ',
-                     duplicate_system_name_suffix='')
+                     duplicate_system_name_suffix='',
+                     linearized_system_name_prefix='',
+                     linearized_system_name_suffix='_linearized')
 
     return (major, minor, patch)

--- a/control/config.py
+++ b/control/config.py
@@ -215,7 +215,13 @@ def use_legacy_defaults(version):
     if major == 0 and minor < 9:
         # switched to 'array' as default for state space objects
         set_defaults('statesp', use_numpy_matrix=True)
+
         # switched to 0 (=continuous) as default timestep
         set_defaults('control', default_dt=None)
+
+        # changed iosys naming conventions
+        set_defaults('iosys', state_name_delim='.',
+                     duplicate_system_name_prefix='copy of ',
+                     duplicate_system_name_suffix='')
 
     return (major, minor, patch)

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -551,7 +551,7 @@ class InputOutputSystem(object):
             A[:, i] = (self._rhs(t, x0 + dx, u0) - F0) / eps
             C[:, i] = (self._out(t, x0 + dx, u0) - H0) / eps
 
-            # Perturb each of the input variables and compute linearization
+        # Perturb each of the input variables and compute linearization
         for i in range(ninputs):
             du = np.zeros((ninputs,))
             du[i] = eps
@@ -565,6 +565,8 @@ class InputOutputSystem(object):
 
         # Set the names the system, inputs, outputs, and states
         if copy:
+            if name is None:
+                linsys.name = self.name + "_linearized"
             linsys.ninputs, linsys.input_index = self.ninputs, \
                 self.input_index.copy()
             linsys.noutputs, linsys.output_index = \
@@ -1804,9 +1806,13 @@ def linearize(sys, xeq, ueq=[], t=0, params={}, **kw):
         for the system as default values, overriding internal defaults.
     copy : bool, Optional
         If `copy` is True, copy the names of the input signals, output signals,
-        and states to the linearized system.
+        and states to the linearized system.  If `name` is not specified,
+        the system name is set to the input system name with the string
+        '_linearized' appended.
     name : string, optional
-        Set the name of the linearized system.
+        Set the name of the linearized system.  If not specified and if `copy`
+        is `False`, a generic name <sys[id]> is generated with a unique
+        integer id.
 
     Returns
     -------

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -42,8 +42,8 @@ from .lti import isctime, isdtime, common_timebase
 from . import config
 
 __all__ = ['InputOutputSystem', 'LinearIOSystem', 'NonlinearIOSystem',
-           'InterconnectedSystem', 'input_output_response', 'find_eqpt',
-           'linearize', 'ss2io', 'tf2io', 'interconnect']
+           'InterconnectedSystem', 'LinearICSystem', 'input_output_response',
+           'find_eqpt', 'linearize', 'ss2io', 'tf2io', 'interconnect']
 
 # Define module default parameter values
 _iosys_defaults = {
@@ -110,8 +110,8 @@ class InputOutputSystem(object):
 
     Notes
     -----
-    The `InputOuputSystem` class (and its subclasses) makes use of two special
-    methods for implementing much of the work of the class:
+    The :class:`~control.InputOuputSystem` class (and its subclasses) makes
+    use of two special methods for implementing much of the work of the class:
 
     * _rhs(t, x, u): compute the right hand side of the differential or
       difference equation for the system.  This must be specified by the
@@ -137,8 +137,8 @@ class InputOutputSystem(object):
         The InputOutputSystem contructor is used to create an input/output
         object with the core information required for all input/output
         systems.  Instances of this class are normally created by one of the
-        input/output subclasses: :class:`~control.LinearIOSystem`,
-        :class:`~control.NonlinearIOSystem`,
+        input/output subclasses: :class:`~control.LinearICSystem`,
+        :class:`~control.LinearIOSystem`, :class:`~control.NonlinearIOSystem`,
         :class:`~control.InterconnectedSystem`.
 
         Parameters
@@ -242,10 +242,10 @@ class InputOutputSystem(object):
               np.zeros((sys2.ninputs, sys2.noutputs))]]
         ))
 
-        # If both systems are linear, create LinearInterconnectedSystem
+        # If both systems are linear, create LinearICSystem
         if isinstance(sys1, StateSpace) and isinstance(sys2, StateSpace):
             ss_sys = StateSpace.__mul__(sys2, sys1)
-            return LinearInterconnectedSystem(newsys, ss_sys)
+            return LinearICSystem(newsys, ss_sys)
 
         # Return the newly created InterconnectedSystem
         return newsys
@@ -294,10 +294,10 @@ class InputOutputSystem(object):
         newsys = InterconnectedSystem(
             (sys1, sys2), inplist=inplist, outlist=outlist)
 
-        # If both systems are linear, create LinearInterconnectedSystem
+        # If both systems are linear, create LinearICSystem
         if isinstance(sys1, StateSpace) and isinstance(sys2, StateSpace):
             ss_sys = StateSpace.__add__(sys2, sys1)
-            return LinearInterconnectedSystem(newsys, ss_sys)
+            return LinearICSystem(newsys, ss_sys)
 
         # Return the newly created InterconnectedSystem
         return newsys
@@ -315,10 +315,10 @@ class InputOutputSystem(object):
         newsys = InterconnectedSystem(
             (sys,), dt=sys.dt, inplist=inplist, outlist=outlist)
 
-        # If the system is linear, create LinearInterconnectedSystem
+        # If the system is linear, create LinearICSystem
         if isinstance(sys, StateSpace):
             ss_sys = StateSpace.__neg__(sys)
-            return LinearInterconnectedSystem(newsys, ss_sys)
+            return LinearICSystem(newsys, ss_sys)
 
         # Return the newly created system
         return newsys
@@ -502,7 +502,7 @@ class InputOutputSystem(object):
         if isinstance(self, StateSpace) and isinstance(other, StateSpace):
             # Special case: maintain linear systems structure
             ss_sys = StateSpace.feedback(self, other, sign=sign)
-            return LinearInterconnectedSystem(newsys, ss_sys)
+            return LinearICSystem(newsys, ss_sys)
 
         # Return the newly created system
         return newsys
@@ -697,10 +697,10 @@ class NonlinearIOSystem(InputOutputSystem):
                  name=None, **kwargs):
         """Create a nonlinear I/O system given update and output functions.
 
-        Creates an `InputOutputSystem` for a nonlinear system by specifying a
-        state update function and an output function.  The new system can be a
-        continuous or discrete time system (Note: discrete-time systems not
-        yet supported by most function.)
+        Creates an :class:`~control.InputOutputSystem` for a nonlinear system
+        by specifying a state update function and an output function.  The new
+        system can be a continuous or discrete time system (Note:
+        discrete-time systems not yet supported by most function.)
 
         Parameters
         ----------
@@ -1284,15 +1284,16 @@ class InterconnectedSystem(InputOutputSystem):
         self.noutputs = output_map.shape[0]
 
 
-class LinearInterconnectedSystem(InterconnectedSystem, LinearIOSystem):
+class LinearICSystem(InterconnectedSystem, LinearIOSystem):
     """Interconnection of a set of linear input/output systems.
 
     This class is used to implement a system that is an interconnection of
     linear input/output systems.  It has all of the structure of an
-    :class:`InterconnectedSystem`, but also maintains the requirement elements
-    of :class:`LinearIOSystem`, including the :class:`StateSpace` class
-    structure, allowing it to be passed to functions that expect a
-    :class:`StateSpace` system.
+    :class:`~control.InterconnectedSystem`, but also maintains the requirement
+    elements of :class:`~control.LinearIOSystem`, including the
+    :class:`StateSpace` class structure, allowing it to be passed to functions
+    that expect a :class:`StateSpace` system.
+
     """
 
     def __init__(self, io_sys, ss_sys=None):
@@ -1755,7 +1756,7 @@ def linearize(sys, xeq, ueq=[], t=0, params={}, **kw):
     """Linearize an input/output system at a given state and input.
 
     This function computes the linearization of an input/output system at a
-    given state and input value and returns a :class:`control.StateSpace`
+    given state and input value and returns a :class:`~control.StateSpace`
     object.  The eavaluation point need not be an equilibrium point.
 
     Parameters
@@ -1840,10 +1841,11 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
 
     This function creates a new system that is an interconnection of a set of
     input/output systems.  If all of the input systems are linear I/O systems
-    (type `LinearIOSystem`) then the resulting system will be a linear
-    interconnected I/O system (type `LinearInterconnectedSystem`) with the
-    appropriate inputs, outputs, and states.  Otherwise, an interconnected I/O
-    system (type `InterconnectedSystem`) will be created.
+    (type :class:`~control.LinearIOSystem`) then the resulting system will be
+    a linear interconnected I/O system (type :class:`~control.LinearICSystem`)
+    with the appropriate inputs, outputs, and states.  Otherwise, an
+    interconnected I/O system (type :class:`~control.InterconnectedSystem`)
+    will be created.
 
     Parameters
     ----------
@@ -1895,8 +1897,8 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
         the system input connects to only one subsystem input, a single input
         specification can be given (without the inner list).
 
-        If omitted, the input map can be specified using the `set_input_map`
-        method.
+        If omitted, the input map can be specified using the
+        :func:`~control.InterconnectedSystem.set_input_map` method.
 
     outlist : list of output connections, optional
         List of connections for how the outputs from the subsystems are mapped
@@ -1910,8 +1912,8 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
         then those signals are added together (multiplying by the any gain
         term) to form the system output.
 
-        If omitted, the output map can be specified using the `set_output_map`
-        method.
+        If omitted, the output map can be specified using the
+        :func:`~control.InterconnectedSystem.set_output_map` method.
 
     inputs : int, list of str or None, optional
         Description of the system inputs.  This can be given as an integer
@@ -1951,17 +1953,17 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
 
     Example
     -------
-    P = control.LinearIOSystem(
-        ct.rss(2, 2, 2, strictly_proper=True), name='P')
-    C = control.LinearIOSystem(control.rss(2, 2, 2), name='C')
-    S = control.InterconnectedSystem(
-        [P, C],
-        connections = [
-          ['P.u[0]', 'C.y[0]'], ['P.u[1]', 'C.y[0]'],
-          ['C.u[0]', '-P.y[0]'], ['C.u[1]', '-P.y[1]']],
-        inplist = ['C.u[0]', 'C.u[1]'],
-        outlist = ['P.y[0]', 'P.y[1]'],
-    )
+    >>> P = control.LinearIOSystem(
+    >>>        ct.rss(2, 2, 2, strictly_proper=True), name='P')
+    >>> C = control.LinearIOSystem(control.rss(2, 2, 2), name='C')
+    >>> S = control.InterconnectedSystem(
+    >>>     [P, C],
+    >>>     connections = [
+    >>>       ['P.u[0]', 'C.y[0]'], ['P.u[1]', 'C.y[0]'],
+    >>>       ['C.u[0]', '-P.y[0]'], ['C.u[1]', '-P.y[1]']],
+    >>>     inplist = ['C.u[0]', 'C.u[1]'],
+    >>>     outlist = ['P.y[0]', 'P.y[1]'],
+    >>> )
 
     Notes
     -----
@@ -1973,10 +1975,11 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
     check your use of tuples.
 
     In addition to its use for general nonlinear I/O systems, the
-    `interconnect` function allows linear systems to be interconnected using
-    named signals (compared with the `connect` function, which uses signal
-    indicies) and to be treated as both a `StateSpace` system as well as an
-    `InputOutputSystem`.
+    :func:`~control.interconnect` function allows linear systems to be
+    interconnected using named signals (compared with the
+    :func:`~control.connect` function, which uses signal indicies) and to be
+    treated as both a :class:`~control.StateSpace` system as well as an
+    :class:`~control.InputOutputSystem`.
 
     """
     newsys = InterconnectedSystem(
@@ -1986,6 +1989,6 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
 
     # If all subsystems are linear systems, maintain linear structure
     if all([isinstance(sys, LinearIOSystem) for sys in syslist]):
-        return LinearInterconnectedSystem(newsys, None)
+        return LinearICSystem(newsys, None)
 
     return newsys

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -494,7 +494,8 @@ class InputOutputSystem(object):
         # Return the newly created system
         return newsys
 
-    def linearize(self, x0, u0, t=0, params={}, eps=1e-6):
+    def linearize(self, x0, u0, t=0, params={}, eps=1e-6,
+                  name=None, copy=False, **kwargs):
         """Linearize an input/output system at a given state and input.
 
         Return the linearization of an input/output system at a given state
@@ -547,8 +548,20 @@ class InputOutputSystem(object):
             D[:, i] = (self._out(t, x0, u0 + du) - H0) / eps
 
         # Create the state space system
-        linsys = StateSpace(A, B, C, D, self.dt, remove_useless=False)
-        return LinearIOSystem(linsys)
+        linsys = LinearIOSystem(
+            StateSpace(A, B, C, D, self.dt, remove_useless=False),
+            name=name, **kwargs)
+
+        # Set the names the system, inputs, outputs, and states
+        if copy:
+            linsys.ninputs, linsys.input_index = self.ninputs, \
+                self.input_index.copy()
+            linsys.noutputs, linsys.output_index = \
+                self.noutputs, self.output_index.copy()
+            linsys.nstates, linsys.state_index = \
+                self.nstates, self.state_index.copy()
+
+        return linsys
 
     def copy(self, newname=None):
         """Make a copy of an input/output system."""
@@ -1759,6 +1772,11 @@ def linearize(sys, xeq, ueq=[], t=0, params={}, **kw):
     params : dict, optional
         Parameter values for the systems.  Passed to the evaluation functions
         for the system as default values, overriding internal defaults.
+    copy : bool, Optional
+        If `copy` is True, copy the names of the input signals, output signals,
+        and states to the linearized system.
+    name : string, optional
+        Set the name of the linearized system.
 
     Returns
     -------

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -49,7 +49,9 @@ __all__ = ['InputOutputSystem', 'LinearIOSystem', 'NonlinearIOSystem',
 _iosys_defaults = {
     'iosys.state_name_delim': '_',
     'iosys.duplicate_system_name_prefix': '',
-    'iosys.duplicate_system_name_suffix': '$copy'
+    'iosys.duplicate_system_name_suffix': '$copy',
+    'iosys.linearized_system_name_prefix': '',
+    'iosys.linearized_system_name_suffix': '$linearized'
 }
 
 
@@ -570,7 +572,10 @@ class InputOutputSystem(object):
         # Set the names the system, inputs, outputs, and states
         if copy:
             if name is None:
-                linsys.name = self.name + "_linearized"
+                linsys.name = \
+                    config.defaults['iosys.linearized_system_name_prefix'] + \
+                    self.name + \
+                    config.defaults['iosys.linearized_system_name_suffix']
             linsys.ninputs, linsys.input_index = self.ninputs, \
                 self.input_index.copy()
             linsys.noutputs, linsys.output_index = \
@@ -1781,9 +1786,13 @@ def linearize(sys, xeq, ueq=[], t=0, params={}, **kw):
         the system name is set to the input system name with the string
         '_linearized' appended.
     name : string, optional
-        Set the name of the linearized system.  If not specified and if `copy`
-        is `False`, a generic name <sys[id]> is generated with a unique
-        integer id.
+        Set the name of the linearized system.  If not specified and
+        if `copy` is `False`, a generic name <sys[id]> is generated
+        with a unique integer id.  If `copy` is `True`, the new system
+        name is determined by adding the prefix and suffix strings in
+        config.defaults['iosys.linearized_system_name_prefix'] and
+        config.defaults['iosys.linearized_system_name_suffix'], with the
+        default being to add the suffix '$linearized'.
 
     Returns
     -------
@@ -1967,6 +1976,13 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
 
     Notes
     -----
+    If a system is duplicated in the list of systems to be connected,
+    a warning is generated a copy of the system is created with the
+    name of the new system determined by adding the prefix and suffix
+    strings in config.defaults['iosys.linearized_system_name_prefix']
+    and config.defaults['iosys.linearized_system_name_suffix'], with the 
+    default being to add the suffix '$copy'$ to the system name.
+
     It is possible to replace lists in most of arguments with tuples instead,
     but strictly speaking the only use of tuples should be in the
     specification of an input- or output-signal via the tuple notation
@@ -1977,7 +1993,7 @@ def interconnect(syslist, connections=[], inplist=[], outlist=[],
     In addition to its use for general nonlinear I/O systems, the
     :func:`~control.interconnect` function allows linear systems to be
     interconnected using named signals (compared with the
-    :func:`~control.connect` function, which uses signal indicies) and to be
+    :func:`~control.connect` function, which uses signal indices) and to be
     treated as both a :class:`~control.StateSpace` system as well as an
     :class:`~control.InputOutputSystem`.
 

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -48,6 +48,7 @@ __all__ = ['InputOutputSystem', 'LinearIOSystem', 'NonlinearIOSystem',
 # Define module default parameter values
 _iosys_defaults = {}
 
+
 class InputOutputSystem(object):
     """A class for representing input/output systems.
 
@@ -75,7 +76,7 @@ class InputOutputSystem(object):
         System timebase. 0 (default) indicates continuous
         time, True indicates discrete time with unspecified sampling
         time, positive number is discrete time with specified
-        sampling time, None indicates unspecified timebase (either  
+        sampling time, None indicates unspecified timebase (either
         continuous or discrete time).
     params : dict, optional
         Parameter values for the systems.  Passed to the evaluation functions
@@ -95,7 +96,7 @@ class InputOutputSystem(object):
         System timebase. 0 (default) indicates continuous
         time, True indicates discrete time with unspecified sampling
         time, positive number is discrete time with specified
-        sampling time, None indicates unspecified timebase (either  
+        sampling time, None indicates unspecified timebase (either
         continuous or discrete time).
     params : dict, optional
         Parameter values for the systems.  Passed to the evaluation functions
@@ -118,6 +119,7 @@ class InputOutputSystem(object):
     """
 
     idCounter = 0
+
     def name_or_default(self, name=None):
         if name is None:
             name = "sys[{}]".format(InputOutputSystem.idCounter)
@@ -153,15 +155,15 @@ class InputOutputSystem(object):
             System timebase. 0 (default) indicates continuous
             time, True indicates discrete time with unspecified sampling
             time, positive number is discrete time with specified
-            sampling time, None indicates unspecified timebase (either  
+            sampling time, None indicates unspecified timebase (either
             continuous or discrete time).
         params : dict, optional
             Parameter values for the systems.  Passed to the evaluation
             functions for the system as default values, overriding internal
             defaults.
         name : string, optional
-            System name (used for specifying signals). If unspecified, a generic
-            name <sys[id]> is generated with a unique integer id.
+            System name (used for specifying signals). If unspecified, a
+            generic name <sys[id]> is generated with a unique integer id.
 
         Returns
         -------
@@ -190,11 +192,14 @@ class InputOutputSystem(object):
         """String representation of an input/output system"""
         str = "System: " + (self.name if self.name else "(None)") + "\n"
         str += "Inputs (%s): " % self.ninputs
-        for key in self.input_index: str += key + ", "
+        for key in self.input_index:
+            str += key + ", "
         str += "\nOutputs (%s): " % self.noutputs
-        for key in self.output_index: str += key + ", "
+        for key in self.output_index:
+            str += key + ", "
         str += "\nStates (%s): " % self.nstates
-        for key in self.state_index: str += key + ", "
+        for key in self.state_index:
+            str += key + ", "
         return str
 
     def __mul__(sys2, sys1):
@@ -224,10 +229,11 @@ class InputOutputSystem(object):
         # Make sure timebase are compatible
         dt = common_timebase(sys1.dt, sys2.dt)
 
-        inplist = [(0,i) for i in range(sys1.ninputs)]
-        outlist = [(1,i) for i in range(sys2.noutputs)]
+        inplist = [(0, i) for i in range(sys1.ninputs)]
+        outlist = [(1, i) for i in range(sys2.noutputs)]
         # Return the series interconnection between the systems
-        newsys = InterconnectedSystem((sys1, sys2), inplist=inplist, outlist=outlist)
+        newsys = InterconnectedSystem(
+            (sys1, sys2), inplist=inplist, outlist=outlist)
 
         #  Set up the connection map manually
         newsys.set_connect_map(np.block(
@@ -281,10 +287,11 @@ class InputOutputSystem(object):
         ninputs = sys1.ninputs
         noutputs = sys1.noutputs
 
-        inplist = [[(0,i),(1,i)] for i in range(ninputs)]
-        outlist = [[(0,i),(1,i)] for i in range(noutputs)]
+        inplist = [[(0, i), (1, i)] for i in range(ninputs)]
+        outlist = [[(0, i), (1, i)] for i in range(noutputs)]
         # Create a new system to handle the composition
-        newsys = InterconnectedSystem((sys1, sys2), inplist=inplist, outlist=outlist)
+        newsys = InterconnectedSystem(
+            (sys1, sys2), inplist=inplist, outlist=outlist)
 
         # Return the newly created system
         return newsys
@@ -303,10 +310,11 @@ class InputOutputSystem(object):
         if sys.ninputs is None or sys.noutputs is None:
             raise ValueError("Can't determine number of inputs or outputs")
 
-        inplist = [(0,i) for i in range(sys.ninputs)]
-        outlist = [(0,i,-1) for i in range(sys.noutputs)]
+        inplist = [(0, i) for i in range(sys.ninputs)]
+        outlist = [(0, i, -1) for i in range(sys.noutputs)]
         # Create a new system to hold the negation
-        newsys = InterconnectedSystem((sys,), dt=sys.dt, inplist=inplist, outlist=outlist)
+        newsys = InterconnectedSystem(
+            (sys,), dt=sys.dt, inplist=inplist, outlist=outlist)
 
         # Return the newly created system
         return newsys
@@ -476,12 +484,13 @@ class InputOutputSystem(object):
         # Make sure timebases are compatible
         dt = common_timebase(self.dt, other.dt)
 
-        inplist = [(0,i) for i in range(self.ninputs)]
-        outlist = [(0,i) for i in range(self.noutputs)]
+        inplist = [(0, i) for i in range(self.ninputs)]
+        outlist = [(0, i) for i in range(self.noutputs)]
 
         # Return the series interconnection between the systems
-        newsys = InterconnectedSystem((self, other), inplist=inplist, outlist=outlist,
-                                      params=params, dt=dt)
+        newsys = InterconnectedSystem(
+            (self, other), inplist=inplist, outlist=outlist,
+            params=params, dt=dt)
 
         #  Set up the connecton map manually
         newsys.set_connect_map(np.block(
@@ -514,8 +523,10 @@ class InputOutputSystem(object):
         ninputs = _find_size(self.ninputs, u0)
 
         # Convert x0, u0 to arrays, if needed
-        if np.isscalar(x0): x0 = np.ones((nstates,)) * x0
-        if np.isscalar(u0): u0 = np.ones((ninputs,)) * u0
+        if np.isscalar(x0):
+            x0 = np.ones((nstates,)) * x0
+        if np.isscalar(u0):
+            u0 = np.ones((ninputs,)) * u0
 
         # Compute number of outputs by evaluating the output function
         noutputs = _find_size(self.noutputs, self._out(t, x0, u0))
@@ -566,7 +577,8 @@ class InputOutputSystem(object):
     def copy(self, newname=None):
         """Make a copy of an input/output system."""
         newsys = copy.copy(self)
-        newsys.name = self.name_or_default("copy of " + self.name if not newname else newname)
+        newsys.name = self.name_or_default(
+            "copy of " + self.name if not newname else newname)
         return newsys
 
 
@@ -605,15 +617,15 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
             System timebase. 0 (default) indicates continuous
             time, True indicates discrete time with unspecified sampling
             time, positive number is discrete time with specified
-            sampling time, None indicates unspecified timebase (either  
+            sampling time, None indicates unspecified timebase (either
             continuous or discrete time).
         params : dict, optional
             Parameter values for the systems.  Passed to the evaluation
             functions for the system as default values, overriding internal
             defaults.
         name : string, optional
-            System name (used for specifying signals). If unspecified, a generic
-            name <sys[id]> is generated with a unique integer id.
+            System name (used for specifying signals). If unspecified, a
+            generic name <sys[id]> is generated with a unique integer id.
 
         Returns
         -------
@@ -729,11 +741,11 @@ class NonlinearIOSystem(InputOutputSystem):
             * dt = 0: continuous time system (default)
             * dt > 0: discrete time system with sampling period 'dt'
             * dt = True: discrete time with unspecified sampling period
-            * dt = None: no timebase specified 
+            * dt = None: no timebase specified
 
         name : string, optional
-            System name (used for specifying signals). If unspecified, a generic
-            name <sys[id]> is generated with a unique integer id.
+            System name (used for specifying signals). If unspecified, a
+            generic name <sys[id]> is generated with a unique integer id.
 
         Returns
         -------
@@ -899,23 +911,28 @@ class InterconnectedSystem(InputOutputSystem):
             * dt = 0: continuous time system (default)
             * dt > 0: discrete time system with sampling period 'dt'
             * dt = True: discrete time with unspecified sampling period
-            * dt = None: no timebase specified 
+            * dt = None: no timebase specified
 
         name : string, optional
-            System name (used for specifying signals). If unspecified, a generic
-            name <sys[id]> is generated with a unique integer id.
+            System name (used for specifying signals). If unspecified, a
+            generic name <sys[id]> is generated with a unique integer id.
 
         """
         # Convert input and output names to lists if they aren't already
-        if not isinstance(inplist, (list, tuple)): inplist = [inplist]
-        if not isinstance(outlist, (list, tuple)): outlist = [outlist]
+        if not isinstance(inplist, (list, tuple)):
+            inplist = [inplist]
+        if not isinstance(outlist, (list, tuple)):
+            outlist = [outlist]
 
         # Check to make sure all systems are consistent
         self.syslist = syslist
         self.syslist_index = {}
-        nstates = 0; self.state_offset = []
-        ninputs = 0; self.input_offset = []
-        noutputs = 0; self.output_offset = []
+        nstates = 0
+        self.state_offset = []
+        ninputs = 0
+        self.input_offset = []
+        noutputs = 0
+        self.output_offset = []
         sysobj_name_dct = {}
         sysname_count_dct = {}
         for sysidx, sys in enumerate(syslist):
@@ -943,14 +960,16 @@ class InterconnectedSystem(InputOutputSystem):
             # Duplicates are renamed sysname_1, sysname_2, etc.
             if sys in sysobj_name_dct:
                 sys = sys.copy()
-                warn("Duplicate object found in system list: %s. Making a copy" % str(sys))
+                warn("Duplicate object found in system list: %s. "
+                     "Making a copy" % str(sys))
             if sys.name is not None and sys.name in sysname_count_dct:
                 count = sysname_count_dct[sys.name]
                 sysname_count_dct[sys.name] += 1
                 sysname = sys.name + "_" + str(count)
                 sysobj_name_dct[sys] = sysname
                 self.syslist_index[sysname] = sysidx
-                warn("Duplicate name found in system list. Renamed to {}".format(sysname))
+                warn("Duplicate name found in system list. "
+                     "Renamed to {}".format(sysname))
             else:
                 sysname_count_dct[sys.name] = 1
                 sysobj_name_dct[sys] = sys.name
@@ -959,7 +978,8 @@ class InterconnectedSystem(InputOutputSystem):
         if states is None:
             states = []
             for sys, sysname in sysobj_name_dct.items():
-                states += [sysname + '.' + statename for statename in sys.state_index.keys()]
+                states += [sysname + '.' +
+                           statename for statename in sys.state_index.keys()]
 
         # Create the I/O system
         super(InterconnectedSystem, self).__init__(
@@ -989,14 +1009,16 @@ class InterconnectedSystem(InputOutputSystem):
         # Convert the input list to a matrix: maps system to subsystems
         self.input_map = np.zeros((ninputs, self.ninputs))
         for index, inpspec in enumerate(inplist):
-            if isinstance(inpspec, (int, str, tuple)): inpspec = [inpspec]
+            if isinstance(inpspec, (int, str, tuple)):
+                inpspec = [inpspec]
             for spec in inpspec:
                 self.input_map[self._parse_input_spec(spec), index] = 1
 
         # Convert the output list to a matrix: maps subsystems to system
         self.output_map = np.zeros((self.noutputs, noutputs + ninputs))
         for index, outspec in enumerate(outlist):
-            if isinstance(outspec, (int, str, tuple)): outspec = [outspec]
+            if isinstance(outspec, (int, str, tuple)):
+                outspec = [outspec]
             for spec in outspec:
                 ylist_index, gain = self._parse_output_spec(spec)
                 self.output_map[index, ylist_index] = gain
@@ -1041,7 +1063,7 @@ class InterconnectedSystem(InputOutputSystem):
 
         # Go through each system and update the right hand side for that system
         xdot = np.zeros((self.nstates,))        # Array to hold results
-        state_index = 0; input_index = 0        # Start at the beginning
+        state_index, input_index = 0, 0         # Start at the beginning
         for sys in self.syslist:
             # Update the right hand side for this subsystem
             if sys.nstates != 0:
@@ -1084,7 +1106,7 @@ class InterconnectedSystem(InputOutputSystem):
         # TODO (later): see if there is a more efficient way to compute
         cycle_count = len(self.syslist) + 1
         while cycle_count > 0:
-            state_index = 0; input_index = 0; output_index = 0
+            state_index, input_index, output_index = 0, 0, 0
             for sys in self.syslist:
                 # Compute outputs for each system from current state
                 ysys = sys._out(
@@ -1097,8 +1119,8 @@ class InterconnectedSystem(InputOutputSystem):
 
                 # Store the input in the second part of ylist
                 ylist[noutputs + input_index:
-                    noutputs + input_index + sys.ninputs] = \
-                    ulist[input_index:input_index + sys.ninputs]
+                      noutputs + input_index + sys.ninputs] = \
+                          ulist[input_index:input_index + sys.ninputs]
 
                 # Increment the index pointers
                 state_index += sys.nstates
@@ -1229,7 +1251,8 @@ class InterconnectedSystem(InputOutputSystem):
             return spec
 
         # Figure out the name of the dictionary to use
-        if dictname is None: dictname = signame + '_index'
+        if dictname is None:
+            dictname = signame + '_index'
 
         if isinstance(spec, str):
             # If we got a dotted string, break up into pieces
@@ -1415,7 +1438,8 @@ def input_output_response(sys, T, U=0., X0=0, params={}, method='RK45',
         for i in range(len(T)):
             u = U[i] if len(U.shape) == 1 else U[:, i]
             y[:, i] = sys._out(T[i], [], u)
-        if (squeeze): y = np.squeeze(y)
+        if squeeze:
+            y = np.squeeze(y)
         if return_x:
             return T, y, []
         else:
@@ -1495,7 +1519,8 @@ def input_output_response(sys, T, U=0., X0=0, params={}, method='RK45',
         raise TypeError("Can't determine system type")
 
     # Get rid of extra dimensions in the output, of desired
-    if (squeeze): y = np.squeeze(y)
+    if squeeze:
+        y = np.squeeze(y)
 
     if return_x:
         return soln.t, y, soln.y
@@ -1580,9 +1605,12 @@ def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
     noutputs = _find_size(sys.noutputs, y0)
 
     # Convert x0, u0, y0 to arrays, if needed
-    if np.isscalar(x0): x0 = np.ones((nstates,)) * x0
-    if np.isscalar(u0): u0 = np.ones((ninputs,)) * u0
-    if np.isscalar(y0): y0 = np.ones((ninputs,)) * y0
+    if np.isscalar(x0):
+        x0 = np.ones((nstates,)) * x0
+    if np.isscalar(u0):
+        u0 = np.ones((ninputs,)) * u0
+    if np.isscalar(y0):
+        y0 = np.ones((ninputs,)) * y0
 
     # Discrete-time not yet supported
     if isdtime(sys, strict=True):
@@ -1718,7 +1746,8 @@ def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
 
             # Compute the update and output maps
             dx = sys._rhs(t, x, u) - dx0
-            if dtime: dx -= x           # TODO: check
+            if dtime:
+                dx -= x           # TODO: check
             dy = sys._out(t, x, u) - y0
 
             # Map the results into the constrained variables
@@ -1736,7 +1765,8 @@ def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
         z = (x, u, sys._out(t, x, u))
 
     # Return the result based on what the user wants and what we found
-    if not return_y: z = z[0:2]     # Strip y from result if not desired
+    if not return_y:
+        z = z[0:2]              # Strip y from result if not desired
     if return_result:
         # Return whatever we got, along with the result dictionary
         return z + (result,)
@@ -1810,7 +1840,8 @@ def _find_size(sysval, vecval):
 
 
 # Convert a state space system into an input/output system (wrapper)
-def ss2io(*args, **kw): return LinearIOSystem(*args, **kw)
+def ss2io(*args, **kw):
+    return LinearIOSystem(*args, **kw)
 ss2io.__doc__ = LinearIOSystem.__init__.__doc__
 
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1264,7 +1264,7 @@ def _convertToStateSpace(sys, **kw):
 
 
 # TODO: add discrete time option
-def _rss_generate(states, inputs, outputs, type):
+def _rss_generate(states, inputs, outputs, type, strictly_proper=False):
     """Generate a random state space.
 
     This does the actual random state space generation expected from rss and
@@ -1374,7 +1374,7 @@ def _rss_generate(states, inputs, outputs, type):
     # Apply masks.
     B = B * Bmask
     C = C * Cmask
-    D = D * Dmask
+    D = D * Dmask if not strictly_proper else zeros(D.shape)
 
     return StateSpace(A, B, C, D)
 
@@ -1649,7 +1649,7 @@ def tf2ss(*args):
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
 
 
-def rss(states=1, outputs=1, inputs=1):
+def rss(states=1, outputs=1, inputs=1, strictly_proper=False):
     """
     Create a stable *continuous* random state space object.
 
@@ -1661,6 +1661,9 @@ def rss(states=1, outputs=1, inputs=1):
         Number of system inputs
     outputs : integer
         Number of system outputs
+    strictly_proper : bool, optional
+        If set to 'True', returns a proper system (no direct term).  Default
+        value is 'False'.
 
     Returns
     -------
@@ -1684,10 +1687,11 @@ def rss(states=1, outputs=1, inputs=1):
 
     """
 
-    return _rss_generate(states, inputs, outputs, 'c')
+    return _rss_generate(states, inputs, outputs, 'c',
+                         strictly_proper=strictly_proper)
 
 
-def drss(states=1, outputs=1, inputs=1):
+def drss(states=1, outputs=1, inputs=1, strictly_proper=False):
     """
     Create a stable *discrete* random state space object.
 
@@ -1722,7 +1726,8 @@ def drss(states=1, outputs=1, inputs=1):
 
     """
 
-    return _rss_generate(states, inputs, outputs, 'd')
+    return _rss_generate(states, inputs, outputs, 'd',
+                         strictly_proper=strictly_proper)
 
 
 def ssdata(sys):

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -219,8 +219,11 @@ class TestIOSys:
 
         # If we copy signal names w/out a system name, append '_linearized'
         ct.use_legacy_defaults('0.8.4')
+        ct.config.use_numpy_matrix(False)       # get rid of warning messages
         linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True)
         assert linearized.name == kincar.name + '_linearized'
+
+        ct.reset_defaults()
         ct.use_legacy_defaults('0.9.0')
         linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True)
         assert linearized.name == kincar.name + '$linearized'

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1293,7 +1293,7 @@ def test_linear_interconnection():
             ['sys2.y[1]'],
             ['sys2.u[1]']])
     assert isinstance(nl_connect, ios.InterconnectedSystem)
-    assert not isinstance(nl_connect, ios.LinearInterconnectedSystem)
+    assert not isinstance(nl_connect, ios.LinearICSystem)
 
     # Now take its linearization
     ss_connect = nl_connect.linearize(0, 0)
@@ -1313,7 +1313,7 @@ def test_linear_interconnection():
             ['sys2.y[1]'],
             ['sys2.u[1]']])
     assert isinstance(io_connect, ios.InterconnectedSystem)
-    assert isinstance(io_connect, ios.LinearInterconnectedSystem)
+    assert isinstance(io_connect, ios.LinearICSystem)
     assert isinstance(io_connect, ios.LinearIOSystem)
     assert isinstance(io_connect, ct.StateSpace)
 

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -218,8 +218,13 @@ class TestIOSys:
         assert linearized.find_state('theta') == 2
 
         # If we copy signal names w/out a system name, append '_linearized'
+        ct.use_legacy_defaults('0.8.4')
         linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True)
         assert linearized.name == kincar.name + '_linearized'
+        ct.use_legacy_defaults('0.9.0')
+        linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True)
+        assert linearized.name == kincar.name + '$linearized'
+        ct.reset_defaults()
 
         # If copy is False, signal names should not be copied
         lin_nocopy = kincar.linearize(0, 0, copy=False)

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -204,7 +204,6 @@ class TestIOSys:
             linearized.C, [[1, 0, 0], [0, 1, 0]])
         np.testing.assert_array_almost_equal(linearized.D, np.zeros((2,2)))
 
-
     def test_linearize_named_signals(self, kincar):
         # Full form of the call
         linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True,
@@ -286,6 +285,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y,atol=0.002,rtol=0.)
 
+    @noscipy0
     @pytest.mark.parametrize(
         "connections, inplist, outlist",
         [pytest.param([[(1, 0), (0, 0, 1)]], [[(0, 0, 1)]], [[(1, 0, 1)]],
@@ -328,6 +328,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y, atol=0.002, rtol=0.)
 
+    @noscipy0
     @pytest.mark.parametrize(
         "connections, inplist, outlist",
         [pytest.param([['sys2.u[0]', 'sys1.y[0]']],

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -205,7 +205,6 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(linearized.D, np.zeros((2,2)))
 
     @pytest.mark.usefixtures("editsdefaults")
-    @matrixfilter               # avoid np.matrix warnings in v0.8.4
     def test_linearize_named_signals(self, kincar):
         # Full form of the call
         linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True,
@@ -225,6 +224,7 @@ class TestIOSys:
 
         # Test legacy version as well
         ct.use_legacy_defaults('0.8.4')
+        ct.config.use_numpy_matrix(False)       # np.matrix deprecated
         linearized = kincar.linearize([0, 0, 0], [0, 0], copy=True)
         assert linearized.name == kincar.name + '_linearized'
 
@@ -954,12 +954,12 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(ss_feedback.D, lin_feedback.D)
 
     @pytest.mark.usefixtures("editsdefaults")
-    @matrixfilter               # avoid np.matrix warnings in v0.8.4
     def test_sys_naming_convention(self, tsys):
         """Enforce generic system names 'sys[i]' to be present when systems are
         created without explicit names."""
 
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
+        ct.config.use_numpy_matrix(False)       # np.matrix deprecated
         ct.InputOutputSystem.idCounter = 0
         sys = ct.LinearIOSystem(tsys.mimo_linsys1)
 
@@ -1014,7 +1014,6 @@ class TestIOSys:
             unnamedsys1 * unnamedsys1
 
     @pytest.mark.usefixtures("editsdefaults")
-    @matrixfilter               # avoid np.matrix warnings in v0.8.4
     def test_signals_naming_convention_0_8_4(self, tsys):
         """Enforce generic names to be present when systems are created
         without explicit signal names:
@@ -1024,6 +1023,7 @@ class TestIOSys:
         """
 
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
+        ct.config.use_numpy_matrix(False)       # np.matrix deprecated
         ct.InputOutputSystem.idCounter = 0
         sys = ct.LinearIOSystem(tsys.mimo_linsys1)
         for statename in ["x[0]", "x[1]"]:
@@ -1216,7 +1216,6 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(io_S.D, ss_S.D)
 
     @pytest.mark.usefixtures("editsdefaults")
-    @matrixfilter               # avoid np.matrix warnings in v0.8.4
     def test_duplicates(self, tsys):
         nlios = ios.NonlinearIOSystem(lambda t, x, u, params: x,
                                       lambda t, x, u, params: u * u,
@@ -1229,6 +1228,7 @@ class TestIOSys:
 
         # Nonduplicate objects
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
+        ct.config.use_numpy_matrix(False)       # np.matrix deprecated
         nlios1 = nlios.copy()
         nlios2 = nlios.copy()
         with pytest.warns(UserWarning, match="Duplicate name"):

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -809,7 +809,7 @@ class TransferFunction(LTI):
                 continuous (0) or discrete (True or > 0).
             False:
                 if `tfobject.dt` is None, continuous time
-                :class:`scipy.signal.lti`objects are returned
+                :class:`scipy.signal.lti` objects are returned
 
         Returns
         -------

--- a/doc/classes.rst
+++ b/doc/classes.rst
@@ -16,18 +16,17 @@ these directly.
    TransferFunction
    StateSpace
    FrequencyResponseData
-   ~iosys.InputOutputSystem
+   InputOutputSystem
 
 Input/output system subclasses
 ==============================
-.. currentmodule:: control.iosys
-
 Input/output systems are accessed primarily via a set of subclasses
 that allow for linear, nonlinear, and interconnected elements:
 
 .. autosummary::
    :toctree: generated/
 
+   InterconnectedSystem
+   LinearICSystem
    LinearIOSystem
    NonlinearIOSystem
-   InterconnectedSystem

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -139,11 +139,12 @@ Nonlinear system support
 .. autosummary::
    :toctree: generated/
 
-   ~iosys.find_eqpt
-   ~iosys.linearize
-   ~iosys.input_output_response
-   ~iosys.ss2io
-   ~iosys.tf2io
+   find_eqpt
+   interconnect
+   linearize
+   input_output_response
+   ss2io
+   tf2io
    flatsys.point_to_point
 
 .. _utility-and-conversions:

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -4,10 +4,6 @@
 Input/output systems
 ********************
 
-.. automodule:: control.iosys
-   :no-members:
-   :no-inherited-members:
-
 Module usage
 ============
 
@@ -40,16 +36,16 @@ equation) and and output function (computes the outputs from the state)::
   io_sys = NonlinearIOSystem(updfcn, outfcn, inputs=M, outputs=P, states=N)
 
 More complex input/output systems can be constructed by using the
-:class:`~control.InterconnectedSystem` class, which allows a collection of
-input/output subsystems to be combined with internal connections between the
-subsystems and a set of overall system inputs and outputs that link to the
-subsystems::
+:func:`~control.interconnect` function, which allows a collection of
+input/output subsystems to be combined with internal connections
+between the subsystems and a set of overall system inputs and outputs
+that link to the subsystems::
 
-    steering = ct.InterconnectedSystem(
-        (plant, controller), name='system',
-        connections=(('controller.e', '-plant.y')),
-        inplist=('controller.e'), inputs='r',
-        outlist=('plant.y'), outputs='y')
+    steering = ct.interconnect(
+        [plant, controller], name='system',
+        connections=[['controller.e', '-plant.y']],
+        inplist=['controller.e'], inputs='r',
+        outlist=['plant.y'], outputs='y')
 
 Interconnected systems can also be created using block diagram manipulations
 such as the :func:`~control.series`, :func:`~control.parallel`, and
@@ -160,19 +156,19 @@ The input to the controller is `u`, consisting of the vector of hare and lynx
 populations followed by the desired lynx population.
 
 To connect the controller to the predatory-prey model, we create an
-`InterconnectedSystem`:
+:class:`~control.InterconnectedSystem`:
 
 .. code-block:: python
 
-  io_closed = control.InterconnectedSystem(
-    (io_predprey, io_controller),	# systems
-    connections=(
-      ('predprey.u', 'control.y[0]'),
-      ('control.u1',  'predprey.H'),
-      ('control.u2',  'predprey.L')
-    ),
-    inplist=('control.Ld'),
-    outlist=('predprey.H', 'predprey.L', 'control.y[0]')
+  io_closed = control.interconnect(
+    [io_predprey, io_controller],	# systems
+    connections=[
+      ['predprey.u', 'control.y[0]'],
+      ['control.u1',  'predprey.H'],
+      ['control.u2',  'predprey.L']
+    ],
+    inplist=['control.Ld'],
+    outlist=['predprey.H', 'predprey.L', 'control.y[0]']
   )
        
 Finally, we simulate the closed loop system:
@@ -200,18 +196,20 @@ Input/output system classes
 ---------------------------
 .. autosummary::
    
-   InputOutputSystem
-   InterconnectedSystem
-   LinearIOSystem
-   NonlinearIOSystem
+   ~control.InputOutputSystem
+   ~control.InterconnectedSystem
+   ~control.LinearICSystem
+   ~control.LinearIOSystem
+   ~control.NonlinearIOSystem
 
 Input/output system functions
 -----------------------------
 .. autosummary::
 
-   find_eqpt
-   linearize
-   input_output_response
-   ss2io
-   tf2io
+   ~control.find_eqpt
+   ~control.linearize
+   ~control.input_output_response
+   ~control.interconnect
+   ~control.ss2io
+   ~control.tf2io
 

--- a/examples/cruise-control.py
+++ b/examples/cruise-control.py
@@ -141,8 +141,8 @@ control_tf = ct.tf2io(
 cruise_tf = ct.InterconnectedSystem(
     (control_tf, vehicle), name='cruise',
     connections = (
-        ('control.u', '-vehicle.v'),
-        ('vehicle.u', 'control.y')),
+        ['control.u', '-vehicle.v'],
+        ['vehicle.u', 'control.y']),
     inplist = ('control.u', 'vehicle.gear', 'vehicle.theta'),
     inputs = ('vref', 'gear', 'theta'),
     outlist = ('vehicle.v', 'vehicle.u'),
@@ -279,8 +279,8 @@ control_pi = ct.NonlinearIOSystem(
 cruise_pi = ct.InterconnectedSystem(
     (vehicle, control_pi), name='cruise',
     connections=(
-        ('vehicle.u', 'control.u'),
-        ('control.v', 'vehicle.v')),
+        ['vehicle.u', 'control.u'],
+        ['control.v', 'vehicle.v']),
     inplist=('control.vref', 'vehicle.gear', 'vehicle.theta'),
     outlist=('control.u', 'vehicle.v'), outputs=['u', 'v'])
 
@@ -404,9 +404,9 @@ control_sf = ct.NonlinearIOSystem(
 cruise_sf = ct.InterconnectedSystem(
     (vehicle, control_sf), name='cruise',
     connections=(
-        ('vehicle.u', 'control.u'),
-        ('control.x', 'vehicle.v'),
-        ('control.y', 'vehicle.v')),
+        ['vehicle.u', 'control.u'],
+        ['control.x', 'vehicle.v'],
+        ['control.y', 'vehicle.v']),
     inplist=('control.r', 'vehicle.gear', 'vehicle.theta'),
     outlist=('control.u', 'vehicle.v'), outputs=['u', 'v'])
 

--- a/examples/steering-gainsched.py
+++ b/examples/steering-gainsched.py
@@ -143,13 +143,13 @@ steering = ct.InterconnectedSystem(
 
     # Interconnections between  subsystems
     connections=(
-        ('controller.ex', 'trajgen.xd', '-vehicle.x'),
-        ('controller.ey', 'trajgen.yd', '-vehicle.y'),
-        ('controller.etheta', 'trajgen.thetad', '-vehicle.theta'),
-        ('controller.vd', 'trajgen.vd'),
-        ('controller.phid', 'trajgen.phid'),
-        ('vehicle.v', 'controller.v'),
-        ('vehicle.phi', 'controller.phi')
+        ['controller.ex', 'trajgen.xd', '-vehicle.x'],
+        ['controller.ey', 'trajgen.yd', '-vehicle.y'],
+        ['controller.etheta', 'trajgen.thetad', '-vehicle.theta'],
+        ['controller.vd', 'trajgen.vd'],
+        ['controller.phid', 'trajgen.phid'],
+        ['vehicle.v', 'controller.v'],
+        ['vehicle.phi', 'controller.phi']
     ),
 
     # System inputs


### PR DESCRIPTION
This PR implements a couple of enhancements for the I/O systems package, mainly related to linear systems:

* The `linearize` command now preserves signal names for the linearized system, so that you can use signal names when forming and `InterconnectedSystem`.

* Interconnections of `LinearIOSystem`s are now treated as `LinearICSystems` (a subclass of `InterconnectedSystem` and `LinearIOSystem`) so that `StateSpace` functions will still work on them and they still keep track of the underlying interconnection structure.

* There is now an `interconnect` function that allows the construction of an `LinearICSystems ` or a `InterconnectedSystem` depending on whether the subsystems are all linear or not.  This basically serves as a replacement for the `connect` function for LTI systems and allows named interconnection of linear or nonlinear systems.

In addition, I cleaned up the description for how to specify interconnections so that tuples are only used for the lowest level signal descriptions; everything else is a list.  (Tuples will still work, but there are some ambiguities when you use tuples since `outlist=(3, 2, 1)` could be interpreted as a signal description for a single signal (subsystem 3, signal 2, with gain 1) or as a list of signals for SISO systems (the single outputs from subsystems 3, 2, and 1).

Additional small changes:

* The `rss` and `drss` functions now allow the `strictly_proper` keyword, which sets the D matrix to zero.  (I needed this to avoid occasional errors in unit tests for the `interconnect` function.

* Added some configuration variables that allow you to change the way that states in interconnected systems are named (default was `sys.state` but is `sys_state` for 0.9+) and the way that duplicate systems are named (default was `copy of sys` but is `sys$copy` for 0.9+).

* Added unit tests for all of the above.

* Updated examples to match the newly documented conventions for signal list specification.