### PR TITLE
Standardize squeeze processing in frequency response functions

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -16,7 +16,7 @@ __all__ = ['defaults', 'set_defaults', 'reset_defaults',
 # Package level default values
 _control_defaults = {
     'control.default_dt': 0,
-    'control.squeeze': True
+    'control.squeeze_frequency_response': True
 }
 defaults = dict(_control_defaults)
 

--- a/control/config.py
+++ b/control/config.py
@@ -15,7 +15,8 @@ __all__ = ['defaults', 'set_defaults', 'reset_defaults',
 
 # Package level default values
 _control_defaults = {
-    'control.default_dt':0
+    'control.default_dt': 0,
+    'control.squeeze': True
 }
 defaults = dict(_control_defaults)
 

--- a/control/config.py
+++ b/control/config.py
@@ -16,7 +16,7 @@ __all__ = ['defaults', 'set_defaults', 'reset_defaults',
 # Package level default values
 _control_defaults = {
     'control.default_dt': 0,
-    'control.squeeze_frequency_response': True
+    'control.squeeze_frequency_response': None
 }
 defaults = dict(_control_defaults)
 

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -358,7 +358,7 @@ second has %i." % (self.outputs, other.outputs))
         squeeze : bool, optional (default=True)
             If True and the system is single-input single-output (SISO),
             return a 1D array rather than a 3D array.  Default value (True)
-            set by config.defaults['control.squeeze'].
+            set by config.defaults['control.squeeze_frequency_response'].
 
         Returns
         -------
@@ -369,7 +369,7 @@ second has %i." % (self.outputs, other.outputs))
         """
         # Set value of squeeze argument if not set
         if squeeze is None:
-            squeeze = config.defaults['control.squeeze']
+            squeeze = config.defaults['control.squeeze_frequency_response']
 
         omega_array = np.array(omega, ndmin=1) # array-like version of omega
         if any(omega_array.imag > 0):
@@ -411,7 +411,7 @@ second has %i." % (self.outputs, other.outputs))
         squeeze : bool, optional (default=True)
             If True and the system is single-input single-output (SISO),
             return a 1D array rather than a 3D array.  Default value (True)
-            set by config.defaults['control.squeeze'].
+            set by config.defaults['control.squeeze_frequency_response'].
 
         Returns
         -------
@@ -429,7 +429,7 @@ second has %i." % (self.outputs, other.outputs))
         """
         # Set value of squeeze argument if not set
         if squeeze is None:
-            squeeze = config.defaults['control.squeeze']
+            squeeze = config.defaults['control.squeeze_frequency_response']
 
         if any(abs(np.array(s, ndmin=1).real) > 0):
             raise ValueError("__call__: FRD systems can only accept "

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -441,10 +441,10 @@ second has %i." % (self.outputs, other.outputs))
             frequency values.
         """
         # Make sure that we are operating on a simple list
-        if len(np.array(s, ndmin=1).shape) > 1:
+        if len(np.atleast_1d(s).shape) > 1:
             raise ValueError("input list must be 1D")
 
-        if any(abs(np.array(s, ndmin=1).real) > 0):
+        if any(abs(np.atleast_1d(s).real) > 0):
             raise ValueError("__call__: FRD systems can only accept "
                             "purely imaginary frequencies")
 

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -50,7 +50,7 @@ import numpy as np
 from numpy import angle, array, empty, ones, \
     real, imag, absolute, eye, linalg, where, dot, sort
 from scipy.interpolate import splprep, splev
-from .lti import LTI
+from .lti import LTI, _process_frequency_response
 from . import config
 
 __all__ = ['FrequencyResponseData', 'FRD', 'frd']
@@ -391,14 +391,10 @@ second has %i." % (self.outputs, other.outputs))
                     for k, w in enumerate(omega_array):
                         frraw = splev(w, self.ifunc[i, j], der=0)
                         out[i, j, k] = frraw[0] + 1.0j * frraw[1]
-        if not hasattr(omega, '__len__'):
-            # omega is a scalar, squeeze down array along last dim
-            out = np.squeeze(out, axis=2)
-        if squeeze and self.issiso():
-            out = out[0][0]
-        return out
 
-    def __call__(self, s, squeeze=True):
+        return _process_frequency_response(self, omega, out, squeeze=squeeze)
+
+    def __call__(self, s, squeeze=None):
         """Evaluate system's transfer function at complex frequencies.
         
         Returns the complex frequency response `sys(s)` of system `sys` with

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -51,6 +51,7 @@ from numpy import angle, array, empty, ones, \
     real, imag, absolute, eye, linalg, where, dot, sort
 from scipy.interpolate import splprep, splev
 from .lti import LTI
+from . import config
 
 __all__ = ['FrequencyResponseData', 'FRD', 'frd']
 
@@ -343,7 +344,7 @@ second has %i." % (self.outputs, other.outputs))
     # G(s) for a transfer function and G(omega) for an FRD object.
     # update Sawyer B. Fuller 2020.08.14: __call__ added to provide a uniform
     # interface to systems in general and the lti.frequency_response method
-    def eval(self, omega, squeeze=True):
+    def eval(self, omega, squeeze=None):
         """Evaluate a transfer function at angular frequency omega.
 
         Note that a "normal" FRD only returns values for which there is an
@@ -355,15 +356,21 @@ second has %i." % (self.outputs, other.outputs))
         omega : float or array_like
             Frequencies in radians per second
         squeeze : bool, optional (default=True)
-            If True and `sys` is single input single output (SISO), returns a
-            1D array rather than a 3D array.
+            If True and the system is single-input single-output (SISO),
+            return a 1D array rather than a 3D array.  Default value (True)
+            set by config.defaults['control.squeeze'].
 
         Returns
         -------
         fresp : (self.outputs, self.inputs, len(x)) or (len(x), ) complex ndarray
-            The frequency response of the system. Array is ``len(x)`` if and only
-            if system is SISO and ``squeeze=True``.
+            The frequency response of the system. Array is ``len(x)``
+            if and only if system is SISO and ``squeeze=True``.
+
         """
+        # Set value of squeeze argument if not set
+        if squeeze is None:
+            squeeze = config.defaults['control.squeeze']
+
         omega_array = np.array(omega, ndmin=1) # array-like version of omega
         if any(omega_array.imag > 0):
             raise ValueError("FRD.eval can only accept real-valued omega")
@@ -406,8 +413,9 @@ second has %i." % (self.outputs, other.outputs))
         s : complex scalar or array_like
             Complex frequencies
         squeeze : bool, optional (default=True)
-            If True and `sys` is single input single output (SISO), i.e. `m=1`,
-            `p=1`, return a 1D array rather than a 3D array.
+            If True and the system is single-input single-output (SISO),
+            return a 1D array rather than a 3D array.  Default value (True)
+            set by config.defaults['control.squeeze'].
 
         Returns
         -------
@@ -423,6 +431,10 @@ second has %i." % (self.outputs, other.outputs))
             :class:`FrequencyDomainData` systems are only defined at imaginary
             frequency values.
         """
+        # Set value of squeeze argument if not set
+        if squeeze is None:
+            squeeze = config.defaults['control.squeeze']
+
         if any(abs(np.array(s, ndmin=1).real) > 0):
             raise ValueError("__call__: FRD systems can only accept "
                             "purely imaginary frequencies")

--- a/control/lti.py
+++ b/control/lti.py
@@ -111,7 +111,7 @@ class LTI:
         Z = -real(splane_poles)/wn
         return wn, Z, poles
 
-    def frequency_response(self, omega, squeeze=True):
+    def frequency_response(self, omega, squeeze=None):
         """Evaluate the linear time-invariant system at an array of angular
         frequencies.
 
@@ -124,18 +124,19 @@ class LTI:
 
              G(exp(j*omega*dt)) = mag*exp(j*phase).
 
-        In general the system may be multiple input, multiple output (MIMO), where
-        `m = self.inputs` number of inputs and `p = self.outputs` number of
-        outputs.
+        In general the system may be multiple input, multiple output (MIMO),
+        where `m = self.inputs` number of inputs and `p = self.outputs` number
+        of outputs.
 
         Parameters
         ----------
         omega : float or array_like
             A list, tuple, array, or scalar value of frequencies in
             radians/sec at which the system will be evaluated.
-        squeeze : bool, optional (default=True)
-            If True and the system is single input single output (SISO), i.e. `m=1`,
-            `p=1`, return a 1D array rather than a 3D array.
+        squeeze : bool, optional
+            If True and the system is single-input single-output (SISO),
+            return a 1D array rather than a 3D array.  Default value (True)
+            set by config.defaults['control.squeeze'].
 
         Returns
         -------
@@ -147,7 +148,7 @@ class LTI:
             The wrapped phase in radians of the system frequency response.
         omega : ndarray
             The (sorted) frequencies at which the response was evaluated.
-            
+
         """
         omega = np.sort(np.array(omega, ndmin=1))
         if isdtime(self, strict=True):
@@ -463,9 +464,8 @@ def damp(sys, doprint=True):
                       (p.real, p.imag, d, w))
     return wn, damping, poles
 
-def evalfr(sys, x, squeeze=True):
-    """
-    Evaluate the transfer function of an LTI system for complex frequency x.
+def evalfr(sys, x, squeeze=None):
+    """Evaluate the transfer function of an LTI system for complex frequency x.
 
     Returns the complex frequency response `sys(x)` where `x` is `s` for
     continuous-time systems and `z` for discrete-time systems, with
@@ -484,8 +484,9 @@ def evalfr(sys, x, squeeze=True):
     x : complex scalar or array_like
         Complex frequency(s)
     squeeze : bool, optional (default=True)
-        If True and `sys` is single input single output (SISO), i.e. `m=1`,
-        `p=1`, return a 1D array rather than a 3D array.
+        If True and the system is single-input single-output (SISO), return a
+        1D array rather than a 3D array.  Default value (True) set by
+        config.defaults['control.squeeze'].
 
     Returns
     -------
@@ -511,12 +512,12 @@ def evalfr(sys, x, squeeze=True):
     >>> # This is the transfer function matrix evaluated at s = i.
 
     .. todo:: Add example with MIMO system
+
     """
     return sys.__call__(x, squeeze=squeeze)
 
-def freqresp(sys, omega, squeeze=True):
-    """
-    Frequency response of an LTI system at multiple angular frequencies.
+def freqresp(sys, omega, squeeze=None):
+    """Frequency response of an LTI system at multiple angular frequencies.
     
     In general the system may be multiple input, multiple output (MIMO), where
     `m = sys.inputs` number of inputs and `p = sys.outputs` number of
@@ -531,8 +532,9 @@ def freqresp(sys, omega, squeeze=True):
         evaluated. The list can be either a python list or a numpy array
         and will be sorted before evaluation.
     squeeze : bool, optional (default=True)
-        If True and `sys` is single input, single output (SISO), returns
-        1D array rather than a 3D array.
+        If True and the system is single-input single-output (SISO), return a
+        1D array rather than a 3D array.  Default value (True) set by
+        config.defaults['control.squeeze'].
 
     Returns
     -------
@@ -579,6 +581,7 @@ def freqresp(sys, omega, squeeze=True):
         #>>> # input to the 1st output, and the phase (in radians) of the
         #>>> # frequency response from the 1st input to the 2nd output, for
         #>>> # s = 0.1i, i, 10i.
+
     """
     return sys.frequency_response(omega, squeeze=squeeze)
 

--- a/control/lti.py
+++ b/control/lti.py
@@ -15,6 +15,7 @@ common_timebase()
 import numpy as np
 from numpy import absolute, real, angle, abs
 from warnings import warn
+from . import config
 
 __all__ = ['issiso', 'timebase', 'common_timebase', 'timebaseEqual',
            'isdtime', 'isctime', 'pole', 'zero', 'damp', 'evalfr',
@@ -596,3 +597,18 @@ def dcgain(sys):
         at the origin
     """
     return sys.dcgain()
+
+
+# Process frequency responses in a uniform way
+def _process_frequency_response(sys, omega, out, squeeze=None):
+    if not hasattr(omega, '__len__'):
+        # received a scalar x, squeeze down the array along last dim
+        out = np.squeeze(out, axis=2)
+
+    # Get rid of unneeded dimensions
+    if squeeze is None:
+        squeeze = config.defaults['control.squeeze']
+    if squeeze and sys.issiso():
+        return out[0][0]
+    else:
+        return out

--- a/control/lti.py
+++ b/control/lti.py
@@ -137,7 +137,7 @@ class LTI:
         squeeze : bool, optional
             If True and the system is single-input single-output (SISO),
             return a 1D array rather than a 3D array.  Default value (True)
-            set by config.defaults['control.squeeze'].
+            set by config.defaults['control.squeeze_frequency_response'].
 
         Returns
         -------
@@ -487,7 +487,7 @@ def evalfr(sys, x, squeeze=None):
     squeeze : bool, optional (default=True)
         If True and the system is single-input single-output (SISO), return a
         1D array rather than a 3D array.  Default value (True) set by
-        config.defaults['control.squeeze'].
+        config.defaults['control.squeeze_frequency_response'].
 
     Returns
     -------
@@ -535,7 +535,7 @@ def freqresp(sys, omega, squeeze=None):
     squeeze : bool, optional (default=True)
         If True and the system is single-input single-output (SISO), return a
         1D array rather than a 3D array.  Default value (True) set by
-        config.defaults['control.squeeze'].
+        config.defaults['control.squeeze_frequency_response'].
 
     Returns
     -------
@@ -607,7 +607,7 @@ def _process_frequency_response(sys, omega, out, squeeze=None):
 
     # Get rid of unneeded dimensions
     if squeeze is None:
-        squeeze = config.defaults['control.squeeze']
+        squeeze = config.defaults['control.squeeze_frequency_response']
     if squeeze and sys.issiso():
         return out[0][0]
     else:

--- a/control/margins.py
+++ b/control/margins.py
@@ -294,25 +294,25 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
             # frequency for gain margin: phase crosses -180 degrees
             w_180 = _poly_iw_real_crossing(num_iw, den_iw, epsw)
             with np.errstate(all='ignore'):  # den=0 is okay
-                w180_resp = evalfr(sys, 1J * w_180, squeeze=True)
+                w180_resp = evalfr(sys, 1J * w_180)
 
             # frequency for phase margin : gain crosses magnitude 1
             wc = _poly_iw_mag1_crossing(num_iw, den_iw, epsw)
-            wc_resp = evalfr(sys, 1J * wc, squeeze=True)
+            wc_resp = evalfr(sys, 1J * wc)
 
             # stability margin
             wstab = _poly_iw_wstab(num_iw, den_iw, epsw)
-            ws_resp = evalfr(sys, 1J * wstab, squeeze=True)
+            ws_resp = evalfr(sys, 1J * wstab)
 
         else:  # Discrete Time
             zargs = _poly_z_invz(sys)
             # gain margin
             z, w_180 = _poly_z_real_crossing(*zargs, epsw=epsw)
-            w180_resp = evalfr(sys, z, squeeze=True)
+            w180_resp = evalfr(sys, z)
 
             # phase margin
             z, wc = _poly_z_mag1_crossing(*zargs, epsw=epsw)
-            wc_resp = evalfr(sys, z, squeeze=True)
+            wc_resp = evalfr(sys, z)
 
             # stability margin
             z, wstab = _poly_z_wstab(*zargs, epsw=epsw)
@@ -437,11 +437,11 @@ def phase_crossover_frequencies(sys):
         omega = _poly_iw_real_crossing(num_iw, den_iw, 0.)
 
         # using real() to avoid rounding errors and results like 1+0j
-        gain = np.real(evalfr(sys, 1J * omega, squeeze=True))
+        gain = np.real(evalfr(sys, 1J * omega))
     else:
         zargs = _poly_z_invz(sys)
         z, omega = _poly_z_real_crossing(*zargs, epsw=0.)
-        gain = np.real(evalfr(sys, z, squeeze=True))
+        gain = np.real(evalfr(sys, z))
 
     return omega, gain
 

--- a/control/margins.py
+++ b/control/margins.py
@@ -294,25 +294,25 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
             # frequency for gain margin: phase crosses -180 degrees
             w_180 = _poly_iw_real_crossing(num_iw, den_iw, epsw)
             with np.errstate(all='ignore'):  # den=0 is okay
-                w180_resp = evalfr(sys, 1J * w_180)
+                w180_resp = evalfr(sys, 1J * w_180, squeeze=True)
 
             # frequency for phase margin : gain crosses magnitude 1
             wc = _poly_iw_mag1_crossing(num_iw, den_iw, epsw)
-            wc_resp = evalfr(sys, 1J * wc)
+            wc_resp = evalfr(sys, 1J * wc, squeeze=True)
 
             # stability margin
             wstab = _poly_iw_wstab(num_iw, den_iw, epsw)
-            ws_resp = evalfr(sys, 1J * wstab)
+            ws_resp = evalfr(sys, 1J * wstab, squeeze=True)
 
         else:  # Discrete Time
             zargs = _poly_z_invz(sys)
             # gain margin
             z, w_180 = _poly_z_real_crossing(*zargs, epsw=epsw)
-            w180_resp = evalfr(sys, z)
+            w180_resp = evalfr(sys, z, squeeze=True)
 
             # phase margin
             z, wc = _poly_z_mag1_crossing(*zargs, epsw=epsw)
-            wc_resp = evalfr(sys, z)
+            wc_resp = evalfr(sys, z, squeeze=True)
 
             # stability margin
             z, wstab = _poly_z_wstab(*zargs, epsw=epsw)
@@ -437,11 +437,11 @@ def phase_crossover_frequencies(sys):
         omega = _poly_iw_real_crossing(num_iw, den_iw, 0.)
 
         # using real() to avoid rounding errors and results like 1+0j
-        gain = np.real(evalfr(sys, 1J * omega))
+        gain = np.real(evalfr(sys, 1J * omega, squeeze=True))
     else:
         zargs = _poly_z_invz(sys)
         z, omega = _poly_z_real_crossing(*zargs, epsw=0.)
-        gain = np.real(evalfr(sys, z))
+        gain = np.real(evalfr(sys, z, squeeze=True))
 
     return omega, gain
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -640,7 +640,7 @@ class StateSpace(LTI):
         raise NotImplementedError(
             "StateSpace.__rdiv__ is not implemented yet.")
 
-    def __call__(self, x, squeeze=True):
+    def __call__(self, x, squeeze=None):
         """Evaluate system's transfer function at complex frequency.
 
         Returns the complex frequency response `sys(x)` where `x` is `s` for
@@ -659,9 +659,10 @@ class StateSpace(LTI):
         ----------
         x : complex or complex array_like
             Complex frequencies
-        squeeze : bool, optional (default=True)
-            If True and `self` is single input single output (SISO), returns a
-            1D array rather than a 3D array.
+        squeeze : bool, optional
+            If True and the system is single-input single-output (SISO),
+            return a 1D array rather than a 3D array.  Default value (True)
+            set by config.defaults['control.squeeze'].
 
         Returns
         -------
@@ -670,6 +671,10 @@ class StateSpace(LTI):
             only if system is SISO and ``squeeze=True``.
 
         """
+        # Set value of squeeze argument if not set
+        if squeeze is None:
+            squeeze = config.defaults['control.squeeze']
+
         # Use Slycot if available
         out = self.horner(x)
         if not hasattr(x, '__len__'):

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -646,10 +646,6 @@ class StateSpace(LTI):
         Returns the complex frequency response `sys(x)` where `x` is `s` for
         continuous-time systems and `z` for discrete-time systems.
 
-        In general the system may be multiple input, multiple output
-        (MIMO), where `m = self.inputs` number of inputs and `p =
-        self.outputs` number of outputs.
-
         To evaluate at a frequency omega in radians per second, enter
         ``x = omega * 1j``, for continuous-time systems, or
         ``x = exp(1j * omega * dt)`` for discrete-time systems. Or use

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -662,7 +662,7 @@ class StateSpace(LTI):
         squeeze : bool, optional
             If True and the system is single-input single-output (SISO),
             return a 1D array rather than a 3D array.  Default value (True)
-            set by config.defaults['control.squeeze'].
+            set by config.defaults['control.squeeze_frequency_response'].
 
         Returns
         -------

--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -157,7 +157,7 @@ class TestLTI:
         assert isctime(obj, strict=True) == strictref
 
     @pytest.mark.usefixtures("editsdefaults")
-    @pytest.mark.parametrize("fcn", [ct.ss, ct.tf, ct.frd])
+    @pytest.mark.parametrize("fcn", [ct.ss, ct.tf, ct.frd, ct.ss2io])
     @pytest.mark.parametrize("nstate, nout, ninp, squeeze, shape", [
         [1, 1, 1, None, (8,)],                          # SISO
         [2, 1, 1, True, (8,)],
@@ -193,7 +193,7 @@ class TestLTI:
         assert ct.evalfr(sys, omega * 1j, squeeze=squeeze).shape == shape
 
         # Changing config.default to False should return 3D frequency response
-        ct.config.set_defaults('control', squeeze=False)
+        ct.config.set_defaults('control', squeeze_frequency_response=False)
         mag, phase, _ = sys.frequency_response(omega)
         assert mag.shape == (sys.outputs, sys.inputs, 8)
         assert phase.shape == (sys.outputs, sys.inputs, 8)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -234,7 +234,7 @@ class TransferFunction(LTI):
                     dt = config.defaults['control.default_dt']
         self.dt = dt
 
-    def __call__(self, x, squeeze=True):
+    def __call__(self, x, squeeze=None):
         """Evaluate system's transfer function at complex frequencies.
 
         Returns the complex frequency response `sys(x)` where `x` is `s` for
@@ -254,8 +254,9 @@ class TransferFunction(LTI):
         x : complex array_like or complex
             Complex frequencies
         squeeze : bool, optional (default=True)
-            If True and `sys` is single input single output (SISO), returns a
-            1D array rather than a 3D array.
+            If True and the system is single-input single-output (SISO),
+            return a 1D array rather than a 3D array.  Default value (True)
+            set by config.defaults['control.squeeze'].
 
         Returns
         -------
@@ -264,6 +265,10 @@ class TransferFunction(LTI):
             only if system is SISO and ``squeeze=True``.
 
         """
+        # Set value of squeeze argument if not set
+        if squeeze is None:
+            squeeze = config.defaults['control.squeeze']
+
         out = self.horner(x)
         if not hasattr(x, '__len__'):
             # received a scalar x, squeeze down the array along last dim

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -63,7 +63,7 @@ from copy import deepcopy
 from warnings import warn
 from itertools import chain
 from re import sub
-from .lti import LTI, common_timebase, isdtime
+from .lti import LTI, common_timebase, isdtime, _process_frequency_response
 from . import config
 
 __all__ = ['TransferFunction', 'tf', 'ss2tf', 'tfdata']
@@ -265,19 +265,8 @@ class TransferFunction(LTI):
             only if system is SISO and ``squeeze=True``.
 
         """
-        # Set value of squeeze argument if not set
-        if squeeze is None:
-            squeeze = config.defaults['control.squeeze']
-
         out = self.horner(x)
-        if not hasattr(x, '__len__'):
-            # received a scalar x, squeeze down the array along last dim
-            out = np.squeeze(out, axis=2)
-        if squeeze and self.issiso():
-            # return a scalar/1d array of outputs
-            return out[0][0]
-        else:
-            return out
+        return _process_frequency_response(self, x, out, squeeze=squeeze)
 
     def horner(self, x):
         """Evaluate system's transfer function at complex frequency

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -256,7 +256,7 @@ class TransferFunction(LTI):
         squeeze : bool, optional (default=True)
             If True and the system is single-input single-output (SISO),
             return a 1D array rather than a 3D array.  Default value (True)
-            set by config.defaults['control.squeeze'].
+            set by config.defaults['control.squeeze_frequency_response'].
 
         Returns
         -------


### PR DESCRIPTION
This PR addresses issue #453 by implementing a uniform method for handling the `squeeze` keyword in frequency response functions (`frequency_response`, `__call__`, etc).  This PR matches the changes in PR #511 to improve consistency between time and frequency response, as described in issue #453.

The following behavior is implemented:

* `squeeze=None` (default case): squeeze inputs and outputs, but leave frequencies alone. This is consistent with current behavior.
* `squeeze=True`: numpy squeeze => all singleton axes are removed, consistent with numpy.
* `squeeze=False`: full MIMO, even for SISO. You always get a p x m array for outputs versus inputs.

Additional changes:

* A new global default `control.squeeze_frequency_response` that sets the default value for the squeeze keyword (set to `None` initially).
* Passing a set of frequencies (or complex values) that is not a scalar of a 1D array_like generates a `ValueError` exception.
* Updated docstrings
* Unit tests to make sure that all of the various cases for `squeeze` are correct.
* Some minor PEP8 cleanup along the way
