### PR TITLE
change default value of statesp.remove_useless_states to False

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -226,4 +226,7 @@ def use_legacy_defaults(version):
                      linearized_system_name_prefix='',
                      linearized_system_name_suffix='_linearized')
 
+        # turned off _remove_useless_states
+        set_defaults('statesp', remove_useless_states=True)
+
     return (major, minor, patch)

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -395,9 +395,6 @@ class TestStateSpace:
         D0 = 0
         D1 = np.ones((2,1))
         assert StateSpace(A0, B0, C1, D1).is_static_gain()
-        # TODO: fix this once remove_useless_states is false by default
-        # should be False when remove_useless is false
-        # print(StateSpace(A1, B0, C1, D1).is_static_gain())
         assert not StateSpace(A0, B1, C1, D1).is_static_gain()
         assert not StateSpace(A1, B1, C1, D1).is_static_gain()
         assert StateSpace(A0, B0, C0, D0).is_static_gain()
@@ -586,10 +583,9 @@ class TestStateSpace:
 
     def test_remove_useless_states(self):
         """Regression: _remove_useless_states gives correct ABC sizes."""
-        g1 = StateSpace(np.zeros((3, 3)),
-                        np.zeros((3, 4)),
-                        np.zeros((5, 3)),
-                        np.zeros((5, 4)))
+        g1 = StateSpace(np.zeros((3, 3)), np.zeros((3, 4)),
+                        np.zeros((5, 3)), np.zeros((5, 4)),
+                        remove_useless_states=True)
         assert (0, 0) == g1.A.shape
         assert (0, 4) == g1.B.shape
         assert (5, 0) == g1.C.shape

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -395,6 +395,7 @@ class TestStateSpace:
         D0 = 0
         D1 = np.ones((2,1))
         assert StateSpace(A0, B0, C1, D1).is_static_gain()
+        assert not StateSpace(A1, B0, C1, D1).is_static_gain()
         assert not StateSpace(A0, B1, C1, D1).is_static_gain()
         assert not StateSpace(A1, B1, C1, D1).is_static_gain()
         assert StateSpace(A0, B0, C0, D0).is_static_gain()


### PR DESCRIPTION
This PR resolves issue #244.  It looks like the only issue was that converting a constant to a state space object was creating an extra state and this state had to then be removed.  By creating a state space system with no internal state (A = [[]] instead of A=[[0]]), this action is no longer required to get sensible results from block diagram algebra functions.

The PR makes that change and also changes the default value of `statesp.remove_useless_states` to `False`.