### PR TITLE
standardize time response return values, return_x/squeeze keyword processing

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -18,6 +18,7 @@ _control_defaults = {
     'control.default_dt': 0,
     'control.squeeze_frequency_response': None,
     'control.squeeze_time_response': True,
+    'control.squeeze_time_response': None,
     'forced_response.return_x': False,
 }
 defaults = dict(_control_defaults)
@@ -235,5 +236,8 @@ def use_legacy_defaults(version):
 
         # forced_response no longer returns x by default
         set_defaults('forced_response', return_x=True)
+
+        # time responses are only squeezed if SISO
+        set_defaults('control', squeeze_time_response=True)
 
     return (major, minor, patch)

--- a/control/config.py
+++ b/control/config.py
@@ -16,7 +16,9 @@ __all__ = ['defaults', 'set_defaults', 'reset_defaults',
 # Package level default values
 _control_defaults = {
     'control.default_dt': 0,
-    'control.squeeze_frequency_response': None
+    'control.squeeze_frequency_response': None,
+    'control.squeeze_time_response': True,
+    'forced_response.return_x': False,
 }
 defaults = dict(_control_defaults)
 
@@ -211,6 +213,7 @@ def use_legacy_defaults(version):
     #
     # Go backwards through releases and reset defaults
     #
+    reset_defaults()            # start from a clean slate
 
     # Version 0.9.0:
     if major == 0 and minor < 9:
@@ -229,5 +232,8 @@ def use_legacy_defaults(version):
 
         # turned off _remove_useless_states
         set_defaults('statesp', remove_useless_states=True)
+
+        # forced_response no longer returns x by default
+        set_defaults('forced_response', return_x=True)
 
     return (major, minor, patch)

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -450,6 +450,10 @@ class InputOutputSystem(object):
         """Find the index for a state given its name (`None` if not found)"""
         return self.state_index.get(name, None)
 
+    def issiso(self):
+        """Check to see if a system is single input, single output"""
+        return self.ninputs == 1 and self.noutputs == 1
+
     def feedback(self, other=1, sign=-1, params={}):
         """Feedback interconnection between two input/output systems
 
@@ -1373,18 +1377,22 @@ def input_output_response(sys, T, U=0., X0=0, params={}, method='RK45',
     return_x : bool, optional
         If True, return the values of the state at each time (default = False).
     squeeze : bool, optional
-        If True and if the system has a single output, return the
-        system output as a 1D array rather than a 2D array.  Default
-        value (True) set by config.defaults['control.squeeze_time_response'].
+        If True and if the system has a single output, return the system
+        output as a 1D array rather than a 2D array.  If False, return the
+        system output as a 2D array even if the system is SISO.  Default value
+        set by config.defaults['control.squeeze_time_response'].
 
     Returns
     -------
     T : array
         Time values of the output.
     yout : array
-        Response of the system.
+        Response of the system.  If the system is SISO and squeeze is not
+        True, the array is 1D (indexed by time).  If the system is not SISO or
+        squeeze is False, the array is 2D (indexed by the output number and
+        time).
     xout : array
-        Time evolution of the state vector (if return_x=True)
+        Time evolution of the state vector (if return_x=True).
 
     Raises
     ------

--- a/control/matlab/timeresp.py
+++ b/control/matlab/timeresp.py
@@ -59,15 +59,13 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
     '''
     from ..timeresp import step_response
 
-    T, yout, xout = step_response(sys, T, X0, input, output,
-                                  transpose=True, return_x=True)
+    # Switch output argument order and transpose outputs
+    out = step_response(sys, T, X0, input, output,
+                        transpose=True, return_x=return_x)
+    return (out[1], out[0], out[2]) if return_x else (out[1], out[0])
 
-    if return_x:
-        return yout, T, xout
-
-    return yout, T
-
-def stepinfo(sys, T=None, SettlingTimeThreshold=0.02, RiseTimeLimits=(0.1, 0.9)):
+def stepinfo(sys, T=None, SettlingTimeThreshold=0.02,
+             RiseTimeLimits=(0.1, 0.9)):
     '''
     Step response characteristics (Rise time, Settling Time, Peak and others).
 
@@ -110,6 +108,7 @@ def stepinfo(sys, T=None, SettlingTimeThreshold=0.02, RiseTimeLimits=(0.1, 0.9))
     '''
     from ..timeresp import step_info
 
+    # Call step_info with MATLAB defaults
     S = step_info(sys, T, None, SettlingTimeThreshold, RiseTimeLimits)
 
     return S
@@ -164,13 +163,11 @@ def impulse(sys, T=None, X0=0., input=0, output=None, return_x=False):
     >>> yout, T = impulse(sys, T)
     '''
     from ..timeresp import impulse_response
-    T, yout, xout = impulse_response(sys, T, X0, input, output,
-                                     transpose = True, return_x=True)
 
-    if return_x:
-        return yout, T, xout
-
-    return yout, T
+    # Switch output argument order and transpose outputs
+    out = impulse_response(sys, T, X0, input, output,
+                           transpose = True, return_x=return_x)
+    return (out[1], out[0], out[2]) if return_x else (out[1], out[0])
 
 def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
     '''
@@ -222,13 +219,12 @@ def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
 
     '''
     from ..timeresp import initial_response
+
+    # Switch output argument order and transpose outputs
     T, yout, xout = initial_response(sys, T, X0, output=output,
                                      transpose=True, return_x=True)
+    return (yout, T, xout) if return_x else (yout, T)
 
-    if return_x:
-        return yout, T, xout
-
-    return yout, T
 
 def lsim(sys, U=0., T=None, X0=0.):
     '''
@@ -273,5 +269,7 @@ def lsim(sys, U=0., T=None, X0=0.):
     >>> yout, T, xout = lsim(sys, U, T, X0)
     '''
     from ..timeresp import forced_response
-    T, yout, xout = forced_response(sys, T, U, X0, transpose = True)
-    return yout, T, xout
+
+    # Switch output argument order and transpose outputs (and always return x)
+    out = forced_response(sys, T, U, X0, return_x=True, transpose=True)
+    return out[1], out[0], out[2]

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -211,12 +211,15 @@ class TestConfig:
             ct.use_legacy_defaults('0.8.3')
             assert(isinstance(ct.ss(0, 0, 0, 1).D, np.matrix))
         ct.reset_defaults()
-        assert(isinstance(ct.ss(0, 0, 0, 1).D, np.ndarray))
-        assert(not isinstance(ct.ss(0, 0, 0, 1).D, np.matrix))
+        assert isinstance(ct.ss(0, 0, 0, 1).D, np.ndarray)
+        assert not isinstance(ct.ss(0, 0, 0, 1).D, np.matrix)
+
+        ct.use_legacy_defaults('0.8.4')
+        assert ct.config.defaults['forced_response.return_x'] is True
 
         ct.use_legacy_defaults('0.9.0')
-        assert(isinstance(ct.ss(0, 0, 0, 1).D, np.ndarray))
-        assert(not isinstance(ct.ss(0, 0, 0, 1).D, np.matrix))
+        assert isinstance(ct.ss(0, 0, 0, 1).D, np.ndarray)
+        assert not isinstance(ct.ss(0, 0, 0, 1).D, np.matrix)
 
         # test that old versions don't raise a problem
         ct.use_legacy_defaults('REL-0.1')

--- a/control/tests/discrete_test.py
+++ b/control/tests/discrete_test.py
@@ -353,9 +353,11 @@ class TestDiscrete:
         tout, yout = step_response(tsys.siso_ss1d, T)
         tout, yout = impulse_response(tsys.siso_ss1d)
         tout, yout = impulse_response(tsys.siso_ss1d, T)
-        tout, yout, xout = forced_response(tsys.siso_ss1d, T, U, 0)
-        tout, yout, xout = forced_response(tsys.siso_ss2d, T, U, 0)
-        tout, yout, xout = forced_response(tsys.siso_ss3d, T, U, 0)
+        tout, yout = forced_response(tsys.siso_ss1d, T, U, 0)
+        tout, yout = forced_response(tsys.siso_ss2d, T, U, 0)
+        tout, yout = forced_response(tsys.siso_ss3d, T, U, 0)
+        tout, yout, xout = forced_response(tsys.siso_ss1d, T, U, 0,
+                                           return_x=True)
 
     def test_sample_system(self, tsys):
         # Make sure we can convert various types of systems

--- a/control/tests/flatsys_test.py
+++ b/control/tests/flatsys_test.py
@@ -48,7 +48,7 @@ class TestFlatSys:
         T = np.linspace(0, Tf, 100)
         xd, ud = traj.eval(T)
 
-        t, y, x = ct.forced_response(sys, T, ud, x1)
+        t, y, x = ct.forced_response(sys, T, ud, x1, return_x=True)
         np.testing.assert_array_almost_equal(x, xd, decimal=3)
 
     def test_kinematic_car(self):

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -61,7 +61,7 @@ class TestIOSys:
 
         # Make sure that simulations also line up
         T, U, X0 = tsys.T, tsys.U, tsys.X0
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y, atol=0.002, rtol=0.)
@@ -75,7 +75,7 @@ class TestIOSys:
 
         # Verify correctness via simulation
         T, U, X0 = tsys.T, tsys.U, tsys.X0
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y, atol=0.002, rtol=0.)
@@ -84,7 +84,7 @@ class TestIOSys:
         tfsys = ct.tf('s')
         with pytest.raises(ValueError):
             iosys=ct.tf2io(tfsys)
-            
+
     def test_ss2io(self, tsys):
         # Create an input/output system from the linear system
         linsys = tsys.siso_linsys
@@ -162,7 +162,7 @@ class TestIOSys:
 
         # Make sure that simulations also line up
         T, U, X0 = tsys.T, tsys.U, tsys.X0
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys, T, U, X0)
         ios_t, ios_y = ios.input_output_response(nlsys, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y,atol=0.002,rtol=0.)
@@ -256,7 +256,7 @@ class TestIOSys:
         X0 = np.concatenate((tsys.X0, tsys.X0))
         ios_t, ios_y, ios_x = ios.input_output_response(
             iosys_series, T, U, X0, return_x=True)
-        lti_t, lti_y, lti_x = ct.forced_response(linsys_series, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys_series, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y,atol=0.002,rtol=0.)
 
@@ -273,7 +273,7 @@ class TestIOSys:
         assert ct.isctime(iosys_series, strict=True)
         ios_t, ios_y, ios_x = ios.input_output_response(
             iosys_series, T, U, X0, return_x=True)
-        lti_t, lti_y, lti_x = ct.forced_response(linsys_series, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys_series, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y,atol=0.002,rtol=0.)
 
@@ -288,7 +288,7 @@ class TestIOSys:
         )
         ios_t, ios_y, ios_x = ios.input_output_response(
             iosys_feedback, T, U, X0, return_x=True)
-        lti_t, lti_y, lti_x = ct.forced_response(linsys_feedback, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys_feedback, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y,atol=0.002,rtol=0.)
 
@@ -325,7 +325,8 @@ class TestIOSys:
         # Create a simulation run to compare against
         T, U = tsys.T, tsys.U
         X0 = np.concatenate((tsys.X0, tsys.X0))
-        lti_t, lti_y, lti_x = ct.forced_response(linsys_series, T, U, X0)
+        lti_t, lti_y, lti_x = ct.forced_response(
+            linsys_series, T, U, X0, return_x=True)
 
         # Create the input/output system with different parameter variations
         iosys_series = ios.InterconnectedSystem(
@@ -360,7 +361,8 @@ class TestIOSys:
         # Create a simulation run to compare against
         T, U = tsys.T, tsys.U
         X0 = np.concatenate((tsys.X0, tsys.X0))
-        lti_t, lti_y, lti_x = ct.forced_response(linsys_series, T, U, X0)
+        lti_t, lti_y, lti_x = ct.forced_response(
+            linsys_series, T, U, X0, return_x=True)
 
         # Set up multiple gainst and make sure a warning is generated
         with pytest.warns(UserWarning, match="multiple.*Combining"):
@@ -388,7 +390,8 @@ class TestIOSys:
 
         # Make sure saturation works properly by comparing linear system with
         # saturated input to nonlinear system with saturation composition
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, Usat, X0)
+        lti_t, lti_y, lti_x = ct.forced_response(
+            linsys, T, Usat, X0, return_x=True)
         ios_t, ios_y, ios_x = ios.input_output_response(
             ioslin * nlsat, T, U, X0, return_x=True)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
@@ -424,7 +427,7 @@ class TestIOSys:
         # Nonlinear system composed with LTI system (series) -- with states
         ios_t, ios_y = ios.input_output_response(
             nlios * lnios * nlios, T, U, X0)
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, U*U, X0)
+        lti_t, lti_y = ct.forced_response(linsys, T, U*U, X0)
         np.testing.assert_array_almost_equal(ios_y, lti_y*lti_y, decimal=3)
 
         # Nonlinear system in feeback loop with LTI system
@@ -480,7 +483,7 @@ class TestIOSys:
         U = [np.sin(T), np.cos(T)]
         X0 = 0
 
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_parallel, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys_parallel, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys_parallel, T, U, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
@@ -502,7 +505,7 @@ class TestIOSys:
 
         # Make sure we got the right thing (via simulation comparison)
         ios_t, ios_y = ios.input_output_response(sys2, T, U, X0)
-        lti_t, lti_y, lti_x = ct.forced_response(ioslin, T, U*U, X0)
+        lti_t, lti_y = ct.forced_response(ioslin, T, U*U, X0)
         np.testing.assert_array_almost_equal(ios_y, lti_y*lti_y, decimal=3)
 
     @noscipy0
@@ -525,7 +528,7 @@ class TestIOSys:
 
         # Make sure we got the right thing (via simulation comparison)
         ios_t, ios_y = ios.input_output_response(sys, T, U, X0)
-        lti_t, lti_y, lti_x = ct.forced_response(ioslin, T, U*U, X0)
+        lti_t, lti_y = ct.forced_response(ioslin, T, U*U, X0)
         np.testing.assert_array_almost_equal(ios_y, -lti_y, decimal=3)
 
     @noscipy0
@@ -541,7 +544,7 @@ class TestIOSys:
         linsys = ct.feedback(tsys.siso_linsys, 1)
 
         ios_t, ios_y = ios.input_output_response(iosys, T, U, X0)
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys, T, U, X0)
         np.testing.assert_allclose(ios_y, lti_y,atol=0.002,rtol=0.)
 
     @noscipy0
@@ -561,33 +564,33 @@ class TestIOSys:
         # Series interconnection
         linsys_series = ct.series(linsys1, linsys2)
         iosys_series = ct.series(linio1, linio2)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_series, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys_series, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys_series, T, U, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
         # Make sure that systems don't commute
         linsys_series = ct.series(linsys2, linsys1)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_series, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys_series, T, U, X0)
         assert not (np.abs(lin_y - ios_y) < 1e-3).all()
 
         # Parallel interconnection
         linsys_parallel = ct.parallel(linsys1, linsys2)
         iosys_parallel = ct.parallel(linio1, linio2)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_parallel, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys_parallel, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys_parallel, T, U, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
         # Negation
         linsys_negate = ct.negate(linsys1)
         iosys_negate = ct.negate(linio1)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_negate, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys_negate, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys_negate, T, U, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
         # Feedback interconnection
         linsys_feedback = ct.feedback(linsys1, linsys2)
         iosys_feedback = ct.feedback(linio1, linio2)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_feedback, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys_feedback, T, U, X0)
         ios_t, ios_y = ios.input_output_response(iosys_feedback, T, U, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
@@ -614,13 +617,13 @@ class TestIOSys:
         # Multiplication
         linsys_multiply = linsys_3i2o * linsys_2i3o
         iosys_multiply = iosys_3i2o * iosys_2i3o
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_multiply, T, U2, X0)
+        lin_t, lin_y = ct.forced_response(linsys_multiply, T, U2, X0)
         ios_t, ios_y = ios.input_output_response(iosys_multiply, T, U2, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
         linsys_multiply = linsys_2i3o * linsys_3i2o
         iosys_multiply = iosys_2i3o * iosys_3i2o
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_multiply, T, U3, X0)
+        lin_t, lin_y = ct.forced_response(linsys_multiply, T, U3, X0)
         ios_t, ios_y = ios.input_output_response(iosys_multiply, T, U3, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
@@ -633,7 +636,7 @@ class TestIOSys:
         # Feedback
         linsys_multiply = ct.feedback(linsys_3i2o, linsys_2i3o)
         iosys_multiply = iosys_3i2o.feedback(iosys_2i3o)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys_multiply, T, U3, X0)
+        lin_t, lin_y = ct.forced_response(linsys_multiply, T, U3, X0)
         ios_t, ios_y = ios.input_output_response(iosys_multiply, T, U3, X0)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
@@ -655,7 +658,7 @@ class TestIOSys:
 
         # Simulate and compare to LTI output
         ios_t, ios_y = ios.input_output_response(lnios, T, U, X0)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys, T, U, X0)
         np.testing.assert_allclose(ios_t, lin_t,atol=0.002,rtol=0.)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
@@ -671,7 +674,7 @@ class TestIOSys:
 
         # Simulate and compare to LTI output
         ios_t, ios_y = ios.input_output_response(lnios, T, U, X0)
-        lin_t, lin_y, lin_x = ct.forced_response(linsys, T, U, X0)
+        lin_t, lin_y = ct.forced_response(linsys, T, U, X0)
         np.testing.assert_allclose(ios_t, lin_t,atol=0.002,rtol=0.)
         np.testing.assert_allclose(ios_y, lin_y,atol=0.002,rtol=0.)
 
@@ -839,7 +842,7 @@ class TestIOSys:
         linsys = tsys.siso_linsys
         iosys = ios.LinearIOSystem(linsys)
         T, U, X0 = tsys.T, tsys.U, tsys.X0
-        lti_t, lti_y, lti_x = ct.forced_response(linsys, T, U, X0)
+        lti_t, lti_y = ct.forced_response(linsys, T, U, X0)
         with pytest.warns(UserWarning, match="LinearIOSystem.*ignored"):
             ios_t, ios_y = ios.input_output_response(
                 iosys, T, U, X0, params={'something':0})

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -158,7 +158,7 @@ class TestIOSys:
         nlout = lambda t, x, u, params: \
             np.reshape(np.dot(linsys.C, np.reshape(x, (-1, 1)))
                        + np.dot(linsys.D, u), (-1,))
-        nlsys = ios.NonlinearIOSystem(nlupd, nlout)
+        nlsys = ios.NonlinearIOSystem(nlupd, nlout, inputs=1, outputs=1)
 
         # Make sure that simulations also line up
         T, U, X0 = tsys.T, tsys.U, tsys.X0

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -321,7 +321,8 @@ class TestMatlab:
         yout, tout, _xout = lsim(siso.ss1, u, t)
         np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
         np.testing.assert_array_almost_equal(tout, t)
-        yout, _t, _xout = lsim(siso.tf3, u, t)
+        with pytest.warns(UserWarning, match="Internal conversion"):
+            yout, _t, _xout = lsim(siso.tf3, u, t)
         np.testing.assert_array_almost_equal(yout, youttrue, decimal=4)
 
         # test with initial value and special algorithm for ``U=0``

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -51,7 +51,7 @@ class TestModelsimp:
         # Test example from docstring
         T = np.linspace(0, 10, 100)
         U = np.ones((1, 100))
-        T, Y, _ = forced_response(tf([1], [1, 0.5], True), T, U)
+        T, Y = forced_response(tf([1], [1, 0.5], True), T, U)
         H = markov(Y, U, 3, transpose=False)
 
         # Test example from issue #395
@@ -102,7 +102,7 @@ class TestModelsimp:
         # Generate input/output data
         T = np.array(range(n)) * Ts
         U = np.cos(T) + np.sin(T/np.pi)
-        _, Y, _ = forced_response(Hd, T, U, squeeze=True)
+        _, Y = forced_response(Hd, T, U, squeeze=True)
         Mcomp = markov(Y, U, m)
 
         # Compare to results from markov()

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -723,26 +723,26 @@ class TestTimeresp:
         assert y.ndim == 1  # SISO returns "scalar" output
         assert t.shape == y.shape  # Allows direct plotting of output
 
-    @pytest.mark.usefixtures("editsdefaults")
     @pytest.mark.parametrize("fcn", [ct.ss, ct.tf, ct.ss2io])
     @pytest.mark.parametrize("nstate, nout, ninp, squeeze, shape", [
         [1, 1, 1, None, (8,)],
         [2, 1, 1, True, (8,)],
         [3, 1, 1, False, (1, 8)],
 #       [4, 1, 1, 'siso', (8,)],        # Use for later 'siso' implementation
-        [1, 2, 1, None, (2, 8)],
-        [2, 2, 1, True, (2, 8)],
-        [3, 2, 1, False, (2, 8)],
-#       [4, 2, 1, 'siso', (2, 8)],      # Use for later 'siso' implementation
-        [1, 1, 2, None, (8,)],
-        [2, 1, 2, True, (8,)],
-        [3, 1, 2, False, (1, 8)],
-#       [4, 1, 2, 'siso', (1, 8)],      # Use for later 'siso' implementation
-        [1, 2, 2, None, (2, 8)],
-        [2, 2, 2, True, (2, 8)],
-        [3, 2, 2, False, (2, 8)],
-#       [4, 2, 2, 'siso', (2, 8)],      # Use for later 'siso' implementation
+        [3, 2, 1, None, (2, 8)],
+        [4, 2, 1, True, (2, 8)],
+        [5, 2, 1, False, (2, 8)],
+#       [6, 2, 1, 'siso', (2, 8)],      # Use for later 'siso' implementation
+        [3, 1, 2, None, (8,)],
+        [4, 1, 2, True, (8,)],
+        [5, 1, 2, False, (1, 8)],
+#       [6, 1, 2, 'siso', (1, 8)],      # Use for later 'siso' implementation
+        [4, 2, 2, None, (2, 8)],
+        [5, 2, 2, True, (2, 8)],
+        [6, 2, 2, False, (2, 8)],
+#       [7, 2, 2, 'siso', (2, 8)],      # Use for later 'siso' implementation
     ])
+    @pytest.mark.usefixtures("editsdefaults")
     def test_squeeze(self, fcn, nstate, nout, ninp, squeeze, shape):
         # Figure out if we have SciPy 1+
         scipy0 = StrictVersion(sp.__version__) < '1.0'
@@ -818,13 +818,13 @@ class TestTimeresp:
             _, yvec = ct.step_response(sys, tvec)
         assert yvec.shape == (sys.outputs, 8)
 
-        _, yvec, xvec = ct.forced_response(
-            sys, tvec, uvec, 0, return_x=True)
-        assert yvec.shape == (sys.outputs, 8)
         if isinstance(sys, ct.StateSpace):
+            _, yvec, xvec = ct.forced_response(
+                sys, tvec, uvec, 0, return_x=True)
             assert xvec.shape == (sys.states, 8)
         else:
-            assert xvec.shape[1] == 8
+            _, yvec = ct.forced_response(sys, tvec, uvec, 0)
+        assert yvec.shape == (sys.outputs, 8)
 
         # For InputOutputSystems, also test input_output_response
         if isinstance(sys, ct.InputOutputSystem) and not scipy0:

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -285,10 +285,10 @@ def forced_response(sys, T=None, U=0., X0=0., transpose=False,
         return_x = config.defaults['forced_response.return_x']
 
     # If return_x is used for TransferFunction, issue a warning
-    if return_x and not isinstance(sys, TransferFunction):
+    if return_x and isinstance(sys, TransferFunction):
         warnings.warn(
             "return_x specified for a transfer function system. Internal "
-            "conversation to state space used; results may meaningless.")
+            "conversion to state space used; results may meaningless.")
 
     sys = _convert_to_statespace(sys)
     A, B, C, D = np.asarray(sys.A), np.asarray(sys.B), np.asarray(sys.C), \


### PR DESCRIPTION
This PR is a partial replacement for #507, focused on addressing the issues in #453 relating to time responses:

* Update `forced_response` to only return the state trajectory if `return_x` is True, consistent with all other time response functions (including `input_output_response`).  Prior to this, `forced_response` always returned the state vector.  In addition to the inconsistency, this was also problematic if the system you were simulating was a transfer function, since the state space depended on the realization and this information is `lost`.  Some other smaller changes related to this:
  - Issue a warning if you ask for the state space trajectory corresponding to a transfer function
  - Set the default value of `return_x` using `config.defaults['forced_response.return_x'] (default = False)
  - Reset the default value of `config.defaults['forced_response.return_x']` to True with `use_legacy_defaults` for versions < 0.9.0 for backward compatibility.
  - Unit tests to make sure all of that is working.

* Consolidate processing of time responses through a new internal function `_process_time_response` that provides uniform processing of the `return_x` and `squeeze` keywords.  This is mainly in preparation for any future changes in how we handle `squeeze`, so that changes only need to be made at one location in the code.   The functionality of the code is unchanged, but the processing is a big different:
  - The default value for the `squeeze` keyword for time responses is now set in `config.defaults['control.squeeze_time_response']`.  This is currently set to True, which means that time responses for systems with a single output are squeezed to a 1D response.
  - Added some unit tests to make sure that we get the right return values for all of the current time responses (`impulse_response`, `initial_response`, `step_response`, `forced_response`, `input_output_response`).
  - Added some commented out code for future implementation of a `squeeze='siso'` capability that would allow time responses to mirror current frequency response behavior (`squeeze=True` only removes axes for SISO systems).  I left this out for now pending resolution of the frequency response squeeze processing (drafted in #507, but needs more thought and effort).

Other changes, not directly related to those above
* Added a warning if you try to specify a non-zero initial state when simulating a transfer function.
* Docstring cleanup to use numpydoc syntax in few places.
