### PR TITLE
MIMO impulse and step response

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -17,7 +17,6 @@ __all__ = ['defaults', 'set_defaults', 'reset_defaults',
 _control_defaults = {
     'control.default_dt': 0,
     'control.squeeze_frequency_response': None,
-    'control.squeeze_time_response': True,
     'control.squeeze_time_response': None,
     'forced_response.return_x': False,
 }

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -1428,8 +1428,9 @@ def input_output_response(sys, T, U=0., X0=0, params={}, method='RK45',
         for i in range(len(T)):
             u = U[i] if len(U.shape) == 1 else U[:, i]
             y[:, i] = sys._out(T[i], [], u)
-        return _process_time_response(sys, T, y, [], transpose=transpose,
-                                      return_x=return_x, squeeze=squeeze)
+        return _process_time_response(
+            sys, T, y, np.array((0, 0, np.asarray(T).size)),
+            transpose=transpose, return_x=return_x, squeeze=squeeze)
 
     # create X0 if not given, test if X0 has correct shape
     X0 = _check_convert_array(X0, [(nstates,), (nstates, 1)],

--- a/control/tests/matlab2_test.py
+++ b/control/tests/matlab2_test.py
@@ -121,25 +121,25 @@ class TestControlMatlab:
         #print("gain:", dcgain(sys))
 
         subplot2grid(plot_shape, (0, 0))
-        t, y = step(sys)
+        y, t = step(sys)
         plot(t, y)
 
         subplot2grid(plot_shape, (0, 1))
         T = linspace(0, 2, 100)
         X0 = array([1, 1])
-        t, y = step(sys, T, X0)
+        y, t = step(sys, T, X0)
         plot(t, y)
 
         # Test output of state vector
-        t, y, x = step(sys, return_x=True)
+        y, t, x = step(sys, return_x=True)
 
         #Test MIMO system
         A, B, C, D = MIMO_mats
         sys = ss(A, B, C, D)
 
         subplot2grid(plot_shape, (0, 2))
-        t, y = step(sys)
-        plot(t, y)
+        y, t = step(sys)
+        plot(t, y[:, 0, 0])
 
     def test_impulse(self, SISO_mats, mplcleanup):
         A, B, C, D = SISO_mats
@@ -168,8 +168,8 @@ class TestControlMatlab:
         #Test MIMO system
         A, B, C, D = MIMO_mats
         sys = ss(A, B, C, D)
-        t, y = impulse(sys)
-        plot(t, y, label='MIMO System')
+        y, t = impulse(sys)
+        plot(t, y[:, :, 0], label='MIMO System')
 
         legend(loc='best')
         #show()

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -500,10 +500,10 @@ def _process_time_response(
         config.defaults['control.squeeze_time_response'].
 
     input : int, optional
-        If present, the response represents ony the listed input.
+        If present, the response represents only the listed input.
 
     output : int, optional
-        If present, the response represents ony the listed input.
+        If present, the response represents only the listed output.
 
     Returns
     -------

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -91,8 +91,7 @@ __all__ = ['forced_response', 'step_response', 'step_info', 'initial_response',
 # Helper function for checking array-like parameters
 def _check_convert_array(in_obj, legal_shapes, err_msg_start, squeeze=False,
                          transpose=False):
-    """
-    Helper function for checking array_like parameters.
+    """Helper function for checking array_like parameters.
 
     * Check type and shape of ``in_obj``.
     * Convert ``in_obj`` to an array if necessary.
@@ -128,8 +127,8 @@ def _check_convert_array(in_obj, legal_shapes, err_msg_start, squeeze=False,
         For example:
         ``array([[1,2,3]])`` is converted to ``array([1, 2, 3])``
 
-   transpose : bool
-        If True, assume that input arrays are transposed for the standard
+    transpose : bool, optional
+        If True, assume that 2D input arrays are transposed from the standard
         format.  Used to convert MATLAB-style inputs to our format.
 
     Returns
@@ -137,6 +136,7 @@ def _check_convert_array(in_obj, legal_shapes, err_msg_start, squeeze=False,
 
     out_array : array
         The checked and converted contents of ``in_obj``.
+
     """
     # convert nearly everything to an array.
     out_array = np.asarray(in_obj)
@@ -226,9 +226,10 @@ def forced_response(sys, T=None, U=0., X0=0., transpose=False,
     X0 : array_like or float, optional
         Initial condition (default = 0).
 
-    transpose : bool, optional (default=False)
+    transpose : bool, optional
         If True, transpose all input and output arrays (for backward
-        compatibility with MATLAB and :func:`scipy.signal.lsim`)
+        compatibility with MATLAB and :func:`scipy.signal.lsim`).  Default
+        value is False.
 
     interpolate : bool, optional (default=False)
         If True and system is a discrete time system, the input will
@@ -456,36 +457,122 @@ def forced_response(sys, T=None, U=0., X0=0., transpose=False,
 
 
 # Process time responses in a uniform way
-def _process_time_response(sys, tout, yout, xout, transpose=None,
-                           return_x=False, squeeze=None):
-    # If squeeze was not specified, figure out the default
+def _process_time_response(
+        sys, tout, yout, xout, transpose=None, return_x=False,
+        squeeze=None, input=None, output=None):
+    """Process time response signals.
+
+    This function processes the outputs of the time response functions and
+    processes the transpose and squeeze keywords.
+
+    Parameters
+    ----------
+    T : 1D array
+        Time values of the output
+
+    yout : ndarray
+        Response of the system.  This can either be a 1D array indexed by time
+        (for SISO systems), a 2D array indexed by output and time (for MIMO
+        systems with no input indexing, such as initial_response or forced
+        response) or a 3D array indexed by output, input, and time.
+
+    xout : array, optional
+        Individual response of each x variable (if return_x is True). For a
+        SISO system (or if a single input is specified), This should be a 2D
+        array indexed by the state index and time (for single input systems)
+        or a 3D array indexed by state, input, and time.
+
+    transpose : bool, optional
+        If True, transpose all input and output arrays (for backward
+        compatibility with MATLAB and :func:`scipy.signal.lsim`).  Default
+        value is False.
+
+    return_x : bool, optional
+        If True, return the state vector (default = False).
+
+    squeeze : bool, optional
+        By default, if a system is single-input, single-output (SISO) then the
+        output response is returned as a 1D array (indexed by time).  If
+        squeeze=True, remove single-dimensional entries from the shape of the
+        output even if the system is not SISO. If squeeze=False, keep the
+        output as a 3D array (indexed by the output, input, and time) even if
+        the system is SISO. The default value can be set using
+        config.defaults['control.squeeze_time_response'].
+
+    input : int, optional
+        If present, the response represents ony the listed input.
+
+    output : int, optional
+        If present, the response represents ony the listed input.
+
+    Returns
+    -------
+    T : 1D array
+        Time values of the output
+
+    yout : ndarray
+        Response of the system.  If the system is SISO and squeeze is not
+        True, the array is 1D (indexed by time).  If the system is not SISO or
+        squeeze is False, the array is either 2D (indexed by output and time)
+        or 3D (indexed by input, output, and time).
+
+    xout : array, optional
+        Individual response of each x variable (if return_x is True). For a
+        SISO system (or if a single input is specified), xout is a 2D array
+        indexed by the state index and time.  For a non-SISO system, xout is a
+        3D array indexed by the state, the input, and time.  The shape of xout
+        is not affected by the ``squeeze`` keyword.
+    """
+    # If squeeze was not specified, figure out the default (might remain None)
     if squeeze is None:
         squeeze = config.defaults['control.squeeze_time_response']
 
-    # Figure out whether and now to squeeze output data
+    # Determine if the system is SISO
+    issiso = sys.issiso() or (input is not None and output is not None)
+
+    # Figure out whether and how to squeeze output data
     if squeeze is True:         # squeeze all dimensions
         yout = np.squeeze(yout)
     elif squeeze is False:      # squeeze no dimensions
         pass
     elif squeeze is None:       # squeeze signals if SISO
-        yout = yout[0] if sys.issiso() else yout
+        if issiso:
+            if len(yout.shape) == 3:
+                yout = yout[0][0]       # remove input and output
+            else:
+                yout = yout[0]          # remove input
     else:
         raise ValueError("unknown squeeze value")
 
+    # Figure out whether and how to squeeze the state data
+    if issiso and len(xout.shape) > 2:
+        xout = xout[:, 0, :]            # remove input
+
     # See if we need to transpose the data back into MATLAB form
     if transpose:
+        # Transpose time vector in case we are using np.matrix
         tout = np.transpose(tout)
-        yout = np.transpose(yout)
-        xout = np.transpose(xout)
+
+        # For signals, put the last index (time) into the first slot
+        yout = np.transpose(yout, np.roll(range(yout.ndim), 1))
+        xout = np.transpose(xout, np.roll(range(xout.ndim), 1))
 
     # Return time, output, and (optionally) state
     return (tout, yout, xout) if return_x else (tout, yout)
 
 
 def _get_ss_simo(sys, input=None, output=None, squeeze=None):
-    """Return a SISO or SIMO state-space version of sys
+    """Return a SISO or SIMO state-space version of sys.
 
-    If input is not specified, select first input and issue warning
+    This function converts the given system to a state space system in
+    preparation for simulation and sets the system matrixes to match the
+    desired input and output.
+
+    If input is not specified, select first input and issue warning (legacy
+    behavior that should eventually not be used).
+
+    If the output is not specified, report on all outputs.
+
     """
     # If squeeze was not specified, figure out the default
     if squeeze is None:
@@ -559,7 +646,8 @@ def step_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
 
     transpose : bool, optional
         If True, transpose all input and output arrays (for backward
-        compatibility with MATLAB and :func:`scipy.signal.lsim`)
+        compatibility with MATLAB and :func:`scipy.signal.lsim`).  Default
+        value is False.
 
     return_x : bool, optional
         If True, return the state vector (default = False).
@@ -605,37 +693,30 @@ def step_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
     >>> T, yout = step_response(sys, T, X0)
 
     """
-    # Convert to state space so that we can simulate
-    sys = _convert_to_statespace(sys)
-
     # Create the time and input vectors
     if T is None or np.asarray(T).size == 1:
         T = _default_time_vector(sys, N=T_num, tfinal=T, is_step=True)
     U = np.ones_like(T)
 
-    # If squeeze was not specified, figure out the default
-    if squeeze is None:
-        squeeze = config.defaults['control.squeeze_time_response']
+    # If we are passed a transfer function and X0 is non-zero, warn the user
+    if isinstance(sys, TransferFunction) and np.any(X0 != 0):
+        warnings.warn(
+            "Non-zero initial condition given for transfer function system. "
+            "Internal conversation to state space used; may not be consistent "
+            "with given X0.")
 
-    # Figure out what type of step response to compute (SISO, SIMO, MIMO)
-    if squeeze is False:
-        # Drop through to MIMO case
-        pass
-    elif sys.issiso() or isinstance(input, int) or isinstance(output, int):
-        # Get the system we need to simulate
-        squeeze, sys = _get_ss_simo(sys, input, output, squeeze=squeeze)
-        return forced_response(sys, T, U, X0, transpose=transpose,
-                               return_x=return_x, squeeze=squeeze)
-    elif input is not None or output is not None:
-        raise ValueError("input and output must either be integers or None")
+    # Convert to state space so that we can simulate
+    sys = _convert_to_statespace(sys)
 
-    # Simulate the response for each input
+    # Set up arrays to handle the output
     ninputs = sys.inputs if input is None else 1
     noutputs = sys.outputs if output is None else 1
-    yout = np.empty((noutputs, ninputs, len(T)))
-    xout = np.empty((sys.states, ninputs, len(T)))
+    yout = np.empty((noutputs, ninputs, np.asarray(T).size))
+    xout = np.empty((sys.states, ninputs, np.asarray(T).size))
+
+    # Simulate the response for each input
     for i in range(sys.inputs):
-        # If input keyword was specified, only handle that case
+        # If input keyword was specified, only simulate for that input
         if isinstance(input, int) and i != input:
             continue
 
@@ -649,8 +730,9 @@ def step_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
         if return_x:
             xout[:, i, :] = out[2]
 
-    return _process_time_response(sys, out[0], yout, xout, transpose=transpose,
-                                  return_x=return_x, squeeze=squeeze)
+    return _process_time_response(
+        sys, out[0], yout, xout, transpose=transpose, return_x=return_x,
+        squeeze=squeeze, input=input, output=output)
 
 
 def step_info(sys, T=None, T_num=None, SettlingTimeThreshold=0.02,
@@ -871,9 +953,10 @@ def impulse_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
         Number of time steps to use in simulation if T is not provided as an
         array (autocomputed if not given); ignored if sys is discrete-time.
 
-    transpose : bool
+    transpose : bool, optional
         If True, transpose all input and output arrays (for backward
-        compatibility with MATLAB and :func:`scipy.signal.lsim`)
+        compatibility with MATLAB and :func:`scipy.signal.lsim`).  Default
+        value is False.
 
     return_x : bool, optional
         If True, return the state vector (default = False).
@@ -920,8 +1003,6 @@ def impulse_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
     >>> T, yout = impulse_response(sys, T, X0)
 
     """
-    # if system has direct feedthrough, can't simulate impulse response
-    # numerically
     # Convert to state space so that we can simulate
     sys = _convert_to_statespace(sys)
 
@@ -943,42 +1024,13 @@ def impulse_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
         T = _default_time_vector(sys, N=T_num, tfinal=T, is_step=False)
     U = np.zeros_like(T)
 
-    # If squeeze was not specified, figure out the default
-    if squeeze is None:
-        squeeze = config.defaults['control.squeeze_time_response']
-
-    # Figure out what type of step response to compute (SISO, SIMO, MIMO)
-    if squeeze is False:
-        # Drop through to MIMO case
-        pass
-    elif sys.issiso() or isinstance(input, int) or isinstance(output, int):
-        # Get the system we need to simulate
-        squeeze, sys = _get_ss_simo(sys, input, output, squeeze=squeeze)
-
-        #
-        # Compute new X0 that contains the impulse
-        #
-        # We can't put the impulse into U because there is no numerical
-        # representation for it (infinitesimally short, infinitely high).
-        # See also: http://www.mathworks.com/support/tech-notes/1900/1901.html
-        #
-        if isctime(sys):
-            B = np.asarray(sys.B).squeeze()
-            new_X0 = B + X0
-        else:
-            new_X0 = X0
-            U[0] = 1./sys.dt # unit area impulse
-
-        return forced_response(sys, T, U, new_X0, transpose=transpose,
-                               return_x=return_x, squeeze=squeeze)
-    elif input is not None or output is not None:
-        raise ValueError("input and output must either be integers or None")
-
-    # Simulate the response for each input
+    # Set up arrays to handle the output
     ninputs = sys.inputs if input is None else 1
     noutputs = sys.outputs if output is None else 1
-    yout = np.empty((noutputs, ninputs, len(T)))
-    xout = np.empty((sys.states, ninputs, len(T)))
+    yout = np.empty((noutputs, ninputs, np.asarray(T).size))
+    xout = np.empty((sys.states, ninputs, np.asarray(T).size))
+
+    # Simulate the response for each input
     for i in range(sys.inputs):
         # If input keyword was specified, only handle that case
         if isinstance(input, int) and i != input:
@@ -987,7 +1039,13 @@ def impulse_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
         # Get the system we need to simulate
         squeeze, simo = _get_ss_simo(sys, i, output, squeeze=squeeze)
 
+        #
         # Compute new X0 that contains the impulse
+        #
+        # We can't put the impulse into U because there is no numerical
+        # representation for it (infinitesimally short, infinitely high).
+        # See also: http://www.mathworks.com/support/tech-notes/1900/1901.html
+        #
         if isctime(simo):
             B = np.asarray(simo.B).squeeze()
             new_X0 = B + X0
@@ -996,7 +1054,7 @@ def impulse_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
             U[0] = 1./simo.dt # unit area impulse
 
         # Simulate the impulse response fo this input
-        out = forced_response(simo, T, U, new_X0, transpose=transpose,
+        out = forced_response(simo, T, U, new_X0, transpose=False,
                               return_x=return_x, squeeze=squeeze)
 
         # Store the output (and states)
@@ -1005,9 +1063,9 @@ def impulse_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
         if return_x:
             xout[:, i, :] = out[2]
 
-    return _process_time_response(sys, out[0], yout, xout, transpose=transpose,
-                                  return_x=return_x, squeeze=squeeze)
-
+    return _process_time_response(
+        sys, out[0], yout, xout, transpose=transpose, return_x=return_x,
+        squeeze=squeeze, input=input, output=output)
 
 
 # utility function to find time period and time increment using pole locations


### PR DESCRIPTION
This PR implements MIMO impulse and step responses, mirroring the style and functionality of frequency response functions for MIMO systems.  It resolves issue #512 and is consistent with the discussion issue #453. Specifically:

* If a system is MIMO, calling `step_response` or `impulse_response` will generate an array of responses (indexed by output, input, and time).
* Consistent with frequency response methods, if a system is SISO then by default the output will just be indexed by time.
* Input and output axes that are single dimensional can be removed by using the `squeeze=True` keyword.
* SISO systems can be tried as MIMO systems (retaining the output and input axes in the response) using the `squeeze=False` keyword.

Note that the response for `initial_response` and `forced_response` is *not* indexed by the input (since there is no input in one case and a specifically applied input in the other).  The processing of the `squeeze` keyword is the same: by default SISO systems will be returned without the output axis, use `squeeze=True` to remove single dimensional axes from MIMO systems, use `squeeze=False` to force SISO systems to be treated like MIMO systems.

Other (small changes):

* Updated unit tests to make sure all of the squeezing rules are properly implemented with the new MIMO functionality.
* Found a bug in the way that the `transpose` keyword was working: it changed [output, input, time] to [time, input, output] instead of [time, output, input].  This was caught when adding unit tests.
* Found some errors in the MATLAB unit tests where the return arguments were in the wrong order (didn't show up with SISO only responses).