### PR TITLE
Freqplot improvements

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -54,6 +54,7 @@ $Id$
 """
 
 import numpy as np
+from scipy.signal.ltisys import StateSpace
 from . import xferfcn as tf
 from . import statesp as ss
 from . import frdata as frd
@@ -280,7 +281,10 @@ def append(*sys):
     >>> sys = append(sys1, sys2)
 
     """
-    s1 = sys[0]
+    if not isinstance(sys[0], StateSpace):
+        s1 = ss._convert_to_statespace(sys[0])
+    else:
+        s1 = sys[0]
     for s in sys[1:]:
         s1 = s1.append(s)
     return s1

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -54,7 +54,6 @@ $Id$
 """
 
 import numpy as np
-from scipy.signal.ltisys import StateSpace
 from . import xferfcn as tf
 from . import statesp as ss
 from . import frdata as frd
@@ -175,7 +174,7 @@ def negate(sys):
     >>> sys2 = negate(sys1) # Same as sys2 = -sys1.
 
     """
-    return -sys;
+    return -sys
 
 #! TODO: expand to allow sys2 default to work in MIMO case?
 def feedback(sys1, sys2=1, sign=-1):
@@ -281,10 +280,7 @@ def append(*sys):
     >>> sys = append(sys1, sys2)
 
     """
-    if not isinstance(sys[0], StateSpace):
-        s1 = ss._convert_to_statespace(sys[0])
-    else:
-        s1 = sys[0]
+    s1 = ss._convert_to_statespace(sys[0])
     for s in sys[1:]:
         s1 = s1.append(s)
     return s1

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -220,18 +220,17 @@ def bode_plot(syslist, omega=None,
             raise ControlMIMONotImplemented(
                 "Bode is currently only implemented for SISO systems.")
         else:
-            omega_sys = np.array(omega)
-            if sys.isdtime(True):
+            omega_sys = np.asarray(omega)
+            if sys.isdtime(strict=True):
                 nyquistfrq = 2. * math.pi * 1. / sys.dt / 2.
                 omega_sys = omega_sys[omega_sys < nyquistfrq]
                 # TODO: What distance to the Nyquist frequency is appropriate?
             else:
                 nyquistfrq = None
 
-            # Get the magnitude and phase of the system
-            mag_tmp, phase_tmp, omega_sys = sys.frequency_response(omega_sys)
-            mag = np.atleast_1d(np.squeeze(mag_tmp))
-            phase = np.atleast_1d(np.squeeze(phase_tmp))
+            mag, phase, omega_sys = sys.frequency_response(omega_sys)
+            mag = np.atleast_1d(mag)
+            phase = np.atleast_1d(phase)
 
             #
             # Post-process the phase to handle initial value and wrapping
@@ -352,8 +351,7 @@ def bode_plot(syslist, omega=None,
                 # Show the phase and gain margins in the plot
                 if margins:
                     # Compute stability margins for the system
-                    margin = stability_margins(sys)
-                    gm, pm, Wcg, Wcp = (margin[i] for i in (0, 1, 3, 4))
+                    gm, pm, Wcg, Wcp = stability_margins(sys)[0:4]
 
                     # Figure out sign of the phase at the first gain crossing
                     # (needed if phase_wrap is True)

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -199,7 +199,7 @@ def bode_plot(syslist, omega=None,
         omega_was_given = False # used do decide whether to include nyq. freq
         if omega_limits is None:
             # Select a default range if none is provided
-            omega = default_frequency_range(syslist, Hz=Hz,
+            omega = _default_frequency_range(syslist, Hz=Hz,
                                             number_of_samples=omega_num)
         else:
             omega_limits = np.asarray(omega_limits)
@@ -591,16 +591,14 @@ def nyquist_plot(syslist, omega=None, plot=True, omega_limits=None,
     if omega is None:
         if omega_limits is None:
             # Select a default range if none is provided
-            omega = default_frequency_range(syslist, Hz=False,
+            omega = _default_frequency_range(syslist, Hz=False,
                                             number_of_samples=omega_num)
         else:
             omega_limits = np.asarray(omega_limits)
             if len(omega_limits) != 2:
                 raise ValueError("len(omega_limits) must be 2")
-            if omega_num:
-                num = omega_num
-            else:
-                num = config.defaults['freqplot.number_of_samples']
+            num = \
+                ct.config._get_param('freqplot','number_of_samples', omega_num)
             omega = np.logspace(np.log10(omega_limits[0]),
                                 np.log10(omega_limits[1]), num=num,
                                 endpoint=True)
@@ -717,7 +715,7 @@ def gangof4_plot(P, C, omega=None, **kwargs):
     # Select a default range if none is provided
     # TODO: This needs to be made more intelligent
     if omega is None:
-        omega = default_frequency_range((P, C, S))
+        omega = _default_frequency_range((P, C, S))
 
     # Set up the axes with labels so that multiple calls to
     # gangof4_plot will superimpose the data.  See details in bode_plot.
@@ -798,7 +796,7 @@ def gangof4_plot(P, C, omega=None, **kwargs):
 #
 
 # Compute reasonable defaults for axes
-def default_frequency_range(syslist, Hz=None, number_of_samples=None,
+def _default_frequency_range(syslist, Hz=None, number_of_samples=None,
                             feature_periphery_decades=None):
     """Compute a reasonable default frequency range for frequency
     domain plots.
@@ -832,7 +830,7 @@ def default_frequency_range(syslist, Hz=None, number_of_samples=None,
     --------
     >>> from matlab import ss
     >>> sys = ss("1. -2; 3. -4", "5.; 7", "6. 8", "9.")
-    >>> omega = default_frequency_range(sys)
+    >>> omega = _default_frequency_range(sys)
 
     """
     # This code looks at the poles and zeros of all of the systems that

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -50,6 +50,7 @@ import numpy as np
 from .ctrlutil import unwrap
 from .bdalg import feedback
 from .margins import stability_margins
+from .exception import ControlMIMONotImplemented
 from . import config
 
 __all__ = ['bode_plot', 'nyquist_plot', 'gangof4_plot',
@@ -214,9 +215,9 @@ def bode_plot(syslist, omega=None,
 
     mags, phases, omegas, nyquistfrqs = [], [], [], []
     for sys in syslist:
-        if sys.ninputs > 1 or sys.noutputs > 1:
+        if not sys.issiso():
             # TODO: Add MIMO bode plots.
-            raise NotImplementedError(
+            raise ControlMIMONotImplemented(
                 "Bode is currently only implemented for SISO systems.")
         else:
             omega_sys = np.array(omega)
@@ -582,9 +583,9 @@ def nyquist_plot(syslist, omega=None, plot=True, label_freq=0,
                             num=50, endpoint=True, base=10.0)
 
     for sys in syslist:
-        if sys.ninputs > 1 or sys.noutputs > 1:
+        if not sys.issiso():
             # TODO: Add MIMO nyquist plots.
-            raise NotImplementedError(
+            raise ControlMIMONotImplemented(
                 "Nyquist is currently only implemented for SISO systems.")
         else:
             # Get the magnitude and phase of the system
@@ -672,9 +673,9 @@ def gangof4_plot(P, C, omega=None, **kwargs):
     -------
     None
     """
-    if P.ninputs > 1 or P.noutputs > 1 or C.ninputs > 1 or C.noutputs > 1:
+    if not P.issiso() or not C.issiso():
         # TODO: Add MIMO go4 plots.
-        raise NotImplementedError(
+        raise ControlMIMONotImplemented(
             "Gang of four is currently only implemented for SISO systems.")
 
     # Get the default parameter values

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -351,7 +351,8 @@ def bode_plot(syslist, omega=None,
                 # Show the phase and gain margins in the plot
                 if margins:
                     # Compute stability margins for the system
-                    gm, pm, Wcg, Wcp = stability_margins(sys)[0:4]
+                    margin = stability_margins(sys)
+                    gm, pm, Wcg, Wcp = (margin[i] for i in (0, 1, 3, 4))
 
                     # Figure out sign of the phase at the first gain crossing
                     # (needed if phase_wrap is True)

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -457,7 +457,7 @@ def bode_plot(syslist, omega=None,
                             "Gm = %.2f %s(at %.2f %s), "
                             "Pm = %.2f %s (at %.2f %s)" %
                             (20*np.log10(gm) if dB else gm,
-                             'dB ' if dB else '\b',
+                             'dB ' if dB else '',
                              Wcg, 'Hz' if Hz else 'rad/s',
                              pm if deg else math.radians(pm),
                              'deg' if deg else 'rad',

--- a/control/margins.py
+++ b/control/margins.py
@@ -207,7 +207,7 @@ def _poly_z_wstab(num, den, num_inv, den_inv, p_q, dt, epsw):
 
 
 # Took the framework for the old function by
-# Sawyer B. Fuller <minster@caltech.edu>, removed a lot of the innards
+# Sawyer B. Fuller <minster@uw.edu>, removed a lot of the innards
 # and replaced with analytical polynomial functions for LTI systems.
 #
 # idea for the frequency data solution copied/adapted from
@@ -294,29 +294,29 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
             # frequency for gain margin: phase crosses -180 degrees
             w_180 = _poly_iw_real_crossing(num_iw, den_iw, epsw)
             with np.errstate(all='ignore'):  # den=0 is okay
-                w180_resp = evalfr(sys, 1J * w_180)
+                w180_resp = sys(1J * w_180)
 
             # frequency for phase margin : gain crosses magnitude 1
             wc = _poly_iw_mag1_crossing(num_iw, den_iw, epsw)
-            wc_resp = evalfr(sys, 1J * wc)
+            wc_resp = sys(1J * wc)
 
             # stability margin
             wstab = _poly_iw_wstab(num_iw, den_iw, epsw)
-            ws_resp = evalfr(sys, 1J * wstab)
+            ws_resp = sys(1J * wstab)
 
         else:  # Discrete Time
             zargs = _poly_z_invz(sys)
             # gain margin
             z, w_180 = _poly_z_real_crossing(*zargs, epsw=epsw)
-            w180_resp = evalfr(sys, z)
+            w180_resp = sys(z)
 
             # phase margin
             z, wc = _poly_z_mag1_crossing(*zargs, epsw=epsw)
-            wc_resp = evalfr(sys, z)
+            wc_resp = sys(z)
 
             # stability margin
             z, wstab = _poly_z_wstab(*zargs, epsw=epsw)
-            ws_resp = evalfr(sys, z)
+            ws_resp = sys(z)
 
         # only keep frequencies where the negative real axis is crossed
         w_180 = w_180[w180_resp <= 0.]

--- a/control/nichols.py
+++ b/control/nichols.py
@@ -52,7 +52,7 @@ nichols.nichols_grid
 import numpy as np
 import matplotlib.pyplot as plt
 from .ctrlutil import unwrap
-from .freqplot import default_frequency_range
+from .freqplot import _default_frequency_range
 from . import config
 
 __all__ = ['nichols_plot', 'nichols', 'nichols_grid']
@@ -91,7 +91,7 @@ def nichols_plot(sys_list, omega=None, grid=None):
 
     # Select a default range if none is provided
     if omega is None:
-        omega = default_frequency_range(sys_list)
+        omega = _default_frequency_range(sys_list)
 
     for sys in sys_list:
         # Get the magnitude and phase of the system

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -203,7 +203,7 @@ class TestConfig:
         assert not ct.config.defaults['bode.dB']
         assert ct.config.defaults['bode.deg']
         assert not ct.config.defaults['bode.Hz']
-        assert ct.config.defaults['freqplot.number_of_samples'] is None
+        assert ct.config.defaults['freqplot.number_of_samples'] is 1000
         assert ct.config.defaults['freqplot.feature_periphery_decades'] == 1.0
 
     def test_legacy_defaults(self):

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -203,7 +203,7 @@ class TestConfig:
         assert not ct.config.defaults['bode.dB']
         assert ct.config.defaults['bode.deg']
         assert not ct.config.defaults['bode.Hz']
-        assert ct.config.defaults['freqplot.number_of_samples'] is 1000
+        assert ct.config.defaults['freqplot.number_of_samples'] == 1000
         assert ct.config.defaults['freqplot.feature_periphery_decades'] == 1.0
 
     def test_legacy_defaults(self):

--- a/control/tests/freqresp_test.py
+++ b/control/tests/freqresp_test.py
@@ -16,6 +16,7 @@ import control as ctrl
 from control.statesp import StateSpace
 from control.xferfcn import TransferFunction
 from control.matlab import ss, tf, bode, rss
+from control.freqplot import bode_plot, nyquist_plot
 from control.tests.conftest import slycotonly
 
 pytestmark = pytest.mark.usefixtures("mplcleanup")
@@ -61,6 +62,24 @@ def test_bode_basic(ss_siso):
     tf_siso = tf(ss_siso)
     bode(ss_siso)
     bode(tf_siso)
+    assert len(bode_plot(tf_siso, plot=False, omega_num=20)[0] == 20)
+    omega = bode_plot(tf_siso, plot=False, omega_limits=(1, 100))[2]
+    assert_allclose(omega[0], 1)
+    assert_allclose(omega[-1], 100)
+    assert len(bode_plot(tf_siso, plot=False, omega=np.logspace(-1,1,10))[0])\
+         == 10
+
+def test_nyquist_basic(ss_siso):
+    """Test nyquist plot call (Very basic)"""
+    # TODO: proper test
+    tf_siso = tf(ss_siso)
+    nyquist_plot(ss_siso)
+    nyquist_plot(tf_siso)
+    assert len(nyquist_plot(tf_siso, plot=False, omega_num=20)[0] == 20)
+    omega = nyquist_plot(tf_siso, plot=False, omega_limits=(1, 100))[2]
+    assert_allclose(omega[0], 1)
+    assert_allclose(omega[-1], 100)
+    assert len(nyquist_plot(tf_siso, plot=False, omega=np.logspace(-1, 1, 10))[0])==10
 
 
 @pytest.mark.filterwarnings("ignore:.*non-positive left xlim:UserWarning")

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -78,8 +78,8 @@ class TestSisotool:
 
         # Check if the bode_mag line has moved
         bode_mag_moved = np.array(
-            [111.83321224, 92.29238035, 76.02822315, 62.46884113, 51.14108703,
-             41.6554004, 33.69409534, 27.00237344, 21.38086717, 16.67791585])
+            [674.0242, 667.8354, 661.7033, 655.6275, 649.6074, 643.6426,
+              637.7324, 631.8765, 626.0742, 620.3252])
         assert_array_almost_equal(ax_mag.lines[0].get_data()[1][10:20],
                                   bode_mag_moved, 4)
 


### PR DESCRIPTION
fixes to freqplot.py:
* empty glyph in margin plot
* evalfr(sys,s)->sys(s)
* changed to a reasonable number of frequency points (1000) in bode plots (up from a very coarse 50)
* unify frequency range specification between bode and nyquist 
edit:
* mag/phase data in bode plot is now plotted along with vertical nyquist freq line for DT systems so that it is convenient to call `legend(('sys1', 'sys2'))`
* unit tests for frequency ranges