### PR TITLE
rename is_static_gain method in LTI systems to _isstatic

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -288,7 +288,7 @@ class StateSpace(LTI):
         if len(args) == 4:
             if 'dt' in kwargs:
                 dt = kwargs['dt']
-            elif self.is_static_gain():
+            elif self._isstatic():
                 dt = None
             else:
                 dt = config.defaults['control.default_dt']
@@ -300,7 +300,7 @@ class StateSpace(LTI):
             try:
                 dt = args[0].dt
             except AttributeError:
-                if self.is_static_gain():
+                if self._isstatic():
                     dt = None
                 else:
                     dt = config.defaults['control.default_dt']
@@ -1213,7 +1213,7 @@ class StateSpace(LTI):
             gain = np.tile(np.nan, (self.noutputs, self.ninputs))
         return np.squeeze(gain)
 
-    def is_static_gain(self):
+    def _isstatic(self):
         """True if and only if the system has no dynamics, that is,
         if A and B are zero. """
         return not np.any(self.A) and not np.any(self.B)

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -383,7 +383,7 @@ class TestStateSpace:
             mag, phase, omega = sys.freqresp(true_omega)
             np.testing.assert_almost_equal(mag, true_mag)
 
-    def test_is_static_gain(self):
+    def test__isstatic(self):
         A0 = np.zeros((2,2))
         A1 = A0.copy()
         A1[0,1] = 1.1
@@ -394,13 +394,13 @@ class TestStateSpace:
         C1 = np.eye(2)
         D0 = 0
         D1 = np.ones((2,1))
-        assert StateSpace(A0, B0, C1, D1).is_static_gain()
-        assert not StateSpace(A1, B0, C1, D1).is_static_gain()
-        assert not StateSpace(A0, B1, C1, D1).is_static_gain()
-        assert not StateSpace(A1, B1, C1, D1).is_static_gain()
-        assert StateSpace(A0, B0, C0, D0).is_static_gain()
-        assert StateSpace(A0, B0, C0, D1).is_static_gain()
-        assert StateSpace(A0, B0, C1, D0).is_static_gain()
+        assert StateSpace(A0, B0, C1, D1)._isstatic()
+        assert not StateSpace(A1, B0, C1, D1)._isstatic()
+        assert not StateSpace(A0, B1, C1, D1)._isstatic()
+        assert not StateSpace(A1, B1, C1, D1)._isstatic()
+        assert StateSpace(A0, B0, C0, D0)._isstatic()
+        assert StateSpace(A0, B0, C0, D1)._isstatic()
+        assert StateSpace(A0, B0, C1, D0)._isstatic()
 
     @slycotonly
     def test_minreal(self):

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -406,7 +406,7 @@ class TestXferFcn:
         assert (sys1.ninputs, sys1.noutputs) == (2, 1)
         assert sys1.dt == 0.5
 
-    def test_is_static_gain(self):
+    def test__isstatic(self):
         numstatic = 1.1
         denstatic = 1.2
         numdynamic = [1, 1]
@@ -415,18 +415,18 @@ class TestXferFcn:
         denstaticmimo = [[[1.9,], [1.2,]], [[1.2,], [0.8,]]]
         numdynamicmimo = [[[1.1, 0.9], [1.2]], [[1.2], [0.8]]]
         dendynamicmimo = [[[1.1, 0.7], [0.2]], [[1.2], [0.8]]]
-        assert TransferFunction(numstatic, denstatic).is_static_gain()
-        assert TransferFunction(numstaticmimo, denstaticmimo).is_static_gain()
+        assert TransferFunction(numstatic, denstatic)._isstatic()
+        assert TransferFunction(numstaticmimo, denstaticmimo)._isstatic()
 
-        assert not TransferFunction(numstatic, dendynamic).is_static_gain()
-        assert not TransferFunction(numdynamic, dendynamic).is_static_gain()
-        assert not TransferFunction(numdynamic, denstatic).is_static_gain()
-        assert not TransferFunction(numstatic, dendynamic).is_static_gain()
+        assert not TransferFunction(numstatic, dendynamic)._isstatic()
+        assert not TransferFunction(numdynamic, dendynamic)._isstatic()
+        assert not TransferFunction(numdynamic, denstatic)._isstatic()
+        assert not TransferFunction(numstatic, dendynamic)._isstatic()
 
         assert not TransferFunction(numstaticmimo,
-                                    dendynamicmimo).is_static_gain()
+                                    dendynamicmimo)._isstatic()
         assert not TransferFunction(numdynamicmimo,
-                                    denstaticmimo).is_static_gain()
+                                    denstaticmimo)._isstatic()
 
     @pytest.mark.parametrize("omega, resp",
                              [(1, np.array([[-0.5 - 0.5j]])),

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -1122,7 +1122,7 @@ def _ideal_tfinal_and_dt(sys, is_step=True):
     pts_per_cycle = 25  # Number of points divide a period of oscillation
     log_decay_percent = np.log(100)  # Factor of reduction for real pole decays
 
-    if sys.is_static_gain():
+    if sys._isstatic():
         tfinal = default_tfinal
         dt = sys.dt if isdtime(sys, strict=True) else default_dt
     elif isdtime(sys, strict=True):

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -214,7 +214,7 @@ class TransferFunction(LTI):
             # no dt given in positional arguments
             if 'dt' in kwargs:
                 dt = kwargs['dt']
-            elif self.is_static_gain():
+            elif self._isstatic():
                 dt = None
             else:
                 dt = config.defaults['control.default_dt']
@@ -228,7 +228,7 @@ class TransferFunction(LTI):
             try:
                 dt = args[0].dt
             except AttributeError:
-                if self.is_static_gain():
+                if self._isstatic():
                     dt = None
                 else:
                     dt = config.defaults['control.default_dt']
@@ -1084,7 +1084,7 @@ class TransferFunction(LTI):
                         gain[i][j] = np.nan
         return np.squeeze(gain)
 
-    def is_static_gain(self):
+    def _isstatic(self):
          """returns True if and only if all of the numerator and denominator
          polynomials of the (possibly MIMO) transfer function are zeroth order,
          that is, if the system has no dynamics. """


### PR DESCRIPTION
 because it should be private, and to be consistent with iosys