### PR TITLE
sisotool small visual cleanup, new feature to show step response of different input-output than loop

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -334,7 +334,8 @@ def connect(sys, Q, inputv, outputv):
     interconnecting multiple systems.
 
     """
-    inputv, outputv, Q = np.asarray(inputv), np.asarray(outputv), np.asarray(Q)
+    inputv, outputv, Q = \
+        np.atleast_1d(inputv), np.atleast_1d(outputv), np.atleast_1d(Q)
     # check indices
     index_errors = (inputv - 1 > sys.ninputs) | (inputv < 1)
     if np.any(index_errors):

--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -137,8 +137,10 @@ def root_locus(sys, kvect=None, xlim=None, ylim=None,
     print_gain = config._get_param(
         'rlocus', 'print_gain', print_gain, _rlocus_defaults)
 
+    sys_loop = sys if sys.issiso() else sys[0,0]
+
     # Convert numerator and denominator to polynomials if they aren't
-    (nump, denp) = _systopoly1d(sys)
+    (nump, denp) = _systopoly1d(sys_loop)
 
     # if discrete-time system and if xlim and ylim are not given,
     #  that we a view of the unit circle
@@ -540,8 +542,9 @@ def _RLSortRoots(mymat):
 
 def _RLZoomDispatcher(event, sys, ax_rlocus, plotstr):
     """Rootlocus plot zoom dispatcher"""
+    sys_loop = sys if sys.issiso() else sys[0,0]
 
-    nump, denp = _systopoly1d(sys)
+    nump, denp = _systopoly1d(sys_loop)
     xlim, ylim = ax_rlocus.get_xlim(), ax_rlocus.get_ylim()
 
     kvect, mymat, xlim, ylim = _default_gains(
@@ -573,7 +576,9 @@ def _RLClickDispatcher(event, sys, fig, ax_rlocus, plotstr, sisotool=False,
 
 def _RLFeedbackClicksPoint(event, sys, fig, ax_rlocus, sisotool=False):
     """Display root-locus gain feedback point for clicks on root-locus plot"""
-    (nump, denp) = _systopoly1d(sys)
+    sys_loop = sys if sys.issiso() else sys[0,0]
+
+    (nump, denp) = _systopoly1d(sys_loop)
 
     xlim = ax_rlocus.get_xlim()
     ylim = ax_rlocus.get_ylim()
@@ -584,10 +589,10 @@ def _RLFeedbackClicksPoint(event, sys, fig, ax_rlocus, sisotool=False):
     # Catch type error when event click is in the figure but not in an axis
     try:
         s = complex(event.xdata, event.ydata)
-        K = -1. / sys(s)
-        K_xlim = -1. / sys(
+        K = -1. / sys_loop(s)
+        K_xlim = -1. / sys_loop(
             complex(event.xdata + 0.05 * abs(xlim[1] - xlim[0]), event.ydata))
-        K_ylim = -1. / sys(
+        K_ylim = -1. / sys_loop(
             complex(event.xdata, event.ydata + 0.05 * abs(ylim[1] - ylim[0])))
 
     except TypeError:

--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -241,12 +241,12 @@ def root_locus(sys, kvect=None, xlim=None, ylim=None,
             else:
                 _sgrid_func()
         else:
-            ax.axhline(0., linestyle=':', color='k', zorder=-20)
-            ax.axvline(0., linestyle=':', color='k', zorder=-20)
+            ax.axhline(0., linestyle=':', color='k', linewidth=.75, zorder=-20)
+            ax.axvline(0., linestyle=':', color='k', linewidth=.75, zorder=-20)
             if isdtime(sys, strict=True):
                 ax.add_patch(plt.Circle(
                     (0, 0), radius=1.0, linestyle=':', edgecolor='k',
-                    linewidth=1.5, fill=False, zorder=-20))
+                    linewidth=0.75, fill=False, zorder=-20))
 
     return mymat, kvect
 

--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -577,8 +577,8 @@ def _RLFeedbackClicksPoint(event, sys, fig, ax_rlocus, sisotool=False):
 
     xlim = ax_rlocus.get_xlim()
     ylim = ax_rlocus.get_ylim()
-    x_tolerance = 0.05 * abs((xlim[1] - xlim[0]))
-    y_tolerance = 0.05 * abs((ylim[1] - ylim[0]))
+    x_tolerance = 0.1 * abs((xlim[1] - xlim[0]))
+    y_tolerance = 0.1 * abs((ylim[1] - ylim[0]))
     gain_tolerance = np.mean([x_tolerance, y_tolerance])*0.1
 
     # Catch type error when event click is in the figure but not in an axis

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -27,9 +27,11 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
     sys : LTI object
         Linear input/output systems. If sys is SISO, use the same
         system for the root locus and step response. If sys is
-        two-input, two-output, insert the selected gain between the
-        first output and first input and use the second input and output
-        for computing the step response.
+        two-input, two-output, insert the negative of the selected gain
+        between the first output and first input and use the second input
+        and output for computing the step response. This allows you to see
+        the step responses of more complex systems while using sisotool,
+        for example, systems with a feedforward path into the plant.
     kvect : list or ndarray, optional
         List of gains to use for plotting root locus
     xlim_rlocus : tuple or list, optional
@@ -39,21 +41,23 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
         control of y-axis range
     plotstr_rlocus : :func:`matplotlib.pyplot.plot` format string, optional
         plotting style for the root locus plot(color, linestyle, etc)
-    rlocus_grid: boolean (default = False)
-        If True plot s-plane grid.
-    omega : freq_range
-        Range of frequencies in rad/sec for the bode plot
+    rlocus_grid : boolean (default = False)
+        If True plot s- or z-plane grid.
+    omega : array_like
+        List of frequencies in rad/sec to be used for bode plot
     dB : boolean
         If True, plot result in dB for the bode plot
     Hz : boolean
         If True, plot frequency in Hz for the bode plot (omega must be provided in rad/sec)
     deg : boolean
         If True, plot phase in degrees for the bode plot (else radians)
-    omega_limits: tuple, list, ... of two values
+    omega_limits : array_like of two values
         Limits of the to generate frequency vector.
-        If Hz=True the limits are in Hz otherwise in rad/s.
-    omega_num: int
-        number of samples
+        If Hz=True the limits are in Hz otherwise in rad/s. Ignored if omega
+        is provided, and auto-generated if omitted.
+    omega_num : int
+        Number of samples to plot.  Defaults to
+        config.defaults['freqplot.number_of_samples'].
     margins_bode : boolean
         If True, plot gain and phase margin in the bode plot
     tvect : list or ndarray, optional
@@ -69,7 +73,7 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
 
     # sys as loop transfer function if SISO
     if not sys.issiso():
-        if not sys.ninputs == 2 and sys.noutputs == 2:
+        if not (sys.ninputs == 2 and sys.noutputs == 2):
             raise ControlMIMONotImplemented(
                 'sys must be SISO or 2-input, 2-output')
 

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -68,13 +68,10 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
     from .rlocus import root_locus
 
     # sys as loop transfer function if SISO
-    if sys.issiso():
-        sys_loop = sys
-    else:
+    if not sys.issiso():
         if not sys.ninputs == 2 and sys.noutputs == 2:
             raise ControlMIMONotImplemented(
                 'sys must be SISO or 2-input, 2-output')
-        sys_loop = sys[0,0]
 
     # Setup sisotool figure or superimpose if one is already present
     fig = plt.gcf()
@@ -101,7 +98,7 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
         1 if kvect is None else kvect[0], bode_plot_params)
 
     # Setup the root-locus plot window
-    root_locus(sys_loop, kvect=kvect, xlim=xlim_rlocus,
+    root_locus(sys, kvect=kvect, xlim=xlim_rlocus,
         ylim=ylim_rlocus, plotstr=plotstr_rlocus, grid=rlocus_grid,
         fig=fig, bode_plot_params=bode_plot_params, tvect=tvect, sisotool=True)
 
@@ -159,10 +156,10 @@ def _SisotoolUpdate(sys, fig, K, bode_plot_params, tvect=None):
     if sys.issiso():
         sys_closed = (K*sys).feedback(1)
     else:
-        sys_closed = append(sys, K)
+        sys_closed = append(sys, -K)
         connects = [[1, 3],
                     [3, 1]]
-        sys_closed = connect(sys_closed, connects, (2,), (2,))
+        sys_closed = connect(sys_closed, connects, 2, 2)
     if tvect is None:
         tvect, yout = step_response(sys_closed, T_num=100)
     else:

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -10,11 +10,10 @@ import matplotlib
 import matplotlib.pyplot as plt
 import warnings
 
-def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
-             plotstr_rlocus = 'b' if int(matplotlib.__version__[0]) == 1 else 'C0',
-             rlocus_grid = False, omega = None, dB = None, Hz = None,
-             deg = None, omega_limits = None, omega_num = None,
-             margins_bode = True, tvect=None):
+def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
+             plotstr_rlocus='C0', rlocus_grid=False, omega=None, dB=None,
+             Hz=None, deg=None, omega_limits=None, omega_num=None,
+             margins_bode=True, tvect=None):
     """
     Sisotool style collection of plots inspired by MATLAB's sisotool.
     The left two plots contain the bode magnitude and phase diagrams.
@@ -26,12 +25,15 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
     ----------
     sys : LTI object
         Linear input/output systems. If sys is SISO, use the same
-        system for the root locus and step response. If sys is
-        two-input, two-output, insert the negative of the selected gain
-        between the first output and first input and use the second input
-        and output for computing the step response. This allows you to see
-        the step responses of more complex systems while using sisotool,
-        for example, systems with a feedforward path into the plant.
+        system for the root locus and step response. If it is desired to
+        see a different step response than feedback(K*loop,1), sys can be
+        provided as a two-input, two-output system (e.g. by using
+        :func:`bdgalg.connect' or :func:`iosys.interconnect`). Sisotool
+        inserts the negative of the selected gain K between the first output
+        and first input and uses the second input and output for computing
+        the step response. This allows you to see the step responses of more
+        complex systems, for example, systems with a feedforward path into the
+        plant or in which the gain appears in the feedback path.
     kvect : list or ndarray, optional
         List of gains to use for plotting root locus
     xlim_rlocus : tuple or list, optional
@@ -108,12 +110,8 @@ def sisotool(sys, kvect = None, xlim_rlocus = None, ylim_rlocus = None,
 
 def _SisotoolUpdate(sys, fig, K, bode_plot_params, tvect=None):
 
-    if int(matplotlib.__version__[0]) == 1:
-        title_font_size = 12
-        label_font_size = 10
-    else:
-        title_font_size = 10
-        label_font_size = 8
+    title_font_size = 10
+    label_font_size = 8
 
     # Get the subaxes and clear them
     ax_mag, ax_rlocus, ax_phase, ax_step = \
@@ -144,7 +142,7 @@ def _SisotoolUpdate(sys, fig, K, bode_plot_params, tvect=None):
 
     ax_step.set_title('Step response',fontsize = title_font_size)
     ax_step.set_xlabel('Time (seconds)',fontsize=label_font_size)
-    ax_step.set_ylabel('Amplitude',fontsize=label_font_size)
+    ax_step.set_ylabel('Output',fontsize=label_font_size)
     ax_step.get_xaxis().set_label_coords(0.5, -0.15)
     ax_step.get_yaxis().set_label_coords(-0.15, 0.5)
     ax_step.tick_params(axis='both', which='major', labelsize=label_font_size)

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -22,6 +22,11 @@ class TestSisotool:
         return TransferFunction([1000], [1, 25, 100, 0])
 
     @pytest.fixture
+    def sysdt(self):
+        """Return a generic SISO transfer function"""
+        return TransferFunction([1000], [1, 25, 100, 0], True)
+
+    @pytest.fixture
     def sys222(self):
         """2-states square system (2 inputs x 2 outputs)"""
         A222 = [[4., 1.],
@@ -45,7 +50,7 @@ class TestSisotool:
         D221 = [[1., -1.]]
         return StateSpace(A222, B222, C221, D221)
 
-    def test_sisotool(self, sys, sys222, sys221):
+    def test_sisotool(self, sys, sysdt, sys222, sys221):
         sisotool(sys, Hz=False)
         fig = plt.gcf()
         ax_mag, ax_rlocus, ax_phase, ax_step = fig.axes[:4]
@@ -114,10 +119,14 @@ class TestSisotool:
         step_response_moved = np.array(
             [0., 0.0072, 0.0516, 0.1554, 0.3281, 0.5681, 0.8646, 1.1987,
              1.5452, 1.875])
-        # old: array([0., 0.0239, 0.161 , 0.4547, 0.8903, 1.407,
-        #             1.9121, 2.2989, 2.4686, 2.353])
         assert_array_almost_equal(
             ax_step.lines[0].get_data()[1][:10], step_response_moved, 4)
+
+        # test supply tvect
+        sisotool(sys, tvect=np.arange(0, 1, .1))
+
+        # test discrete-time
+        sisotool(sysdt, tvect=5)
 
         # test MIMO compatibility
         # sys must be siso or 2 input, 2 output
@@ -125,4 +134,6 @@ class TestSisotool:
             sisotool(sys221)
         # does not raise an error:
         sisotool(sys222)
+
+
 


### PR DESCRIPTION
This PR adds a new feature to sisotool that allows it to show the step response of a system that is not the loop transfer function L. Some visual cleanup including reducing oversized axis tick labels. 

* To see a the step response of a more complicated system that includes a feedforward controller, or any other input-output pair, you can do so by passing sisotool a 2 input, 2-output system. The gain you choose when you click the rlocus plot gets inserted between output[0] and input[0], and then the step response is between input[1] and output[1]. 
* Doubled the click threshold size in rlocus because I had a hard time aiming the mouse well enough to get successful click events.  