### PR TITLE
Update xferfcn.py - numpy deprecations.

### DIFF
--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1559,7 +1559,7 @@ def _clean_part(data):
     for i in range(len(data)):
         for j in range(len(data[i])):
             for k in range(len(data[i][j])):
-                if isinstance(data[i][j][k], (int, np.int)):
+                if isinstance(data[i][j][k], (int, np.int32, np.int64)):
                     data[i][j][k] = float(data[i][j][k])
 
     return data


### PR DESCRIPTION
> DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Changed the logic to check for an instance of both 32 & 64-bit ints.

The `np.int` is covered by the builtin `int`:

```
>>> isinstance(np.int(1), (int, np.int32, np.int64))
True
>>> isinstance(int(1), (int, np.int32, np.int64))
True
```