### PR TITLE
Fix inconsistencies in frequency response at poles

### DIFF
--- a/control/lti.py
+++ b/control/lti.py
@@ -644,8 +644,9 @@ def dcgain(sys):
     Returns
     -------
     gain : ndarray
-        The zero-frequency gain, or np.nan if the system has a pole
-        at the origin
+        The zero-frequency gain, or np.inf if the system has a pole at the
+        origin, np.nan if there is a pole/zero cancellation at the origin.
+
     """
     return sys.dcgain()
 

--- a/control/lti.py
+++ b/control/lti.py
@@ -644,8 +644,9 @@ def dcgain(sys):
     Returns
     -------
     gain : ndarray
-        The zero-frequency gain, or np.inf if the system has a pole at the
-        origin, np.nan if there is a pole/zero cancellation at the origin.
+        The zero-frequency gain, or (inf + nanj) if the system has a pole at
+        the origin, (nan + nanj) if there is a pole/zero cancellation at the
+        origin.
 
     """
     return sys.dcgain()

--- a/control/margins.py
+++ b/control/margins.py
@@ -294,8 +294,7 @@ def stability_margins(sysdata, returnall=False, epsw=0.0):
             num_iw, den_iw = _poly_iw(sys)
             # frequency for gain margin: phase crosses -180 degrees
             w_180 = _poly_iw_real_crossing(num_iw, den_iw, epsw)
-            with np.errstate(all='ignore'):  # den=0 is okay
-                w180_resp = sys(1J * w_180)
+            w180_resp = sys(1J * w_180, warn_infinite=False)  # den=0 is okay
 
             # frequency for phase margin : gain crosses magnitude 1
             wc = _poly_iw_mag1_crossing(num_iw, den_iw, epsw)

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1219,9 +1219,10 @@ class StateSpace(LTI):
         Returns
         -------
         gain : ndarray
-            An array of shape (outputs,inputs); the array will either
-            be the zero-frequency (or DC) gain, or, if the frequency
-            response is singular, the array will be filled with np.inf.
+            An array of shape (outputs,inputs); the array will either be the
+            zero-frequency (or DC) gain, or, if the frequency response is
+            singular, the array will be filled with (inf + nanj).
+
         """
         return self(0, warn_infinite=warn_infinite) if self.isctime() \
             else self(1, warn_infinite=warn_infinite)

--- a/control/tests/freqresp_test.py
+++ b/control/tests/freqresp_test.py
@@ -367,7 +367,7 @@ def test_phase_wrap(TF, wrap_phase, min_phase, max_phase):
 
 
 def test_freqresp_warn_infinite():
-    """Test evaluation of transfer functions at the origin"""
+    """Test evaluation warnings for transfer functions w/ pole at the origin"""
     sys_finite = ctrl.tf([1], [1, 0.01])
     sys_infinite = ctrl.tf([1], [1, 0.01, 0])
 
@@ -378,11 +378,13 @@ def test_freqresp_warn_infinite():
 
     # Transfer function with infinite zero frequency gain
     with pytest.warns(RuntimeWarning, match="divide by zero"):
-        np.testing.assert_almost_equal(sys_infinite(0), np.inf)
+        np.testing.assert_almost_equal(
+            sys_infinite(0), complex(np.inf, np.nan))
     with pytest.warns(RuntimeWarning, match="divide by zero"):
         np.testing.assert_almost_equal(
-            sys_infinite(0, warn_infinite=True), np.inf)
-    np.testing.assert_almost_equal(sys_infinite(0, warn_infinite=False), np.inf)
+            sys_infinite(0, warn_infinite=True), complex(np.inf, np.nan))
+    np.testing.assert_almost_equal(
+        sys_infinite(0, warn_infinite=False), complex(np.inf, np.nan))
 
     # Switch to state space
     sys_finite = ctrl.tf2ss(sys_finite)
@@ -394,13 +396,15 @@ def test_freqresp_warn_infinite():
     np.testing.assert_almost_equal(sys_finite(0, warn_infinite=True), 100)
 
     # State space system with infinite zero frequency gain
-    with pytest.warns(RuntimeWarning, match="not finite"):
-        np.testing.assert_almost_equal(sys_infinite(0), np.inf)
-    with pytest.warns(RuntimeWarning, match="not finite"):
-        np.testing.assert_almost_equal(sys_infinite(0), np.inf)
-    np.testing.assert_almost_equal(sys_infinite(0, warn_infinite=True), np.inf)
-    np.testing.assert_almost_equal(sys_infinite(0, warn_infinite=False), np.inf)
-    
+    with pytest.warns(RuntimeWarning, match="singular matrix"):
+        np.testing.assert_almost_equal(
+            sys_infinite(0), complex(np.inf, np.nan))
+    with pytest.warns(RuntimeWarning, match="singular matrix"):
+        np.testing.assert_almost_equal(
+            sys_infinite(0, warn_infinite=True), complex(np.inf, np.nan))
+    np.testing.assert_almost_equal(sys_infinite(
+        0, warn_infinite=False), complex(np.inf, np.nan))
+
 
 def test_dcgain_consistency():
     """Test to make sure that DC gain is consistently evaluated"""
@@ -412,25 +416,74 @@ def test_dcgain_consistency():
     sys_ss = ctrl.tf2ss(sys_tf)
     assert 0 in sys_ss.pole()
 
-    # Evaluation
-    np.testing.assert_equal(sys_tf(0), np.inf + 0j)
-    np.testing.assert_equal(sys_ss(0), np.inf + 0j)
-    np.testing.assert_equal(sys_tf.dcgain(), np.inf + 0j)
-    np.testing.assert_equal(sys_ss.dcgain(), np.inf + 0j)
+    # Finite (real) numerator over 0 denominator => inf + nanj
+    np.testing.assert_equal(
+        sys_tf(0, warn_infinite=False), complex(np.inf, np.nan))
+    np.testing.assert_equal(
+        sys_ss(0, warn_infinite=False), complex(np.inf, np.nan))
+    np.testing.assert_equal(
+        sys_tf(0j, warn_infinite=False), complex(np.inf, np.nan))
+    np.testing.assert_equal(
+        sys_ss(0j, warn_infinite=False), complex(np.inf, np.nan))
+    np.testing.assert_equal(
+        sys_tf.dcgain(warn_infinite=False), complex(np.inf, np.nan))
+    np.testing.assert_equal(
+        sys_ss.dcgain(warn_infinite=False), complex(np.inf, np.nan))
 
     # Set up transfer function with pole, zero at the origin
     sys_tf = ctrl.tf([1, 0], [1, 0])
     assert 0 in sys_tf.pole()
     assert 0 in sys_tf.zero()
-    
+
     sys_ss = ctrl.tf2ss(ctrl.tf([1, 0], [1, 1])) * \
         ctrl.tf2ss(ctrl.tf([1], [1, 0]))
     assert 0 in sys_ss.pole()
     assert 0 in sys_ss.zero()
 
-    # Pole and zero at the origin should give nan for the response
-    np.testing.assert_equal(sys_tf(0), np.nan)
-    np.testing.assert_equal(sys_tf.dcgain(), np.nan)
-    # TODO: state space cases not yet working
-    # np.testing.assert_equal(sys_ss(0), np.nan)
-    # np.testing.assert_equal(sys_ss.dcgain(), np.nan)
+    # Pole and zero at the origin should give nan + nanj for the response
+    np.testing.assert_equal(
+        sys_tf(0, warn_infinite=False), complex(np.nan, np.nan))
+    np.testing.assert_equal(
+        sys_tf(0j, warn_infinite=False), complex(np.nan, np.nan))
+    np.testing.assert_equal(
+        sys_tf.dcgain(warn_infinite=False), complex(np.nan, np.nan))
+    np.testing.assert_equal(
+        sys_ss(0, warn_infinite=False), complex(np.nan, np.nan))
+    np.testing.assert_equal(
+        sys_ss(0j, warn_infinite=False), complex(np.nan, np.nan))
+    np.testing.assert_equal(
+        sys_ss.dcgain(warn_infinite=False), complex(np.nan, np.nan))
+
+    # Pole with non-zero, complex numerator => inf + infj
+    s = ctrl.tf('s')
+    sys_tf = (s + 1) / (s**2 + 1)
+    assert 1j in sys_tf.pole()
+
+    # Set up state space system with pole on imaginary axis
+    sys_ss = ctrl.tf2ss(sys_tf)
+    assert 1j in sys_tf.pole()
+
+    # Make sure we get correct response if evaluated at the pole
+    np.testing.assert_equal(
+        sys_tf(1j, warn_infinite=False), complex(np.inf, np.inf))
+
+    # For state space, numerical errors come into play
+    resp_ss = sys_ss(1j, warn_infinite=False)
+    if np.isfinite(resp_ss):
+        assert abs(resp_ss) > 1e15
+    else:
+        if resp_ss != complex(np.inf, np.inf):
+            pytest.xfail("statesp evaluation at poles not fully implemented")
+        else:
+            np.testing.assert_equal(resp_ss, complex(np.inf, np.inf))
+
+    # DC gain is finite
+    np.testing.assert_almost_equal(sys_tf.dcgain(), 1.)
+    np.testing.assert_almost_equal(sys_ss.dcgain(), 1.)
+
+    # Make sure that we get the *signed* DC gain
+    sys_tf = -1 / (s + 1)
+    np.testing.assert_almost_equal(sys_tf.dcgain(), -1)
+
+    sys_ss = ctrl.tf2ss(sys_tf)
+    np.testing.assert_almost_equal(sys_ss.dcgain(), -1)

--- a/control/tests/input_element_int_test.py
+++ b/control/tests/input_element_int_test.py
@@ -23,7 +23,7 @@ class TestTfInputIntElement:
 
         sys = tf(num, den)
 
-        np.testing.assert_array_max_ulp(1., dcgain(sys))
+        np.testing.assert_almost_equal(1., dcgain(sys))
 
     def test_tf_num_with_numpy_int_element(self):
         num = np.convolve([1], [1, 1])
@@ -31,7 +31,7 @@ class TestTfInputIntElement:
 
         sys = tf(num, den)
 
-        np.testing.assert_array_max_ulp(1., dcgain(sys))
+        np.testing.assert_almost_equal(1., dcgain(sys))
 
     # currently these pass
     def test_tf_input_with_int_element(self):
@@ -40,7 +40,7 @@ class TestTfInputIntElement:
 
         sys = tf(num, den)
 
-        np.testing.assert_array_max_ulp(1., dcgain(sys))
+        np.testing.assert_almost_equal(1., dcgain(sys))
 
     def test_ss_input_with_int_element(self):
         a = np.array([[0, 1],
@@ -52,7 +52,7 @@ class TestTfInputIntElement:
 
         sys = ss(a, b, c, d)
         sys2 = tf(sys)
-        np.testing.assert_array_max_ulp(dcgain(sys), dcgain(sys2))
+        np.testing.assert_almost_equal(dcgain(sys), dcgain(sys2))
 
     def test_ss_input_with_0int_dcgain(self):
         a = np.array([[0, 1],

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -498,7 +498,7 @@ class TestStateSpace:
         np.testing.assert_allclose(sys2.dcgain(), expected)
 
         sys3 = StateSpace(0., 1., 1., 0.)
-        np.testing.assert_equal(sys3.dcgain(), np.nan)
+        np.testing.assert_equal(sys3.dcgain(), np.inf)
 
     def test_dc_gain_discr(self):
         """Test DC gain for discrete-time state-space systems."""
@@ -516,7 +516,7 @@ class TestStateSpace:
 
         # summer
         sys = StateSpace(1, 1, 1, 0, True)
-        np.testing.assert_equal(sys.dcgain(), np.nan)
+        np.testing.assert_equal(sys.dcgain(), np.inf)
 
     @pytest.mark.parametrize("outputs", range(1, 6))
     @pytest.mark.parametrize("inputs", range(1, 6))
@@ -539,7 +539,7 @@ class TestStateSpace:
         c = np.eye(max(outputs, states))[:outputs, :states]
         d = np.zeros((outputs, inputs))
         sys = StateSpace(a, b, c, d, dt)
-        dc = np.squeeze(np.full_like(d, np.nan))
+        dc = np.squeeze(np.full_like(d, np.inf))
         np.testing.assert_array_equal(dc, sys.dcgain())
 
     def test_scalar_static_gain(self):

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -523,7 +523,7 @@ class TestStateSpace:
     @pytest.mark.parametrize("dt", [None, 0, 1, True],
                              ids=["dtNone", "c", "dt1", "dtTrue"])
     def test_dc_gain_integrator(self, outputs, inputs, dt):
-        """DC gain when eigenvalue at DC returns appropriately sized array of nan.
+        """DC gain w/ pole at origin returns appropriately sized array of inf.
 
         the SISO case is also tested in test_dc_gain_{cont,discr}
         time systems (dt=0)

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -21,7 +21,6 @@ from control.statesp import (StateSpace, _convert_to_statespace, drss,
                              rss, ss, tf2ss, _statesp_defaults)
 from control.tests.conftest import ismatarrayout, slycotonly
 from control.xferfcn import TransferFunction, ss2tf
-from control.exception import ControlSlycot
 
 from .conftest import editsdefaults
 

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -807,7 +807,7 @@ class TestXferFcn:
         np.testing.assert_equal(sys2.dcgain(), 2)
 
         sys3 = TransferFunction(6, [1, 0])
-        np.testing.assert_equal(sys3.dcgain(), np.inf)
+        np.testing.assert_equal(sys3.dcgain(), complex(np.inf, np.nan))
 
         num = [[[15], [21], [33]], [[10], [14], [22]]]
         den = [[[1, 3], [2, 3], [3, 3]], [[1, 5], [2, 7], [3, 11]]]
@@ -827,8 +827,13 @@ class TestXferFcn:
 
         # differencer
         sys = TransferFunction(1, [1, -1], True)
+        np.testing.assert_equal(sys.dcgain(), complex(np.inf, np.nan))
+
+        # differencer, with warning
+        sys = TransferFunction(1, [1, -1], True)
         with pytest.warns(RuntimeWarning, match="divide by zero"):
-            np.testing.assert_equal(sys.dcgain(), np.inf)
+            np.testing.assert_equal(
+                sys.dcgain(warn_infinite=True), complex(np.inf, np.nan))
 
         # summer
         sys = TransferFunction([1, -1], [1], True)


### PR DESCRIPTION
This PR addresses issue #532 regarding inconsistencies in the return values for various frequency response functions.  The changes fixes a number of previous inconsistencies, where state space and transfer function representations could return different values and evaluating the frequency response at the "origin" gave different values depending on whether you evaluated at 0 or 0j.

The changes here only affect results when evaluating the system at a pole of the system.

In this PR:
* State space systems and transfer functions return the same values when evaluated at poles (including poles at the origin):
  * Evaluation at 0 with pole at the origin: returns (inf + nanj)
  * Evaluation at non-origin pole with nonzero numerator: returns (inf + infj)
  * Evaluation at pole with cancellation by a zero: returns (nan + nanj)
* State space systems and transfer functions interpret argument as a complex number, so that G(0) and G(0j) return the same value.
* Computing the DC gain is (exactly) the same as evaluating at 0

A few other small changes:
* Added a `warn_infinity` flag to all functions used to evaluate frequency response.  By default this is set to `True`, in which case you get a divide by zero warning or singular matrix warning when evaluating at a pole.  Setting it to `False` suppresses this warning.  (Also, `dcgain` sets `warn_infinity` to False by default).
* Updated docstrings and unit tests