### PR TITLE
eliminate warnings in freqresp_test.py 

### DIFF
--- a/control/tests/freqresp_test.py
+++ b/control/tests/freqresp_test.py
@@ -220,7 +220,7 @@ def dsystem_dt(request):
     dt = request.param
     systems = {'sssiso': StateSpace(sys.A, sys.B, sys.C, sys.D, dt),
                'ssmimo': StateSpace(A, B, C, D, dt),
-               'tf': TransferFunction([1, 1], [1, 2, 1], dt)}
+               'tf': TransferFunction([2, 1], [2, 1, 1], dt)}
     return systems
 
 


### PR DESCRIPTION
by changing discrete-time transfer function in `freqresp_test.py` to be a better-behaved, stable transfer function that does not have poles and zeros on the unit circle, addressing #538 . This is a somewhat quick fix. It doesn't address the deeper issue of how to best accommodate poles and zeros along the imaginary axis(cont time)/unit circle(discrete time) in `freqplot.py`. 