### PR TITLE
new dynamics() and output() methods in StateSpace

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -736,10 +736,11 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
             warn("Parameters passed to LinearIOSystems are ignored.")
 
     def dynamics(self, t, x, u):
-        # Convert input to column vector and then change output to 1D array
-        xdot = np.dot(self.A, np.reshape(x, (-1, 1))) \
-            + np.dot(self.B, np.reshape(u, (-1, 1)))
-        return np.array(xdot).reshape((-1,))
+        return StateSpace.dynamics(self, t, x, u)
+#        # Convert input to column vector and then change output to 1D array
+#        xdot = np.dot(self.A, np.reshape(x, (-1, 1))) \
+#            + np.dot(self.B, np.reshape(u, (-1, 1)))
+#        return np.array(xdot).reshape((-1,))
 
     def output(self, t, x, u):
         # Convert input to column vector and then change output to 1D array

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -735,18 +735,8 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
         if params and warning:
             warn("Parameters passed to LinearIOSystems are ignored.")
 
-    def dynamics(self, t, x, u):
-        return StateSpace.dynamics(self, t, x, u)
-#        # Convert input to column vector and then change output to 1D array
-#        xdot = np.dot(self.A, np.reshape(x, (-1, 1))) \
-#            + np.dot(self.B, np.reshape(u, (-1, 1)))
-#        return np.array(xdot).reshape((-1,))
-
-    def output(self, t, x, u):
-        # Convert input to column vector and then change output to 1D array
-        y = np.dot(self.C, np.reshape(x, (-1, 1))) \
-            + np.dot(self.D, np.reshape(u, (-1, 1)))
-        return np.array(y).reshape((-1,))
+    dynamics = StateSpace.dynamics
+    output = StateSpace.output
 
 
 class NonlinearIOSystem(InputOutputSystem):

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -101,7 +101,7 @@ def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
 
     # First time call to setup the bode and step response plots
     _SisotoolUpdate(sys, fig,
-        1 if kvect is None else kvect[0], bode_plot_params)
+        1 if kvect is None else kvect[0], bode_plot_params, tvect=tvect)
 
     # Setup the root-locus plot window
     root_locus(sys, kvect=kvect, xlim=xlim_rlocus,

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1215,8 +1215,76 @@ class StateSpace(LTI):
 
     def _isstatic(self):
         """True if and only if the system has no dynamics, that is,
-        if A and B are zero. """
+        if `self.A` and `self.B` are zero.
+        """
         return not np.any(self.A) and not np.any(self.B)
+
+    def dynamics(self, x, u=None):
+        """Compute the dynamics of the system
+
+        Given input `u` and state `x`, returns the dynamics of the state-space
+        system. If the system is continuous, returns the time derivative dx/dt
+
+            dx/dt = A x + B u
+
+        where A and B are the state-space matrices of the system. If the
+        system is discrete-time, returns the next value of `x`:
+
+            x[k+1] = A x[k] + B u[k]
+
+        The inputs `x` and `u` must be of the correct length.
+
+        Parameters
+        ----------
+        x : array_like
+            current state
+        u : array_like
+            input (optional)
+
+        Returns
+        -------
+        dx/dt or x[k+1] : ndarray
+        """
+
+        if len(np.atleast_1d(x)) != self.nstates:
+            raise ValueError("len(x) must be equal to number of states")
+        if u is not None:
+            if len(np.atleast_1d(u)) != self.ninputs:
+                raise ValueError("len(u) must be equal to number of inputs")
+
+        return self.A.dot(x) if u is None else self.A.dot(x) + self.B.dot(u)
+
+    def output(self, x, u=None):
+        """Compute the output of the system
+
+        Given input `u` and state `x`, returns the output `y` of the
+        state-space system:
+
+            y = C x + D u
+
+        where A and B are the state-space matrices of the system. The inputs
+        `x` and `u` must be of the correct length.
+
+        Parameters
+        ----------
+        x : array_like
+            current state
+        u : array_like
+            input (optional)
+
+        Returns
+        -------
+        y : ndarray
+        """
+        if len(np.atleast_1d(x)) != self.nstates:
+            raise ValueError("len(x) must be equal to number of states")
+        if u is not None:
+            if len(np.atleast_1d(u)) != self.ninputs:
+                raise ValueError("len(u) must be equal to number of inputs")
+
+        return self.C.dot(x) if u is None else self.C.dot(x) + self.D.dot(u)
+
+
 
 
 # TODO: add discrete time check

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -56,7 +56,7 @@ class TestIOSys:
         # Make sure that the right hand side matches linear system
         for x, u in (([0, 0], 0), ([1, 0], 0), ([0, 1], 0), ([0, 0], 1)):
             np.testing.assert_array_almost_equal(
-                np.reshape(iosys._rhs(0, x, u), (-1, 1)),
+                np.reshape(iosys.dynamics(0, x, u), (-1, 1)),
                 np.dot(linsys.A, np.reshape(x, (-1, 1))) + np.dot(linsys.B, u))
 
         # Make sure that simulations also line up
@@ -687,7 +687,7 @@ class TestIOSys:
         assert result.success
         np.testing.assert_array_almost_equal(xeq, [1.64705879, 1.17923874])
         np.testing.assert_array_almost_equal(
-            nlsys._rhs(0, xeq, ueq), np.zeros((2,)))
+            nlsys.dynamics(0, xeq, ueq), np.zeros((2,)))
 
         # Ducted fan dynamics with output = velocity
         nlsys = ios.NonlinearIOSystem(pvtol, lambda t, x, u, params: x[0:2])
@@ -697,7 +697,7 @@ class TestIOSys:
             nlsys, [0, 0, 0, 0], [0, 4*9.8], return_result=True)
         assert result.success
         np.testing.assert_array_almost_equal(
-            nlsys._rhs(0, xeq, ueq), np.zeros((4,)))
+            nlsys.dynamics(0, xeq, ueq), np.zeros((4,)))
         np.testing.assert_array_almost_equal(xeq, [0, 0, 0, 0])
 
         # Use a small lateral force to cause motion
@@ -705,7 +705,7 @@ class TestIOSys:
             nlsys, [0, 0, 0, 0], [0.01, 4*9.8], return_result=True)
         assert result.success
         np.testing.assert_array_almost_equal(
-            nlsys._rhs(0, xeq, ueq), np.zeros((4,)), decimal=5)
+            nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
         # Equilibrium point with fixed output
         xeq, ueq, result = ios.find_eqpt(
@@ -715,7 +715,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(
             nlsys._out(0, xeq, ueq), [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys._rhs(0, xeq, ueq), np.zeros((4,)), decimal=5)
+            nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
         # Specify outputs to constrain (replicate previous)
         xeq, ueq, result = ios.find_eqpt(
@@ -725,7 +725,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(
             nlsys._out(0, xeq, ueq), [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys._rhs(0, xeq, ueq), np.zeros((4,)), decimal=5)
+            nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
         # Specify inputs to constrain (replicate previous), w/ no result
         xeq, ueq = ios.find_eqpt(
@@ -733,7 +733,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(
             nlsys._out(0, xeq, ueq), [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys._rhs(0, xeq, ueq), np.zeros((4,)), decimal=5)
+            nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
         # Now solve the problem with the original PVTOL variables
         # Constrain the output angle and x velocity
@@ -746,7 +746,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(
             nlsys_full._out(0, xeq, ueq)[[2, 3]], [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys_full._rhs(0, xeq, ueq)[-4:], np.zeros((4,)), decimal=5)
+            nlsys_full.dynamics(0, xeq, ueq)[-4:], np.zeros((4,)), decimal=5)
 
         # Fix one input and vary the other
         nlsys_full = ios.NonlinearIOSystem(pvtol_full, None)
@@ -759,7 +759,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(
             nlsys_full._out(0, xeq, ueq)[[3]], [0.1], decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys_full._rhs(0, xeq, ueq)[-4:], np.zeros((4,)), decimal=5)
+            nlsys_full.dynamics(0, xeq, ueq)[-4:], np.zeros((4,)), decimal=5)
 
         # PVTOL with output = y velocity
         xeq, ueq, result = ios.find_eqpt(
@@ -771,7 +771,7 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(
             nlsys_full._out(0, xeq, ueq)[-3:], [0.1, 0, 0], decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys_full._rhs(0, xeq, ueq)[-5:], np.zeros((5,)), decimal=5)
+            nlsys_full.dynamics(0, xeq, ueq)[-5:], np.zeros((5,)), decimal=5)
 
         # Unobservable system
         linsys = ct.StateSpace(

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -713,7 +713,7 @@ class TestIOSys:
             y0=[0.1, 0.1], return_result=True)
         assert result.success
         np.testing.assert_array_almost_equal(
-            nlsys._out(0, xeq, ueq), [0.1, 0.1], decimal=5)
+            nlsys.output(0, xeq, ueq), [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
             nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
@@ -723,7 +723,7 @@ class TestIOSys:
             iy = [0, 1], return_result=True)
         assert result.success
         np.testing.assert_array_almost_equal(
-            nlsys._out(0, xeq, ueq), [0.1, 0.1], decimal=5)
+            nlsys.output(0, xeq, ueq), [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
             nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
@@ -731,7 +731,7 @@ class TestIOSys:
         xeq, ueq = ios.find_eqpt(
             nlsys, [0, 0, 0, 0], [0.01, 4*9.8], y0=[0.1, 0.1], iu = [])
         np.testing.assert_array_almost_equal(
-            nlsys._out(0, xeq, ueq), [0.1, 0.1], decimal=5)
+            nlsys.output(0, xeq, ueq), [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
             nlsys.dynamics(0, xeq, ueq), np.zeros((4,)), decimal=5)
 
@@ -744,7 +744,7 @@ class TestIOSys:
             idx=[2, 3, 4, 5], ix=[0, 1], return_result=True)
         assert result.success
         np.testing.assert_array_almost_equal(
-            nlsys_full._out(0, xeq, ueq)[[2, 3]], [0.1, 0.1], decimal=5)
+            nlsys_full.output(0, xeq, ueq)[[2, 3]], [0.1, 0.1], decimal=5)
         np.testing.assert_array_almost_equal(
             nlsys_full.dynamics(0, xeq, ueq)[-4:], np.zeros((4,)), decimal=5)
 
@@ -757,7 +757,7 @@ class TestIOSys:
         assert result.success
         np.testing.assert_almost_equal(ueq[1], 4*9.8, decimal=5)
         np.testing.assert_array_almost_equal(
-            nlsys_full._out(0, xeq, ueq)[[3]], [0.1], decimal=5)
+            nlsys_full.output(0, xeq, ueq)[[3]], [0.1], decimal=5)
         np.testing.assert_array_almost_equal(
             nlsys_full.dynamics(0, xeq, ueq)[-4:], np.zeros((4,)), decimal=5)
 
@@ -769,7 +769,7 @@ class TestIOSys:
             ix=[0, 1], return_result=True)
         assert result.success
         np.testing.assert_array_almost_equal(
-            nlsys_full._out(0, xeq, ueq)[-3:], [0.1, 0, 0], decimal=5)
+            nlsys_full.output(0, xeq, ueq)[-3:], [0.1, 0, 0], decimal=5)
         np.testing.assert_array_almost_equal(
             nlsys_full.dynamics(0, xeq, ueq)[-5:], np.zeros((5,)), decimal=5)
 

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -757,44 +757,65 @@ class TestStateSpace:
             np.squeeze(sys322.horner(1.j)),
             mag[:, :, 0] * np.exp(1.j * phase[:, :, 0]))
 
-    @pytest.mark.parametrize('x', [[1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
+    @pytest.mark.parametrize('x',
+        [None, [1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
     @pytest.mark.parametrize('u', [None, 0, 1, np.atleast_1d(2)])
     def test_dynamics_output_siso(self, x, u, sys121):
         assert_array_almost_equal(
-            sys121.dynamics(x, u),
-            sys121.A.dot(x) + (0 if u is None else sys121.B.dot(u)))
+            sys121.dynamics(0, x, u),
+            np.zeros(2) + \
+            (0 if x is None else sys121.A.dot(x).reshape((-1,))) + \
+            (0 if u is None else sys121.B.dot(u).reshape((-1,))))
         assert_array_almost_equal(
-            sys121.output(x, u),
-            sys121.C.dot(x) + (0 if u is None else sys121.D.dot(u)))
+            sys121.output(0, x, u),
+            np.zeros(1) + \
+            (0 if x is None else sys121.C.dot(x).reshape((-1,))) + \
+            (0 if u is None else sys121.D.dot(u).reshape((-1,))))
 
     # too few and too many states and inputs
     @pytest.mark.parametrize('x', [0, 1, [], [1, 2, 3], np.atleast_1d(2)])
-    @pytest.mark.parametrize('u', [None, [1, 1], np.atleast_1d((2, 2))])
-    def test_dynamics_output_siso_fails(self, x, u, sys121):
+    def test_error_x_dynamics_output_siso(self, x, sys121):
         with pytest.raises(ValueError):
-            sys121.dynamics(x, u)
+            sys121.dynamics(0, x, None)
         with pytest.raises(ValueError):
-            sys121.output(x, u)
+            sys121.output(0, x, None)
+    @pytest.mark.parametrize('u', [[1, 1], np.atleast_1d((2, 2))])
+    def test_error_u_dynamics_output_siso(self, u, sys121):
+        with pytest.raises(ValueError):
+            sys121.dynamics(0, None, u)
+        with pytest.raises(ValueError):
+            sys121.output(0, None, u)
 
-    @pytest.mark.parametrize('x',[[1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
+    @pytest.mark.parametrize('x',
+        [None, [1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
     @pytest.mark.parametrize('u',
         [None, [1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
     def test_dynamics_output_mimo(self, x, u, sys222):
         assert_array_almost_equal(
-            sys222.dynamics(x, u),
-            sys222.A.dot(x) + (0 if u is None else sys222.B.dot(u)))
+            sys222.dynamics(0, x, u),
+            np.zeros(2) + \
+            (0 if x is None else sys222.A.dot(x).reshape((-1,))) + \
+            (0 if u is None else sys222.B.dot(u).reshape((-1,))))
         assert_array_almost_equal(
-            sys222.output(x, u),
-            sys222.C.dot(x) + (0 if u is None else sys222.D.dot(u)))
+            sys222.output(0, x, u),
+            np.zeros(2) + \
+            (0 if x is None else sys222.C.dot(x).reshape((-1,))) + \
+            (0 if u is None else sys222.D.dot(u).reshape((-1,))))
+            #sys222.C.dot(x) + (0 if u is None else sys222.D.dot(u)))
 
     # too few and too many states and inputs
     @pytest.mark.parametrize('x', [0, 1, [1, 1, 1]])
-    @pytest.mark.parametrize('u', [None, 0, 1, [1, 1, 1]])
-    def test_dynamics_mimo_fails(self, x, u, sys222):
+    def test_error_x_dynamics_mimo(self, x, sys222):
         with pytest.raises(ValueError):
-            sys222.dynamics(x, u)
+            sys222.dynamics(0, x)
         with pytest.raises(ValueError):
-            sys222.output(x, u)
+            sys222.output(0, x)
+    @pytest.mark.parametrize('u', [0, 1, [1, 1, 1]])
+    def test_error_u_dynamics_mimo(self, u, sys222):
+        with pytest.raises(ValueError):
+            sys222.dynamics(0, None, u)
+        with pytest.raises(ValueError):
+            sys222.output(0, None, u)
 
 class TestRss:
     """These are tests for the proper functionality of statesp.rss."""

--- a/control/tests/type_conversion_test.py
+++ b/control/tests/type_conversion_test.py
@@ -19,7 +19,7 @@ def sys_dict():
     sdict['frd'] = ct.frd([10+0j, 9 + 1j, 8 + 2j], [1,2,3])
     sdict['lio'] = ct.LinearIOSystem(ct.ss([[-1]], [[5]], [[5]], [[0]]))
     sdict['ios'] = ct.NonlinearIOSystem(
-        sdict['lio']._rhs, sdict['lio']._out, 1, 1, 1)
+        sdict['lio'].dynamics, sdict['lio']._out, 1, 1, 1)
     sdict['arr'] = np.array([[2.0]])
     sdict['flt'] = 3.
     return sdict
@@ -66,7 +66,7 @@ conversion_table = [
     ('add',     'ios', ['xos', 'xos', 'E',   'ios', 'ios', 'xos', 'xos']),
     ('add',     'arr', ['ss',  'tf',  'xrd', 'xio', 'xos', 'arr', 'arr']),
     ('add',     'flt', ['ss',  'tf',  'xrd', 'xio', 'xos', 'arr', 'flt']),
-    
+
     # op        left     ss     tf    frd    lio    ios    arr    flt
     ('sub',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'xos', 'ss',  'ss' ]),
     ('sub',     'tf',  ['tf',  'tf',  'xrd', 'tf',  'xos', 'tf',  'tf' ]),
@@ -75,7 +75,7 @@ conversion_table = [
     ('sub',     'ios', ['xos', 'xio', 'E',   'ios', 'xos'  'xos', 'xos']),
     ('sub',     'arr', ['ss',  'tf',  'xrd', 'xio', 'xos', 'arr', 'arr']),
     ('sub',     'flt', ['ss',  'tf',  'xrd', 'xio', 'xos', 'arr', 'flt']),
-    
+
     # op        left     ss     tf    frd    lio    ios    arr    flt
     ('mul',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'xos', 'ss',  'ss' ]),
     ('mul',     'tf',  ['tf',  'tf',  'xrd', 'tf',  'xos', 'tf',  'tf' ]),
@@ -84,7 +84,7 @@ conversion_table = [
     ('mul',     'ios', ['xos', 'xos', 'E',   'ios', 'ios', 'xos', 'xos']),
     ('mul',     'arr', ['ss',  'tf',  'xrd', 'xio', 'xos', 'arr', 'arr']),
     ('mul',     'flt', ['ss',  'tf',  'frd', 'xio', 'xos', 'arr', 'flt']),
-    
+
     # op        left     ss     tf    frd    lio    ios    arr    flt
     ('truediv', 'ss',  ['xs',  'tf',  'xrd', 'xio', 'xos', 'xs',  'xs' ]),
     ('truediv', 'tf',  ['tf',  'tf',  'xrd', 'tf',  'xos', 'tf',  'tf' ]),
@@ -100,7 +100,7 @@ for i, (opname, ltype, expected_list) in enumerate(conversion_table):
     for rtype, expected in zip(rtype_list, expected_list):
         # Add this to the list of tests to run
         test_matrix.append([opname, ltype, rtype, expected])
-    
+
 @pytest.mark.parametrize("opname, ltype, rtype, expected", test_matrix)
 def test_operator_type_conversion(opname, ltype, rtype, expected, sys_dict):
     op = getattr(operator, opname)
@@ -110,7 +110,7 @@ def test_operator_type_conversion(opname, ltype, rtype, expected, sys_dict):
     # Get rid of warnings for InputOutputSystem objects by making a copy
     if isinstance(leftsys, ct.InputOutputSystem) and leftsys == rightsys:
         rightsys = leftsys.copy()
-            
+
     # Make sure we get the right result
     if expected == 'E' or expected[0] == 'x':
         # Exception expected
@@ -119,7 +119,7 @@ def test_operator_type_conversion(opname, ltype, rtype, expected, sys_dict):
     else:
         # Operation should work and return the given type
         result = op(leftsys, rightsys)
-                
+
         # Print out what we are testing in case something goes wrong
         assert isinstance(result, type_dict[expected])
 
@@ -138,7 +138,7 @@ def test_operator_type_conversion(opname, ltype, rtype, expected, sys_dict):
 #
 #   * For IOS/LTI, convert to IOS.  In the case of a linear I/O system (LIO),
 #     this will preserve the linear structure since the LTI system will
-#     be converted to state space.  
+#     be converted to state space.
 #
 #   * When combining state space or transfer with linear I/O systems, the
 #   * output should be of type Linear IO system, since that maintains the
@@ -149,7 +149,7 @@ def test_operator_type_conversion(opname, ltype, rtype, expected, sys_dict):
 
 type_list = ['ss', 'tf', 'tfx', 'frd', 'lio', 'ios', 'arr', 'flt']
 conversion_table = [
-    # L \ R ['ss',  'tf',  'tfx', 'frd', 'lio', 'ios', 'arr', 'flt'] 
+    # L \ R ['ss',  'tf',  'tfx', 'frd', 'lio', 'ios', 'arr', 'flt']
     ('ss',  ['ss',  'ss',  'tf'   'frd', 'lio', 'ios', 'ss',  'ss' ]),
     ('tf',  ['tf',  'tf',  'tf'   'frd', 'lio', 'ios', 'tf',  'tf' ]),
     ('tfx', ['tf',  'tf',  'tf',  'frd', 'E',   'E',   'tf',  'tf' ]),

--- a/control/tests/type_conversion_test.py
+++ b/control/tests/type_conversion_test.py
@@ -19,7 +19,7 @@ def sys_dict():
     sdict['frd'] = ct.frd([10+0j, 9 + 1j, 8 + 2j], [1,2,3])
     sdict['lio'] = ct.LinearIOSystem(ct.ss([[-1]], [[5]], [[5]], [[0]]))
     sdict['ios'] = ct.NonlinearIOSystem(
-        sdict['lio'].dynamics, sdict['lio']._out, 1, 1, 1)
+        sdict['lio'].dynamics, sdict['lio'].output, 1, 1, 1)
     sdict['arr'] = np.array([[2.0]])
     sdict['flt'] = 3.
     return sdict

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -29,8 +29,8 @@ Input/output systems can be created from state space LTI systems by using the
   io_sys = LinearIOSystem(ss_sys)
 
 Nonlinear input/output systems can be created using the
-:class:`~control.NonlinearIOSystem` class, which requires the definition of an
-update function (for the right hand side of the differential or different
+:class:`~control.NonlinearIOSystem` class, which requires the definition of a
+dynamics function (the right hand side of the differential or difference
 equation) and and output function (computes the outputs from the state)::
 
   io_sys = NonlinearIOSystem(updfcn, outfcn, inputs=M, outputs=P, states=N)
@@ -68,7 +68,7 @@ We begin by defining the dynamics of the system
   import numpy as np
   import matplotlib.pyplot as plt
 
-  def predprey_rhs(t, x, u, params):
+  def predprey_dynamics(t, x, u, params):
       # Parameter setup
       a = params.get('a', 3.2)
       b = params.get('b', 0.6)
@@ -76,18 +76,18 @@ We begin by defining the dynamics of the system
       d = params.get('d', 0.56)
       k = params.get('k', 125)
       r = params.get('r', 1.6)
-      
+
       # Map the states into local variable names
       H = x[0]
       L = x[1]
 
       # Compute the control action (only allow addition of food)
       u_0 = u if u > 0 else 0
-  
+
       # Compute the discrete updates
       dH = (r + u_0) * H * (1 - H/k) - (a * H * L)/(c + H)
       dL = b * (a * H *  L)/(c + H) - d * L
-  
+
       return [dH, dL]
 
 We now create an input/output system using these dynamics:
@@ -95,7 +95,7 @@ We now create an input/output system using these dynamics:
 .. code-block:: python
 
   io_predprey = control.NonlinearIOSystem(
-      predprey_rhs, None, inputs=('u'), outputs=('H', 'L'),
+      predprey_dynamics, None, inputs=('u'), outputs=('H', 'L'),
       states=('H', 'L'), name='predprey')
 
 Note that since we have not specified an output function, the entire state
@@ -108,10 +108,10 @@ of the system:
 
   X0 = [25, 20]                 # Initial H, L
   T = np.linspace(0, 70, 500)   # Simulation 70 years of time
-  
+
   # Simulate the system
   t, y = control.input_output_response(io_predprey, T, 0, X0)
-  
+
   # Plot the response
   plt.figure(1)
   plt.plot(t, y[0])
@@ -171,14 +171,14 @@ function:
     inplist=['control.Ld'],
     outlist=['predprey.H', 'predprey.L', 'control.y[0]']
   )
-       
+
 Finally, we simulate the closed loop system:
 
 .. code-block:: python
 
   # Simulate the system
   t, y = control.input_output_response(io_closed, T, 30, [15, 20])
-  
+
   # Plot the response
   plt.figure(2)
   plt.subplot(2, 1, 1)


### PR DESCRIPTION
Creates new `dynamics(x, u)` and `output(x, u)` methods for `StateSpace` systems. These correspond to the right hand side of the dynamcs and output equations for such systems (i.e. calculates xdot in xdot = Ax+Bu and y in y=Cx+Bu). This can be used for simulating or numerically integrating such systems in your own code, as suggested in #83. 

Renames equivalent private methods `_rhs` and `_out` functions in `iosys` to same name. The latter have a slightly different call signature: the first argument is the time `t` rather than the state `x`. Since they were private methods, we can change them; it might make sense to rearrange arguments so that `t` is a keyword argument that appears at the end with a default value (e.g. 0) so that call signatures then are the same across system types. 

Follows the discussion in #434.

I considered a few alternatives for the name `dynamics`: `eval`, `evaluate`, `update`, `evolve`, `evolve_state`, `calculate`, and `compute`. I settled on `dynamics`  because it works for both cont-time and discrete-time systems, suggests that it is evaluating how they change in time, and doesn't suggest any mutation is happening to the system, unlike `update.` Happy to consider alternatives. 