### PR TITLE
update np.float to float to fix NumPy 1.20 deprecation warnings

### DIFF
--- a/control/tests/input_element_int_test.py
+++ b/control/tests/input_element_int_test.py
@@ -63,4 +63,4 @@ class TestTfInputIntElement:
         d = 0
         sys = ss(a, b, c, d)
         np.testing.assert_allclose(dcgain(sys), 0,
-                                   atol=np.finfo(np.float).epsneg)
+                                   atol=np.finfo(float).epsneg)

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -408,7 +408,7 @@ class TestTimeresp:
         """Test forced response of SISO systems as step response"""
         sys = tsystem.sys
         t = tsystem.t
-        u = np.ones_like(t, dtype=np.float)
+        u = np.ones_like(t, dtype=float)
         yref = tsystem.ystep
 
         tout, yout = forced_response(sys, t, u)
@@ -416,7 +416,7 @@ class TestTimeresp:
         np.testing.assert_array_almost_equal(yout, yref, decimal=4)
 
     @pytest.mark.parametrize("u",
-                             [np.zeros((10,), dtype=np.float),
+                             [np.zeros((10,), dtype=float),
                               0]  # special algorithm
                              )
     def test_forced_response_initial(self, siso_ss1, u):

--- a/control/tests/xferfcn_input_test.py
+++ b/control/tests/xferfcn_input_test.py
@@ -54,15 +54,15 @@ cases = {
 
 
 @pytest.mark.parametrize("dtype",
-                         [np.int, np.int8, np.int16, np.int32, np.int64,
-                          np.float, np.float16, np.float32, np.float64,
+                         [int, np.int8, np.int16, np.int32, np.int64,
+                          float, np.float16, np.float32, np.float64,
                           np.longdouble])
 @pytest.mark.parametrize("num, fun", cases.values(), ids=cases.keys())
 def test_clean_part(num, fun, dtype):
     """Test clean part for various inputs"""
     numa = fun(dtype, num)
     num_ = _clean_part(numa)
-    ref_ = np.array(num, dtype=np.float, ndmin=3)
+    ref_ = np.array(num, dtype=float, ndmin=3)
 
     assert isinstance(num_, list)
     assert np.all([isinstance(part, list) for part in num_])


### PR DESCRIPTION
Fixes the following warning (and others like it):
```
  /Users/murray/Dropbox/macosx/src/python-control/murrayrm/control/tests/timeresp_test.py:411: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
