### PR TITLE
Matched plurality in the documentation.

### DIFF
--- a/control/pzmap.py
+++ b/control/pzmap.py
@@ -74,7 +74,7 @@ def pzmap(sys, plot=None, grid=None, title='Pole Zero Map', **kwargs):
 
     Returns
     -------
-    pole: array
+    poles: array
         The systems poles
     zeros: array
         The system's zeros.


### PR DESCRIPTION
Code variable and 'return's documentation both indicate multiple poles can be returned.