### PR TITLE
new dynamics and output functions for statespace and iosystems

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -756,8 +756,17 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
         if params and warning:
             warn("Parameters passed to LinearIOSystems are ignored.")
 
-    _rhs = StateSpace.dynamics
-    _out = StateSpace.output
+    def _rhs(self, t, x, u):
+        # Convert input to column vector and then change output to 1D array
+        xdot = np.dot(self.A, np.reshape(x, (-1, 1))) \
+            + np.dot(self.B, np.reshape(u, (-1, 1)))
+        return np.array(xdot).reshape((-1,))
+
+    def _out(self, t, x, u):
+        # Convert input to column vector and then change output to 1D array
+        y = np.dot(self.C, np.reshape(x, (-1, 1))) \
+            + np.dot(self.D, np.reshape(u, (-1, 1)))
+        return np.array(y).reshape((-1,))
 
 class NonlinearIOSystem(InputOutputSystem):
     """Nonlinear I/O system.

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -370,7 +370,7 @@ class InputOutputSystem(object):
         NotImplemented("Evaluation not implemented for system of type ",
                        type(self))
 
-    def dynamics(self, t, x, u, params={}):
+    def dynamics(self, t, x, u):
         """Compute the dynamics of a differential or difference equation.
 
         Given time `t`, input `u` and state `x`, returns the value of the
@@ -401,7 +401,7 @@ class InputOutputSystem(object):
         -------
         dx/dt or x[t+dt] : ndarray
         """
-        return self._rhs(t, x, u, params)
+        return self._rhs(t, x, u)
 
     def _out(self, t, x, u, params={}):
         """Evaluate the output of a system at a given state, input, and time
@@ -415,7 +415,7 @@ class InputOutputSystem(object):
         # If no output function was defined in subclass, return state
         return x
 
-    def output(self, t, x, u, params={}):
+    def output(self, t, x, u):
         """Compute the output of the system
 
         Given time `t`, input `u` and state `x`, returns the output of the
@@ -438,7 +438,7 @@ class InputOutputSystem(object):
         -------
         y : ndarray
         """
-        return self._out(t, x, u, params)
+        return self._out(t, x, u)
 
     def set_inputs(self, inputs, prefix='u'):
         """Set the number/names of the system inputs.
@@ -767,6 +767,7 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
         y = np.dot(self.C, np.reshape(x, (-1, 1))) \
             + np.dot(self.D, np.reshape(u, (-1, 1)))
         return np.array(y).reshape((-1,))
+
 
 class NonlinearIOSystem(InputOutputSystem):
     """Nonlinear I/O system.

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -362,7 +362,9 @@ class InputOutputSystem(object):
         """Evaluate right hand side of a differential or difference equation.
 
         Private function used to compute the right hand side of an
-        input/output system model.
+        input/output system model. Intended for fast
+        evaluation; for a more user-friendly interface
+        you may want to use :meth:`dynamics`.
 
         """
         NotImplemented("Evaluation not implemented for system of type ",
@@ -405,7 +407,9 @@ class InputOutputSystem(object):
         """Evaluate the output of a system at a given state, input, and time
 
         Private function used to compute the output of of an input/output
-        system model given the state, input, parameters, and time.
+        system model given the state, input, parameters. Intended for fast
+        evaluation; for a more user-friendly interface you may want to use
+        :meth:`output`.
 
         """
         # If no output function was defined in subclass, return state

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1262,16 +1262,20 @@ class StateSpace(LTI):
         dx/dt or x[t+dt] : ndarray
         """
         if len(args) not in (2, 3):
-            raise ValueError("received"+len(args)+"args, expected 2 or 3")
-        if np.size(args[1]) != self.nstates:
+            raise ValueError("received" + len(args) + "args, expected 2 or 3")
+
+        x = np.reshape(args[1], (-1, 1)) # force to a column in case matrix
+        if np.size(x) != self.nstates:
             raise ValueError("len(x) must be equal to number of states")
+
         if len(args) == 2: # received t and x, ignore t
-            return self.A.dot(args[1]).reshape((-1,)) # return as row vector
+            return self.A.dot(x).reshape((-1,)) # return as row vector
         else: # received t, x, and u, ignore t
-            if np.size(args[2]) != self.ninputs:
+            u = np.reshape(args[2], (-1, 1)) # force to a column in case matrix
+            if np.size(u) != self.ninputs:
                 raise ValueError("len(u) must be equal to number of inputs")
-            return self.A.dot(args[1]).reshape((-1,)) \
-                 + self.B.dot(args[2]).reshape((-1,)) # return as row vector
+            return self.A.dot(x).reshape((-1,)) \
+                 + self.B.dot(u).reshape((-1,)) # return as row vector
 
     def output(self, *args):
         """Compute the output of the system
@@ -1306,15 +1310,19 @@ class StateSpace(LTI):
         """
         if len(args) not in (2, 3):
             raise ValueError("received"+len(args)+"args, expected 2 or 3")
-        if np.size(args[1]) != self.nstates:
+
+        x = np.reshape(args[1], (-1, 1)) # force to a column in case matrix
+        if np.size(x) != self.nstates:
             raise ValueError("len(x) must be equal to number of states")
+
         if len(args) == 2: # received t and x, ignore t
-            return self.C.dot(args[1]).reshape((-1,)) # return as row vector
+            return self.C.dot(x).reshape((-1,)) # return as row vector
         else: # received t, x, and u, ignore t
-            if np.size(args[2]) != self.ninputs:
+            u = np.reshape(args[2], (-1, 1)) # force to a column in case matrix
+            if np.size(u) != self.ninputs:
                 raise ValueError("len(u) must be equal to number of inputs")
-            return self.C.dot(args[1]).reshape((-1,)) \
-                 + self.D.dot(args[2]).reshape((-1,)) # return as row vector
+            return self.C.dot(x).reshape((-1,)) \
+                 + self.D.dot(u).reshape((-1,)) # return as row vector
 
     def _isstatic(self):
         """True if and only if the system has no dynamics, that is,

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1227,7 +1227,7 @@ class StateSpace(LTI):
         return self(0, warn_infinite=warn_infinite) if self.isctime() \
             else self(1, warn_infinite=warn_infinite)
 
-    def dynamics(self, *args):
+    def dynamics(self, t, x, u=0):
         """Compute the dynamics of the system
 
         Given input `u` and state `x`, returns the dynamics of the state-space
@@ -1242,11 +1242,10 @@ class StateSpace(LTI):
 
         The inputs `x` and `u` must be of the correct length for the system.
 
-        The calling signature is ``out = sys.dynamics(t, x[, u])``
         The first argument `t` is ignored because :class:`StateSpace` systems
         are time-invariant. It is included so that the dynamics can be passed
-        to most numerical integrators, such as scipy's `integrate.solve_ivp` and
-        for consistency with :class:`IOSystem` systems.
+        to most numerical integrators, such as :func:`scipy.integrate.solve_ivp`
+        and for consistency with :class:`IOSystem` systems.
 
         Parameters
         ----------
@@ -1261,23 +1260,19 @@ class StateSpace(LTI):
         -------
         dx/dt or x[t+dt] : ndarray
         """
-        if len(args) not in (2, 3):
-            raise ValueError("received" + len(args) + "args, expected 2 or 3")
-
-        x = np.reshape(args[1], (-1, 1)) # force to a column in case matrix
+        x = np.reshape(x, (-1, 1)) # force to a column in case matrix
         if np.size(x) != self.nstates:
             raise ValueError("len(x) must be equal to number of states")
-
-        if len(args) == 2: # received t and x, ignore t
+        if u is 0:
             return self.A.dot(x).reshape((-1,)) # return as row vector
         else: # received t, x, and u, ignore t
-            u = np.reshape(args[2], (-1, 1)) # force to a column in case matrix
+            u = np.reshape(u, (-1, 1)) # force to a column in case matrix
             if np.size(u) != self.ninputs:
                 raise ValueError("len(u) must be equal to number of inputs")
             return self.A.dot(x).reshape((-1,)) \
                  + self.B.dot(u).reshape((-1,)) # return as row vector
 
-    def output(self, *args):
+    def output(self, t, x, u=0):
         """Compute the output of the system
 
         Given input `u` and state `x`, returns the output `y` of the
@@ -1287,7 +1282,6 @@ class StateSpace(LTI):
 
         where A and B are the state-space matrices of the system.
 
-        The calling signature is ``y = sys.output(t, x[, u])``
         The first argument `t` is ignored because :class:`StateSpace` systems
         are time-invariant. It is included so that the dynamics can be passed
         to most numerical integrators, such as scipy's `integrate.solve_ivp` and
@@ -1308,17 +1302,14 @@ class StateSpace(LTI):
         -------
         y : ndarray
         """
-        if len(args) not in (2, 3):
-            raise ValueError("received"+len(args)+"args, expected 2 or 3")
-
-        x = np.reshape(args[1], (-1, 1)) # force to a column in case matrix
+        x = np.reshape(x, (-1, 1)) # force to a column in case matrix
         if np.size(x) != self.nstates:
             raise ValueError("len(x) must be equal to number of states")
 
-        if len(args) == 2: # received t and x, ignore t
+        if u is 0:
             return self.C.dot(x).reshape((-1,)) # return as row vector
         else: # received t, x, and u, ignore t
-            u = np.reshape(args[2], (-1, 1)) # force to a column in case matrix
+            u = np.reshape(u, (-1, 1)) # force to a column in case matrix
             if np.size(u) != self.ninputs:
                 raise ValueError("len(u) must be equal to number of inputs")
             return self.C.dot(x).reshape((-1,)) \

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -773,6 +773,12 @@ class TestStateSpace:
         assert_array_almost_equal(
             sys121.output(0, x, u),
             sys121.C.dot(x).reshape((-1,)) + sys121.D.dot(u).reshape((-1,)))
+        assert_array_almost_equal(
+            sys121.dynamics(0, x),
+            sys121.A.dot(x).reshape((-1,)))
+        assert_array_almost_equal(
+            sys121.output(0, x),
+            sys121.C.dot(x).reshape((-1,)))
 
     # too few and too many states and inputs
     @pytest.mark.parametrize('x', [0, 1, [], [1, 2, 3], np.atleast_1d(2)])
@@ -799,6 +805,12 @@ class TestStateSpace:
         assert_array_almost_equal(
             sys222.output(0, x, u),
             sys222.C.dot(x).reshape((-1,)) + sys222.D.dot(u).reshape((-1,)))
+        assert_array_almost_equal(
+            sys222.dynamics(0, x),
+            sys222.A.dot(x).reshape((-1,)))
+        assert_array_almost_equal(
+            sys222.output(0, x),
+            sys222.C.dot(x).reshape((-1,)))
 
     # too few and too many states and inputs
     @pytest.mark.parametrize('x', [0, 1, [1, 1, 1]])
@@ -807,7 +819,7 @@ class TestStateSpace:
             sys222.dynamics(0, x)
         with pytest.raises(ValueError):
             sys222.output(0, x)
-    @pytest.mark.parametrize('u', [0, 1, [1, 1, 1]])
+    @pytest.mark.parametrize('u', [1, [1, 1, 1]])
     def test_error_u_dynamics_mimo(self, u, sys222):
         with pytest.raises(ValueError):
             sys222.dynamics(0, (1, 1), u)

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -8,6 +8,7 @@ BG,  26 Jul 2020 merge statesp_array_test.py differences into statesp_test.py
 """
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 import pytest
 import operator
 from numpy.linalg import solve
@@ -46,6 +47,17 @@ class TestStateSpace:
     def sys322(self, sys322ABCD):
         """3-states square system (2 inputs x 2 outputs)"""
         return StateSpace(*sys322ABCD)
+
+    @pytest.fixture
+    def sys121(self):
+        """2 state, 1 input, 1 output (siso)  system"""
+        A121 = [[4., 1.],
+                [2., -3]]
+        B121 = [[5.],
+                [-3.]]
+        C121 = [[2., -4]]
+        D121 = [[3.]]
+        return StateSpace(A121, B121, C121, D121)
 
     @pytest.fixture
     def sys222(self):
@@ -750,6 +762,58 @@ class TestStateSpace:
         np.testing.assert_array_almost_equal(
             np.squeeze(sys322.horner(1.j)),
             mag[:, :, 0] * np.exp(1.j * phase[:, :, 0]))
+
+    @pytest.mark.parametrize('x',
+        [[1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
+    @pytest.mark.parametrize('u', [0, 1, np.atleast_1d(2)])
+    def test_dynamics_and_output_siso(self, x, u, sys121):
+        assert_array_almost_equal(
+            sys121.dynamics(0, x, u),
+            sys121.A.dot(x).reshape((-1,)) + sys121.B.dot(u).reshape((-1,)))
+        assert_array_almost_equal(
+            sys121.output(0, x, u),
+            sys121.C.dot(x).reshape((-1,)) + sys121.D.dot(u).reshape((-1,)))
+
+    # too few and too many states and inputs
+    @pytest.mark.parametrize('x', [0, 1, [], [1, 2, 3], np.atleast_1d(2)])
+    def test_error_x_dynamics_and_output_siso(self, x, sys121):
+        with pytest.raises(ValueError):
+            sys121.dynamics(0, x)
+        with pytest.raises(ValueError):
+            sys121.output(0, x)
+    @pytest.mark.parametrize('u', [[1, 1], np.atleast_1d((2, 2))])
+    def test_error_u_dynamics_output_siso(self, u, sys121):
+        with pytest.raises(ValueError):
+            sys121.dynamics(0, 1, u)
+        with pytest.raises(ValueError):
+            sys121.output(0, 1, u)
+
+    @pytest.mark.parametrize('x',
+        [[1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
+    @pytest.mark.parametrize('u',
+        [[1, 1], [[1], [1]], np.atleast_2d([1,1]).T])
+    def test_dynamics_and_output_mimo(self, x, u, sys222):
+        assert_array_almost_equal(
+            sys222.dynamics(0, x, u),
+            sys222.A.dot(x).reshape((-1,)) + sys222.B.dot(u).reshape((-1,)))
+        assert_array_almost_equal(
+            sys222.output(0, x, u),
+            sys222.C.dot(x).reshape((-1,)) + sys222.D.dot(u).reshape((-1,)))
+
+    # too few and too many states and inputs
+    @pytest.mark.parametrize('x', [0, 1, [1, 1, 1]])
+    def test_error_x_dynamics_mimo(self, x, sys222):
+        with pytest.raises(ValueError):
+            sys222.dynamics(0, x)
+        with pytest.raises(ValueError):
+            sys222.output(0, x)
+    @pytest.mark.parametrize('u', [0, 1, [1, 1, 1]])
+    def test_error_u_dynamics_mimo(self, u, sys222):
+        with pytest.raises(ValueError):
+            sys222.dynamics(0, (1, 1), u)
+        with pytest.raises(ValueError):
+            sys222.output(0, (1, 1), u)
+
 
 class TestRss:
     """These are tests for the proper functionality of statesp.rss."""


### PR DESCRIPTION
revised version of #546. 
* makes `t` argument required following discussion there. not sure yet that this is the best, but I was almost there already so I just submitted this PR. 
* benchmark results in the discussion of that PR that showed that creating a separate callable that skips argument processing had only a small performance advantage, so I decided to leave `dynamics` as a method.  
* leaves code and usage of `_rhs` and `_out` unchanged in `iosys`. The idea is to leave them as fast internal methods and to have `dynamics` and `output` serve as more user-friendly versions where speed is of less importance. 