### PR TITLE
new method keyword in stability_margins and auto-fallback back to FRD ..

### DIFF
--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -88,7 +88,7 @@ _bode_defaults = {
 
 def bode_plot(syslist, omega=None,
               plot=True, omega_limits=None, omega_num=None,
-              margins=None, *args, **kwargs):
+              margins=None, method='best', *args, **kwargs):
     """Bode plot for a system
 
     Plots a Bode plot for the system over a (optional) frequency range.
@@ -117,6 +117,7 @@ def bode_plot(syslist, omega=None,
         config.defaults['freqplot.number_of_samples'].
     margins : bool
         If True, plot gain and phase margin.
+    method : method to use in computing margins (see :func:`stability_margins`)
     *args : :func:`matplotlib.pyplot.plot` positional properties, optional
         Additional arguments for `matplotlib` plots (color, linestyle, etc)
     **kwargs : :func:`matplotlib.pyplot.plot` keyword properties, optional
@@ -373,7 +374,7 @@ def bode_plot(syslist, omega=None,
                 # Show the phase and gain margins in the plot
                 if margins:
                     # Compute stability margins for the system
-                    margin = stability_margins(sys)
+                    margin = stability_margins(sys, method=method)
                     gm, pm, Wcg, Wcp = (margin[i] for i in (0, 1, 3, 4))
 
                     # Figure out sign of the phase at the first gain crossing

--- a/control/margins.py
+++ b/control/margins.py
@@ -300,6 +300,7 @@ def stability_margins(sysdata, returnall=False, epsw=0.0, method='best'):
     determined by the frequency of maximum sensitivity (given by the
     magnitude of 1/(1+L)).
     """
+    # TODO: FRD method for cont-time systems doesn't work
     try:
         if isinstance(sysdata, frdata.FRD):
             sys = frdata.FRD(sysdata, smooth=True)
@@ -408,7 +409,6 @@ def stability_margins(sysdata, returnall=False, epsw=0.0, method='best'):
         w_180 = np.array(
             [sp.optimize.brentq(_arg, sys.omega[i], sys.omega[i+1])
              for i in widx])
-        # TODO: replace by evalfr(sys, 1J*w) or sys(1J*w), (needs gh-449)
         w180_resp = sys(1j * w_180)
 
         # Find all crossings, note that this depends on omega having

--- a/control/margins.py
+++ b/control/margins.py
@@ -51,6 +51,7 @@ $Id$
 """
 
 import math
+from warnings import warn
 import numpy as np
 import scipy as sp
 from . import xferfcn
@@ -207,7 +208,7 @@ def _poly_z_wstab(num, den, num_inv_zp, den_inv_zq, p_q, dt, epsw):
 
     return z, w
 
-def _numerical_inaccuracy(sys):
+def _likely_numerical_inaccuracy(sys):
     # crude, conservative check for if
     # num(z)*num(1/z) << den(z)*den(1/z) for DT systems
     num, den, num_inv_zp, den_inv_zq, p_q, dt = _poly_z_invz(sys)
@@ -334,7 +335,9 @@ def stability_margins(sysdata, returnall=False, epsw=0.0, method='best'):
     elif method == 'best':
         # convert to FRD if anticipated numerical issues
         if isinstance(sys, xferfcn.TransferFunction) and not sys.isctime():
-            if _numerical_inaccuracy(sys):
+            if _likely_numerical_inaccuracy(sys):
+                warn("stability_margins: Falling back to 'frd' method "
+                "because of chance of numerical inaccuracy in 'poly' method.")
                 omega_sys = freqplot._default_frequency_range(sys)
                 omega_sys = omega_sys[omega_sys < np.pi / sys.dt]
                 sys = frdata.FRD(sys, omega_sys, smooth=True)

--- a/control/margins.py
+++ b/control/margins.py
@@ -330,16 +330,14 @@ def stability_margins(sysdata, returnall=False, epsw=0.0, method='best'):
                 sys = frdata.FRD(sys, omega_sys)
             else:
                 omega_sys = omega_sys[omega_sys < np.pi / sys.dt]
-                sys = frdata.FRD(sys(np.exp(1j*sys.dt*omega_sys)), omega_sys,
-                                    smooth=True)
+                sys = frdata.FRD(sys, omega_sys, smooth=True)
     elif method == 'best':
         # convert to FRD if anticipated numerical issues
         if isinstance(sys, xferfcn.TransferFunction) and not sys.isctime():
             if _numerical_inaccuracy(sys):
                 omega_sys = freqplot._default_frequency_range(sys)
                 omega_sys = omega_sys[omega_sys < np.pi / sys.dt]
-                sys = frdata.FRD(sys(np.exp(1j*sys.dt*omega_sys)), omega_sys,
-                                    smooth=True)
+                sys = frdata.FRD(sys, omega_sys, smooth=True)
     elif method != 'poly':
         raise ValueError("method " + method + " unknown")
 

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -369,10 +369,7 @@ def test_stability_margins_methods():
     sysd = sys.sample(0.001, 'zoh')
     """Test stability_margins() function with different methods"""
     out = stability_margins(sysd, method='best')
-    assert_allclose(
-        (18.876634845228644, 11.244969911924102, 0.40684128014454546,
-         9.763585543509473, 4.351735617240803, 2.559873290031937),
-        stability_margins(sysd, method='poly'))
+    # confirm getting reasonable results using FRD method
     assert_allclose(
         (18.876634740386308, 26.356358386241055, 0.40684127995261044,
          9.763585494645046, 2.3293357226374805, 2.55985695034263),

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -373,4 +373,4 @@ def test_stability_margins_methods():
     assert_allclose(
         (18.876634740386308, 26.356358386241055, 0.40684127995261044,
          9.763585494645046, 2.3293357226374805, 2.55985695034263),
-        stability_margins(sysd, method='frd'))
+        stability_margins(sysd, method='frd'), rtol=1e-5)

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -104,7 +104,6 @@ def test_margin_sys(tsys):
     out = margin(sys)
     assert_allclose(out, np.array(refout)[[0, 1, 3, 4]], atol=1.5e-3)
 
-
 def test_margin_3input(tsys):
     sys, refout, refoutall = tsys
     """Test margin() function with mag, phase, omega input"""
@@ -339,11 +338,11 @@ def test_zmore_stability_margins(tsys_zmore):
     'ref,'
     'rtol',
     [( # gh-465
-      [2], [1, 3, 2, 0], 1e-2,  
+      [2], [1, 3, 2, 0], 1e-2,
       [2.9558, 32.390, 0.43584, 1.4037, 0.74951, 0.97079],
       2e-3), # the gradient of the function reduces numerical precision
      ( # 2/(s+1)**3
-      [2], [1, 3, 3, 1], .1,  
+      [2], [1, 3, 3, 1], .1,
       [3.4927, 65.4212, 0.5763, 1.6283, 0.76625, 1.2019],
       1e-4),
      ( # gh-523
@@ -354,5 +353,13 @@ def test_zmore_stability_margins(tsys_zmore):
 def test_stability_margins_discrete(cnum, cden, dt, ref, rtol):
     """Test stability_margins with discrete TF input"""
     tf = TransferFunction(cnum, cden).sample(dt)
-    out = stability_margins(tf)
+    out = stability_margins(tf, method='poly')
     assert_allclose(out, ref, rtol=rtol)
+
+def test_stability_margins_methods():
+    sys = TransferFunction(1, (1, 2))
+    """Test stability_margins() function with different methods"""
+    out = stability_margins(sys, method='best')
+    out = stability_margins(sys, method='frd')
+    out = stability_margins(sys, method='poly')
+

--- a/control/tests/margin_test.py
+++ b/control/tests/margin_test.py
@@ -356,10 +356,24 @@ def test_stability_margins_discrete(cnum, cden, dt, ref, rtol):
     out = stability_margins(tf, method='poly')
     assert_allclose(out, ref, rtol=rtol)
 
-def test_stability_margins_methods():
-    sys = TransferFunction(1, (1, 2))
-    """Test stability_margins() function with different methods"""
-    out = stability_margins(sys, method='best')
-    out = stability_margins(sys, method='frd')
-    out = stability_margins(sys, method='poly')
 
+def test_stability_margins_methods():
+    # the following system gives slightly inaccurate result for DT systems
+    # because of numerical issues
+    omegan = 1
+    zeta = 0.5
+    resonance = TransferFunction(omegan**2, [1, 2*zeta*omegan, omegan**2])
+    omegan2 = 100
+    resonance2 = TransferFunction(omegan2**2, [1, 2*zeta*omegan2, omegan2**2])
+    sys = 5 * resonance * resonance2
+    sysd = sys.sample(0.001, 'zoh')
+    """Test stability_margins() function with different methods"""
+    out = stability_margins(sysd, method='best')
+    assert_allclose(
+        (18.876634845228644, 11.244969911924102, 0.40684128014454546,
+         9.763585543509473, 4.351735617240803, 2.559873290031937),
+        stability_margins(sysd, method='poly'))
+    assert_allclose(
+        (18.876634740386308, 26.356358386241055, 0.40684127995261044,
+         9.763585494645046, 2.3293357226374805, 2.55985695034263),
+        stability_margins(sysd, method='frd'))


### PR DESCRIPTION
... when it is detected that there may be numerical inaccuracy in dt polynomial calculation. 
* this is intended to resolve numerical issue observed in DT margin calculation when there is a large difference between the size of numerator and denominator coefficients #523. I am not sure how good the method is I used to detect this issue is any good. In fact I am sure it is not. comments welcome here. 
* can use `method='poly'` to override and force polynomial evaluation, or `method='FRD'` to force to using interpolated FRD to calculate gain and phase crossover frequencies. 