### PR TITLE
use new Slycot sb03md57 call signature if available

### DIFF
--- a/control/mateqn.py
+++ b/control/mateqn.py
@@ -5,9 +5,6 @@
 #
 # Author: Bjorn Olofsson
 
-# Python 3 compatibility (needs to go here)
-from __future__ import print_function
-
 # Copyright (c) 2011, All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -43,6 +40,34 @@ from numpy import shape, size, asarray, copy, zeros, eye, dot, \
 from scipy.linalg import eigvals, solve_discrete_are, solve
 from .exception import ControlSlycot, ControlArgument
 from .statesp import _ssmatrix
+
+# Make sure we have access to the right slycot routines
+try:
+    from slycot import sb03md57
+    # wrap without the deprecation warning
+    def sb03md(n, C, A, U, dico, job='X',fact='N',trana='N',ldwork=None):
+        ret = sb03md57(A, U, C, dico, job, fact, trana, ldwork)
+        return ret[2:]
+except ImportError:
+    try:
+        from slycot import sb03md
+    except ImportError:
+        sb03md = None
+
+try:
+    from slycot import sb04md
+except ImportError:
+    sb04md = None
+
+try:
+    from slycot import sb04qd
+except ImportError:
+    sb0qmd = None
+
+try:
+    from slycot import sg03ad
+except ImportError:
+    sb04ad = None
 
 __all__ = ['lyap', 'dlyap', 'dare', 'care']
 
@@ -93,16 +118,11 @@ def lyap(A, Q, C=None, E=None):
     state space operations.  See :func:`~control.use_numpy_matrix`.
     """
 
-    # Make sure we have access to the right slycot routines
-    try:
-        from slycot import sb03md
-    except ImportError:
+    if sb03md is None:
         raise ControlSlycot("can't find slycot module 'sb03md'")
-
-    try:
-        from slycot import sb04md
-    except ImportError:
+    if sb04md is None:
         raise ControlSlycot("can't find slycot module 'sb04md'")
+
 
     # Reshape 1-d arrays
     if len(shape(A)) == 1:
@@ -279,19 +299,11 @@ def dlyap(A, Q, C=None, E=None):
     of the same dimension. """
 
     # Make sure we have access to the right slycot routines
-    try:
-        from slycot import sb03md
-    except ImportError:
+    if sb03md is None:
         raise ControlSlycot("can't find slycot module 'sb03md'")
-
-    try:
-        from slycot import sb04qd
-    except ImportError:
+    if sb04qd is None:
         raise ControlSlycot("can't find slycot module 'sb04qd'")
-
-    try:
-        from slycot import sg03ad
-    except ImportError:
+    if sg03ad is None:
         raise ControlSlycot("can't find slycot module 'sg03ad'")
 
     # Reshape 1-d arrays

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -47,6 +47,25 @@ from .mateqn import care
 from .statesp import _ssmatrix
 from .exception import ControlSlycot, ControlArgument, ControlDimension
 
+# Make sure we have access to the right slycot routines
+try:
+    from slycot import sb03md57
+    # wrap without the deprecation warning
+    def sb03md(n, C, A, U, dico, job='X',fact='N',trana='N',ldwork=None):
+        ret = sb03md57(A, U, C, dico, job, fact, trana, ldwork)
+        return ret[2:]
+except ImportError:
+    try:
+        from slycot import sb03md
+    except ImportError:
+        sb03md = None
+
+try:
+    from slycot import sb03od
+except ImportError:
+    sb03od = None
+
+
 __all__ = ['ctrb', 'obsv', 'gram', 'place', 'place_varga', 'lqr', 'lqe',
            'acker']
 
@@ -574,7 +593,7 @@ def gram(sys, type):
         * if `type` is not 'c', 'o', 'cf' or 'of'
         * if system is unstable (sys.A has eigenvalues not in left half plane)
 
-    ImportError
+    ControlSlycot
         if slycot routine sb03md cannot be found
         if slycot routine sb03od cannot be found
 
@@ -614,9 +633,7 @@ def gram(sys, type):
     if type == 'c' or type == 'o':
         # Compute Gramian by the Slycot routine sb03md
         # make sure Slycot is installed
-        try:
-            from slycot import sb03md
-        except ImportError:
+        if sb03md is None:
             raise ControlSlycot("can't find slycot module 'sb03md'")
         if type == 'c':
             tra = 'T'
@@ -634,9 +651,7 @@ def gram(sys, type):
 
     elif type == 'cf' or type == 'of':
         # Compute cholesky factored gramian from slycot routine sb03od
-        try:
-            from slycot import sb03od
-        except ImportError:
+        if sb03od is None:
             raise ControlSlycot("can't find slycot module 'sb03od'")
         tra = 'N'
         n = sys.nstates


### PR DESCRIPTION
Removes the deprecation warning if testing with current Slycot master.