### PR TITLE
enhance step_info to MIMO and time series of response data

### DIFF
--- a/control/matlab/timeresp.py
+++ b/control/matlab/timeresp.py
@@ -64,38 +64,59 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
                         transpose=True, return_x=return_x)
     return (out[1], out[0], out[2]) if return_x else (out[1], out[0])
 
-def stepinfo(sys, T=None, SettlingTimeThreshold=0.02,
+
+def stepinfo(sysdata, T=None, yfinal=None, SettlingTimeThreshold=0.02,
              RiseTimeLimits=(0.1, 0.9)):
-    '''
+    """
     Step response characteristics (Rise time, Settling Time, Peak and others).
 
     Parameters
     ----------
-    sys: StateSpace, or TransferFunction
-        LTI system to simulate
-
-    T: array-like or number, optional
+    sysdata : StateSpace or TransferFunction or array_like
+        The system data. Either LTI system to similate (StateSpace,
+        TransferFunction), or a time series of step response data.
+    T : array_like or float, optional
         Time vector, or simulation time duration if a number (time vector is
-        autocomputed if not given)
-
-    SettlingTimeThreshold: float value, optional
+        autocomputed if not given).
+        Required, if sysdata is a time series of response data.
+    yfinal : scalar or array_like, optional
+        Steady-state response. If not given, sysdata.dcgain() is used for
+        systems to simulate and the last value of the the response data is
+        used for a given time series of response data. Scalar for SISO,
+        (noutputs, ninputs) array_like for MIMO systems.
+    SettlingTimeThreshold : float, optional
         Defines the error to compute settling time (default = 0.02)
-
-    RiseTimeLimits: tuple (lower_threshold, upper_theshold)
+    RiseTimeLimits : tuple (lower_threshold, upper_theshold)
         Defines the lower and upper threshold for RiseTime computation
 
     Returns
     -------
-    S: a dictionary containing:
-        RiseTime: Time from 10% to 90% of the steady-state value.
-        SettlingTime: Time to enter inside a default error of 2%
-        SettlingMin: Minimum value after RiseTime
-        SettlingMax: Maximum value after RiseTime
-        Overshoot: Percentage of the Peak relative to steady value
-        Undershoot: Percentage of undershoot
-        Peak: Absolute peak value
-        PeakTime: time of the Peak
-        SteadyStateValue: Steady-state value
+    S : dict or list of list of dict
+        If `sysdata` corresponds to a SISO system, S is a dictionary
+        containing:
+
+        RiseTime:
+            Time from 10% to 90% of the steady-state value.
+        SettlingTime:
+            Time to enter inside a default error of 2%
+        SettlingMin:
+            Minimum value after RiseTime
+        SettlingMax:
+            Maximum value after RiseTime
+        Overshoot:
+            Percentage of the Peak relative to steady value
+        Undershoot:
+            Percentage of undershoot
+        Peak:
+            Absolute peak value
+        PeakTime:
+            time of the Peak
+        SteadyStateValue:
+            Steady-state value
+
+        If `sysdata` corresponds to a MIMO system, `S` is a 2D list of dicts.
+        To get the step response characteristics from the j-th input to the
+        i-th output, access ``S[i][j]``
 
 
     See Also
@@ -105,11 +126,13 @@ def stepinfo(sys, T=None, SettlingTimeThreshold=0.02,
     Examples
     --------
     >>> S = stepinfo(sys, T)
-    '''
+    """
     from ..timeresp import step_info
 
     # Call step_info with MATLAB defaults
-    S = step_info(sys, T, None, SettlingTimeThreshold, RiseTimeLimits)
+    S = step_info(sysdata, T=T, T_num=None, yfinal=yfinal,
+                  SettlingTimeThreshold=SettlingTimeThreshold,
+                  RiseTimeLimits=RiseTimeLimits)
 
     return S
 

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -68,8 +68,8 @@ class TestSisotool:
 
         # Check the step response before moving the point
         step_response_original = np.array(
-            [0.    , 0.021 , 0.124 , 0.3146, 0.5653, 0.8385, 1.0969, 1.3095,
-             1.4549, 1.5231])
+            [0.    , 0.0216, 0.1271, 0.3215, 0.5762, 0.8522, 1.1114, 1.3221,
+             1.4633, 1.5254])
         assert_array_almost_equal(
             ax_step.lines[0].get_data()[1][:10], step_response_original, 4)
 
@@ -113,8 +113,8 @@ class TestSisotool:
 
         # Check if the step response has changed
         step_response_moved = np.array(
-            [0.    , 0.023 , 0.1554, 0.4401, 0.8646, 1.3722, 1.875 , 2.2709,
-              2.4633, 2.3827])
+            [0.    , 0.0237, 0.1596, 0.4511, 0.884 , 1.3985, 1.9031, 2.2922,
+             2.4676, 2.3606])
         assert_array_almost_equal(
             ax_step.lines[0].get_data()[1][:10], step_response_moved, 4)
 
@@ -157,7 +157,3 @@ class TestSisotool:
         # but 2 input, 1 output should
         with pytest.raises(ControlMIMONotImplemented):
             sisotool(sys221)
-
-
-
-

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -193,7 +193,7 @@ class TestTimeresp:
     def no_pole_cancellation(self):
         return TransferFunction([1.881e+06],
                                 [188.1, 1.881e+06])
-    
+
     @pytest.fixture
     def siso_tf_type1(self):
         # System Type 1 - Step response not stationary:  G(s)=1/s(s+1)
@@ -309,36 +309,6 @@ class TestTimeresp:
         t, y = step_response(sys)
         np.testing.assert_array_equal(y, np.ones(len(t)))
 
-    def test_step_info(self):
-        # From matlab docs:
-        sys = TransferFunction([1, 5, 5], [1, 1.65, 5, 6.5, 2])
-        Strue = {
-            'RiseTime': 3.8456,
-            'SettlingTime': 27.9762,
-            'SettlingMin': 2.0689,
-            'SettlingMax': 2.6873,
-            'Overshoot': 7.4915,
-            'Undershoot': 0,
-            'Peak': 2.6873,
-            'PeakTime': 8.0530,
-            'SteadyStateValue': 2.50
-        }
-
-        S = step_info(sys)
-
-        Sk = sorted(S.keys())
-        Sktrue = sorted(Strue.keys())
-        assert Sk == Sktrue
-        # Very arbitrary tolerance because I don't know if the
-        # response from the MATLAB is really that accurate.
-        # maybe it is a good idea to change the Strue to match
-        # but I didn't do it because I don't know if it is
-        # accurate either...
-        rtol = 2e-2
-        np.testing.assert_allclose([S[k] for k in Sk],
-                                   [Strue[k] for k in Sktrue],
-                                   rtol=rtol)
-
     # tolerance for all parameters could be wrong for some systems
     # discrete systems time parameters tolerance could be +/-dt
     @pytest.mark.parametrize(
@@ -394,17 +364,21 @@ class TestTimeresp:
              'SteadyStateValue': np.NaN}, 2e-2)],
         indirect=["tsystem"])
     def test_step_info(self, tsystem, info_true, tolerance):
-        """  """
+        """Test step info for SISO systems"""
         info = step_info(tsystem)
 
         info_true_sorted = sorted(info_true.keys())
         info_sorted = sorted(info.keys())
-
         assert info_sorted == info_true_sorted
 
-        np.testing.assert_allclose([info_true[k] for k in info_true_sorted],
-                                   [info[k] for k in info_sorted],
-                                   rtol=tolerance)
+        for k in info:
+            np.testing.assert_allclose(info[k], info_true[k], rtol=tolerance,
+                                       err_msg=f"key {k} does not match")
+
+    def test_step_info_mimo(self, tsystem, info_true, tolearance):
+        """Test step info for MIMO systems"""
+        # TODO: implement
+        pass
 
     def test_step_pole_cancellation(self, pole_cancellation,
                                     no_pole_cancellation):

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -469,7 +469,7 @@ class TestTimeresp:
     @pytest.mark.parametrize(
         "tsystem",
         ['mimo_ss_step_matlab',
-         'mimo_tf_step'],
+         pytest.param('mimo_tf_step', marks=slycotonly)],
         indirect=["tsystem"])
     def test_step_info_mimo(self, tsystem):
         """Test step info for MIMO systems"""

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -15,15 +15,13 @@ import numpy as np
 import pytest
 import scipy as sp
 
-
 import control as ct
-from control import (StateSpace, TransferFunction, c2d, isctime, isdtime,
-                     ss2tf, tf2ss)
+from control import StateSpace, TransferFunction, c2d, isctime, ss2tf, tf2ss
+from control.exception import slycot_check
+from control.tests.conftest import slycotonly
 from control.timeresp import (_default_time_vector, _ideal_tfinal_and_dt,
                               forced_response, impulse_response,
                               initial_response, step_info, step_response)
-from control.tests.conftest import slycotonly
-from control.exception import slycot_check
 
 
 class TSys:

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -1303,16 +1303,18 @@ def _default_time_vector(sys, N=None, tfinal=None, is_step=True):
         # only need to use default_tfinal if not given; N is ignored.
         if tfinal is None:
             # for discrete time, change from ideal_tfinal if N too large/small
-            N = int(np.clip(ideal_tfinal/sys.dt, N_min_dt, N_max))# [N_min, N_max]
-            tfinal = sys.dt * N
+            # [N_min, N_max]
+            N = int(np.clip(np.ceil(ideal_tfinal/sys.dt)+1, N_min_dt, N_max))
+            tfinal = sys.dt * (N-1)
         else:
-            N = int(tfinal/sys.dt)
-            tfinal = N * sys.dt # make tfinal an integer multiple of sys.dt
+            N = int(np.ceil(tfinal/sys.dt)) + 1
+            tfinal = sys.dt * (N-1) # make tfinal an integer multiple of sys.dt
     else:
         if tfinal is None:
             # for continuous time, simulate to ideal_tfinal but limit N
             tfinal = ideal_tfinal
         if N is None:
-            N = int(np.clip(tfinal/ideal_dt, N_min_ct, N_max)) # N<-[N_min, N_max]
+            # [N_min, N_max]
+            N = int(np.clip(np.ceil(tfinal/ideal_dt)+1, N_min_ct, N_max))
 
-    return np.linspace(0, tfinal, N, endpoint=False)
+    return np.linspace(0, tfinal, N, endpoint=True)

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -740,7 +740,7 @@ def step_response(sys, T=None, X0=0., input=None, output=None, T_num=None,
 
 def step_info(sys, T=None, T_num=None, SettlingTimeThreshold=0.02,
               RiseTimeLimits=(0.1, 0.9)):
-    '''
+    """
     Step response characteristics (Rise time, Settling Time, Peak and others).
 
     Parameters
@@ -781,7 +781,9 @@ def step_info(sys, T=None, T_num=None, SettlingTimeThreshold=0.02,
         SteadyStateValue:
             Steady-state value
 
-        If `sys` is a MIMO system, S is a 2D-List of dicts.
+        If `sys` is a MIMO system, `S` is a 2D list of dicts. To get the
+        step response characteristics from the j-th input to the i-th output,
+        access ``S[i][j]``
 
 
     See Also
@@ -790,8 +792,47 @@ def step_info(sys, T=None, T_num=None, SettlingTimeThreshold=0.02,
 
     Examples
     --------
-    >>> info = step_info(sys, T)
-    '''
+    >>> from control import step_info, TransferFunction
+    >>> sys = TransferFunction([-1, 1], [1, 1, 1])
+    >>> S = step_info(sys)
+    >>> for k in S:
+    ...     print(f"{k}: {S[k]:3.4}")
+    ...
+    RiseTime: 1.256
+    SettlingTime: 9.071
+    SettlingMin: 0.9011
+    SettlingMax: 1.208
+    Overshoot: 20.85
+    Undershoot: 27.88
+    Peak: 1.208
+    PeakTime: 4.187
+    SteadyStateValue: 1.0
+
+    MIMO System: Simulate until a final time of 10. Get the step response
+    characteristics for the second input and specify a 5% error until the
+    signal is considered settled.
+
+    >>> from numpy import sqrt
+    >>> from control import step_info, StateSpace
+    >>> sys = StateSpace([[-1., -1.],
+    ...                   [1., 0.]],
+    ...                  [[-1./sqrt(2.), 1./sqrt(2.)],
+    ...                   [0, 0]],
+    ...                  [[sqrt(2.), -sqrt(2.)]],
+    ...                  [[0, 0]])
+    >>> S = step_info(sys, T=10., SettlingTimeThreshold=0.05)
+    >>> for k, v in S[0][1].items():
+    ...     print(f"{k}: {float(v):3.4}")
+    RiseTime: 1.212
+    SettlingTime: 6.061
+    SettlingMin: -1.209
+    SettlingMax: -0.9184
+    Overshoot: 20.87
+    Undershoot: 28.02
+    Peak: 1.209
+    PeakTime: 4.242
+    SteadyStateValue: -1.0
+    """
     if T is None or np.asarray(T).size == 1:
         T = _default_time_vector(sys, N=T_num, tfinal=T, is_step=True)
     T, Yout = step_response(sys, T, squeeze=False)

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -71,18 +71,17 @@ Date: August 17, 2020
 $Id$
 """
 
-# Libraries that we make use of
-import scipy as sp              # SciPy library (used all over)
-import numpy as np              # NumPy library
-from scipy.linalg import eig, eigvals, matrix_balance, norm
-from numpy import (einsum, maximum, minimum,
-                   atleast_1d)
 import warnings
-from .lti import LTI     # base class of StateSpace, TransferFunction
-from .xferfcn import TransferFunction
-from .statesp import _convert_to_statespace, _mimo2simo, _mimo2siso, ssdata
-from .lti import isdtime, isctime
+
+import numpy as np
+import scipy as sp
+from numpy import atleast_1d, einsum, maximum, minimum
+from scipy.linalg import eig, eigvals, matrix_balance, norm
+
 from . import config
+from .lti import (LTI, isctime, isdtime)
+from .statesp import _convert_to_statespace, _mimo2simo, _mimo2siso, ssdata
+from .xferfcn import TransferFunction
 
 __all__ = ['forced_response', 'step_response', 'step_info', 'initial_response',
            'impulse_response']

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -746,18 +746,18 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
         TransferFunction), or a time series of step response data.
     T : array_like or float, optional
         Time vector, or simulation time duration if a number (time vector is
-        autocomputed if not given, see :func:`step_response` for more detail)
+        autocomputed if not given, see :func:`step_response` for more detail).
         Required, if sysdata is a time series of response data.
     T_num : int, optional
         Number of time steps to use in simulation if T is not provided as an
         array; autocomputed if not given; ignored if sysdata is a
         discrete-time system or a time series or response data.
-    yfinal: scalar or array_like, optional
+    yfinal : scalar or array_like, optional
         Steady-state response. If not given, sysdata.dcgain() is used for
         systems to simulate and the last value of the the response data is
         used for a given time series of response data. Scalar for SISO,
         (noutputs, ninputs) array_like for MIMO systems.
-    SettlingTimeThreshold : float value, optional
+    SettlingTimeThreshold : float, optional
         Defines the error to compute settling time (default = 0.02)
     RiseTimeLimits : tuple (lower_threshold, upper_theshold)
         Defines the lower and upper threshold for RiseTime computation


### PR DESCRIPTION
Enhance the `step_info()` function to return a 2D list of info dicts for MIMO systems.

Cleaned up the code a little.

Fixes #574

WIP: needs unit tests for MIMO