### PR TITLE
don't install toplevel benchmarks package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     url='http://python-control.org',
     description='Python Control Systems Library',
     long_description=long_description,
-    packages=find_packages(),
+    packages=find_packages(exclude=['benchmarks']),
     classifiers=[f for f in CLASSIFIERS.split('\n') if f],
     install_requires=['numpy',
                       'scipy',


### PR DESCRIPTION
`python setup.py install` and `pip install control` install the benchmarks module into the toplevel sitelib. This is bad practice, because it could conflict with other packages doing the same.