### PR TITLE
Change step_info undershoot percentage calculation

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -301,10 +301,10 @@ class TestTimeresp:
                          'SteadyStateValue': -0.5394},
                          {'RiseTime': 0.0000, # (*)
                          'SettlingTime': 3.4000,
-                         'SettlingMin': -0.1034,
+                         'SettlingMin': -0.4350,# -0.1935 in MATLAB. (is wrong) 
                          'SettlingMax': -0.1485,
                          'Overshoot': 132.0170,
-                         'Undershoot': 79.222, # 0. in MATLAB
+                         'Undershoot': 0, # 0. in MATLAB (is correct)
                          'Peak': 0.4350,
                          'PeakTime': .2,
                          'SteadyStateValue': -0.1875}]]

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -304,14 +304,14 @@ class TestTimeresp:
                          'SettlingMin': -0.4350,  # (*)
                          'SettlingMax': -0.1485,
                          'Overshoot': 132.0170,
-                         'Undershoot': 0,
+                         'Undershoot': 0.,
                          'Peak': 0.4350,
                          'PeakTime': .2,
                          'SteadyStateValue': -0.1875}]]
-                         # (*): MATLAB gives 0.4 here, but it is unclear what
-                         # 10% and 90% of the steady state response mean, when
-                         # the step for this channel does not start a 0 for
-                         # 0 initial conditions
+                         # (*): MATLAB gives 0.4 for RiseTime and -0.1034 for
+                         # SettlingMin, but it is unclear what 10% and 90% of
+                         # the steady state response mean, when the step for
+                         # this channel does not start a 0.
         return T
 
     @pytest.fixture

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -301,10 +301,10 @@ class TestTimeresp:
                          'SteadyStateValue': -0.5394},
                          {'RiseTime': 0.0000, # (*)
                          'SettlingTime': 3.4000,
-                         'SettlingMin': -0.4350,# -0.1935 in MATLAB. (is wrong) 
+                         'SettlingMin': -0.4350,  # (*)
                          'SettlingMax': -0.1485,
                          'Overshoot': 132.0170,
-                         'Undershoot': 0, # 0. in MATLAB (is correct)
+                         'Undershoot': 0,
                          'Peak': 0.4350,
                          'PeakTime': .2,
                          'SteadyStateValue': -0.1875}]]

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -926,7 +926,7 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
                 # Undershoot 
                 y_us = (sgnInf*yout).min()
                 y_us_index = (sgnInf*yout).argmin()
-                if (sgnInf * yout[y_us_index]) < 0: # must have oposite sign
+                if (sgnInf * yout[y_us_index]) < 0:  # InfValue and undershoot must have opposite sign
                     undershoot = np.abs(100. * np.abs(y_us) / InfValue)
                 else:
                     undershoot = 0

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -882,6 +882,7 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
 
             # Steady state value
             InfValue = InfValues[i, j]
+            InfValue_sign = np.sign(InfValue)
             sgnInf = np.sign(InfValue.real)
 
             rise_time: float = np.NaN
@@ -923,11 +924,11 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
                 else:
                     overshoot = 0
 
-                # Undershoot
-                y_us = (sgnInf * yout).min()
-                dy_us = np.abs(y_us)
-                if dy_us > 0:
-                    undershoot = np.abs(100. * dy_us / InfValue)
+                # Undershoot 
+                y_us = (InfValue_sign*yout).min()
+                y_us_index = (InfValue_sign*yout).argmin()
+                if (InfValue_sign * yout[y_us_index]) < 0: # must have oposite sign
+                    undershoot = np.abs(100. * np.abs(y_us) / InfValue)
                 else:
                     undershoot = 0
 

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -882,7 +882,6 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
 
             # Steady state value
             InfValue = InfValues[i, j]
-            InfValue_sign = np.sign(InfValue)
             sgnInf = np.sign(InfValue.real)
 
             rise_time: float = np.NaN
@@ -925,9 +924,9 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
                     overshoot = 0
 
                 # Undershoot 
-                y_us = (InfValue_sign*yout).min()
-                y_us_index = (InfValue_sign*yout).argmin()
-                if (InfValue_sign * yout[y_us_index]) < 0: # must have oposite sign
+                y_us = (sgnInf*yout).min()
+                y_us_index = (sgnInf*yout).argmin()
+                if (sgnInf * yout[y_us_index]) < 0: # must have oposite sign
                     undershoot = np.abs(100. * np.abs(y_us) / InfValue)
                 else:
                     undershoot = 0

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -923,11 +923,11 @@ def step_info(sysdata, T=None, T_num=None, yfinal=None,
                 else:
                     overshoot = 0
 
-                # Undershoot 
-                y_us = (sgnInf*yout).min()
-                y_us_index = (sgnInf*yout).argmin()
-                if (sgnInf * yout[y_us_index]) < 0:  # InfValue and undershoot must have opposite sign
-                    undershoot = np.abs(100. * np.abs(y_us) / InfValue)
+                # Undershoot : InfValue and undershoot must have opposite sign
+                y_us_index = (sgnInf * yout).argmin()
+                y_us = yout[y_us_index]
+                if (sgnInf * y_us) < 0:
+                    undershoot = (-100. * y_us / InfValue)
                 else:
                     undershoot = 0
 


### PR DESCRIPTION
Improper systems with negative respose, if do not have inverse
respons, the undershoot must be 0.
This ocurr in the MIMO system used in the step_info test.
I think, the rise time and setting minimun and maximun computed
by this funtion are right in.