### PR TITLE
IPython LaTeX output only generated for small systems

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -75,6 +75,7 @@ _statesp_defaults = {
     'statesp.remove_useless_states': False,
     'statesp.latex_num_format': '.3g',
     'statesp.latex_repr_type': 'partitioned',
+    'statesp.latex_maxsize': 10,
     }
 
 
@@ -517,19 +518,26 @@ class StateSpace(LTI):
     def _repr_latex_(self):
         """LaTeX representation of state-space model
 
-        Output is controlled by config options statesp.latex_repr_type
-        and statesp.latex_num_format.
+        Output is controlled by config options statesp.latex_repr_type,
+        statesp.latex_num_format, and statesp.latex_maxsize.
 
         The output is primarily intended for Jupyter notebooks, which
         use MathJax to render the LaTeX, and the results may look odd
         when processed by a 'conventional' LaTeX system.
 
+
         Returns
         -------
-        s : string with LaTeX representation of model
+
+        s : string with LaTeX representation of model, or None if
+            either matrix dimension is greater than
+            statesp.latex_maxsize
 
         """
-        if config.defaults['statesp.latex_repr_type'] == 'partitioned':
+        syssize = self.nstates + max(self.noutputs, self.ninputs)
+        if syssize > config.defaults['statesp.latex_maxsize']:
+            return None
+        elif config.defaults['statesp.latex_repr_type'] == 'partitioned':
             return self._latex_partitioned()
         elif config.defaults['statesp.latex_repr_type'] == 'separate':
             return self._latex_separate()

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -1063,3 +1063,29 @@ def test_xferfcn_ndarray_precedence(op, tf, arr):
     ss = ct.tf2ss(tf)
     result = op(arr, ss)
     assert isinstance(result, ct.StateSpace)
+
+
+def test_latex_repr_testsize(editsdefaults):
+    # _repr_latex_ returns None when size > maxsize
+    from control import set_defaults
+
+    maxsize = defaults['statesp.latex_maxsize']
+    nstates = maxsize // 2
+    ninputs = maxsize - nstates
+    noutputs = ninputs
+
+    assert nstates > 0
+    assert ninputs > 0
+
+    g = rss(nstates, ninputs, noutputs)
+    assert isinstance(g._repr_latex_(), str)
+
+    set_defaults('statesp', latex_maxsize=maxsize - 1)
+    assert g._repr_latex_() is None
+
+    set_defaults('statesp', latex_maxsize=-1)
+    assert g._repr_latex_() is None
+
+    gstatic = ss([], [], [], 1)
+    assert gstatic._repr_latex_() is None
+


### PR DESCRIPTION
StateSpace._repr_latex_ now returns None for systems whose size is
greater than new config variable statesp.latex_maxsize.  System size
is the largest dimension of the partitioned system matrix.
statesp.latex_maxsize is 10.


See conversation staring at https://github.com/python-control/python-control/issues/278#issuecomment-811603495