### PR TITLE
Fix warnings generated by sisotool

### DIFF
--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -180,7 +180,7 @@ def root_locus(sys, kvect=None, xlim=None, ylim=None,
             fig.axes[1].plot(
                 [root.real for root in start_mat],
                 [root.imag for root in start_mat],
-                'm.', marker='s', markersize=8, zorder=20, label='gain_point')
+                marker='s', markersize=8, zorder=20, label='gain_point')
             s = start_mat[0][0]
             if isdtime(sys, strict=True):
                 zeta = -np.cos(np.angle(np.log(s)))
@@ -628,7 +628,7 @@ def _RLFeedbackClicksPoint(event, sys, fig, ax_rlocus, sisotool=False):
             ax_rlocus.plot(
                 [root.real for root in mymat],
                 [root.imag for root in mymat],
-                'm.', marker='s', markersize=8, zorder=20, label='gain_point')
+                marker='s', markersize=8, zorder=20, label='gain_point')
         else:
             ax_rlocus.plot(s.real, s.imag, 'k.', marker='s', markersize=8,
                            zorder=20, label='gain_point')

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -81,10 +81,10 @@ def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
 
     # Setup sisotool figure or superimpose if one is already present
     fig = plt.gcf()
-    if fig.canvas.get_window_title() != 'Sisotool':
+    if fig.canvas.manager.get_window_title() != 'Sisotool':
         plt.close(fig)
         fig,axes = plt.subplots(2, 2)
-        fig.canvas.set_window_title('Sisotool')
+        fig.canvas.manager.set_window_title('Sisotool')
 
     # Extract bode plot parameters
     bode_plot_params = {


### PR DESCRIPTION
Use recommended canvas.manager.{get,set}_window_title instead of
deprecated canvas.{get,set}_window_title.

Remove redundant marker specification in sisotool rlocus plot.canvas.manager.{get,set}_window_title

Fixes these warnings on master (Python 3.9.2, Matplotlib 3.4.1, python-control 8299ebbe):

```
ontrol/tests/sisotool_test.py::TestSisotool::test_sisotool
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect_dt
control/tests/sisotool_test.py::TestSisotool::test_sisotool_mimo
  /home/rory/src/python-control/control/sisotool.py:84: MatplotlibDeprecationWarning: 
  The get_window_title function was deprecated in Matplotlib 3.4 and will be removed two minor releases later. Use manager.get_window_title or GUI-specific methods instead.
    if fig.canvas.get_window_title() != 'Sisotool':

control/tests/sisotool_test.py::TestSisotool::test_sisotool
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect_dt
control/tests/sisotool_test.py::TestSisotool::test_sisotool_mimo
  /home/rory/src/python-control/control/sisotool.py:87: MatplotlibDeprecationWarning: 
  The set_window_title function was deprecated in Matplotlib 3.4 and will be removed two minor releases later. Use manager.set_window_title or GUI-specific methods instead.
    fig.canvas.set_window_title('Sisotool')

control/tests/sisotool_test.py::TestSisotool::test_sisotool
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect_dt
control/tests/sisotool_test.py::TestSisotool::test_sisotool_mimo
  /home/rory/src/python-control/control/rlocus.py:180: UserWarning: marker is redundantly defined by the 'marker' keyword argument and the fmt string "m." (-> marker='.'). The keyword argument will take precedence.
    fig.axes[1].plot(

control/tests/sisotool_test.py::TestSisotool::test_sisotool
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect
control/tests/sisotool_test.py::TestSisotool::test_sisotool_tvect_dt
  /home/rory/src/python-control/control/rlocus.py:628: UserWarning: marker is redundantly defined by the 'marker' keyword argument and the fmt string "m." (-> marker='.'). The keyword argument will take precedence.
    ax_rlocus.plot(
```
