### PR TITLE
Updated rlocus.py to remove warning by sisotool() with rlocus_grid=True

### DIFF
--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -236,7 +236,7 @@ def root_locus(sys, kvect=None, xlim=None, ylim=None,
             if isdtime(sys, strict=True):
                 zgrid(ax=ax)
             else:
-                _sgrid_func(f)
+                _sgrid_func(fig=fig)
         elif grid:
             if isdtime(sys, strict=True):
                 zgrid(ax=ax)


### PR DESCRIPTION
At line 239 in rlocus.py parameter passed to _sgrid_func() has been corrected. It was giving error when calling sisotool() with parameter rlocus_grid=True.