### PR TITLE
fix damp method for discrete time systems with a negative real-valued pole

### DIFF
--- a/control/lti.py
+++ b/control/lti.py
@@ -159,8 +159,7 @@ class LTI:
         poles = self.pole()
 
         if isdtime(self, strict=True):
-            poles = poles.astype(complex)
-            splane_poles = np.log(poles)/self.dt
+            splane_poles = np.log(poles.astype(complex))/self.dt
         else:
             splane_poles = poles
         wn = absolute(splane_poles)

--- a/control/lti.py
+++ b/control/lti.py
@@ -159,6 +159,7 @@ class LTI:
         poles = self.pole()
 
         if isdtime(self, strict=True):
+            poles = poles.astype(complex)
             splane_poles = np.log(poles)/self.dt
         else:
             splane_poles = poles

--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -70,15 +70,14 @@ class TestLTI:
         np.testing.assert_almost_equal(sys_dt.damp(), expected_dt)
         np.testing.assert_almost_equal(damp(sys_dt), expected_dt)
 
-        #also check that for a discrete system with a negative real pole the damp function can extract wn and theta.
+        #also check that for a discrete system with a negative real pole the damp function can extract wn and zeta.
         p2_zplane = -0.2
-        sys_dt2 = tf(1,[1,-p2_zplane],dt)
-        wn2, zeta2, _ = sys_dt2.damp()
-        p2 = -wn2 * zeta2 + 1j * wn2 * np.sqrt(1 - zeta2**2)
-        p2_zplane = np.exp(p2*dt)
-        np.testing.assert_almost_equal(sys_dt2.pole(),p2_zplane)
+        sys_dt2 = tf(1, [1, -p2_zplane], dt)
+        wn2, zeta2, p2 = sys_dt2.damp()
+        p2_splane = -wn2 * zeta2 + 1j * wn2 * np.sqrt(1 - zeta2**2)
+        p2_zplane = np.exp(p2_splane * dt)
+        np.testing.assert_almost_equal(p2, p2_zplane)
         
-
     def test_dcgain(self):
         sys = tf(84, [1, 2])
         np.testing.assert_allclose(sys.dcgain(), 42)

--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -70,6 +70,15 @@ class TestLTI:
         np.testing.assert_almost_equal(sys_dt.damp(), expected_dt)
         np.testing.assert_almost_equal(damp(sys_dt), expected_dt)
 
+        #also check that for a discrete system with a negative real pole the damp function can extract wn and theta.
+        p2_zplane = -0.2
+        sys_dt2 = tf(1,[1,-p2_zplane],dt)
+        wn2, zeta2, _ = sys_dt2.damp()
+        p2 = -wn2 * zeta2 + 1j * wn2 * np.sqrt(1 - zeta2**2)
+        p2_zplane = np.exp(p2*dt)
+        np.testing.assert_almost_equal(sys_dt2.pole(),p2_zplane)
+        
+
     def test_dcgain(self):
         sys = tf(84, [1, 2])
         np.testing.assert_allclose(sys.dcgain(), 42)


### PR DESCRIPTION
(first pull request on GitHub)

When a discrete time system has a real-valued negative pole, the discrete to continuous conversion using the log function returns nan. Then, the damp method is not able to compute the damping and the wn values.

To avoid this problem, the poles must be cast to complex values (https://numpy.org/doc/stable/reference/generated/numpy.log.html)

