### PR TITLE
ease test tolerance on timeseries

### DIFF
--- a/control/tests/flatsys_test.py
+++ b/control/tests/flatsys_test.py
@@ -339,8 +339,9 @@ class TestFlatSys:
         traj_kwarg = fs.point_to_point(
             flat_sys, timepts, x0, u0, xf, uf, cost=cost_fcn,
             basis=fs.PolyFamily(8), minimize_kwargs={'method': 'slsqp'})
-        np.testing.assert_almost_equal(
-            traj_method.eval(timepts)[0], traj_kwarg.eval(timepts)[0])
+        np.testing.assert_allclose(
+            traj_method.eval(timepts)[0], traj_kwarg.eval(timepts)[0],
+            atol=1e-5)
 
         # Unrecognized keywords
         with pytest.raises(TypeError, match="unrecognized keyword"):

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -681,7 +681,8 @@ class TestTimeresp:
             fr_kwargs['X0'] = tsystem.X0
         t, y = forced_response(tsystem.sys, **fr_kwargs)
         np.testing.assert_allclose(t, tsystem.t)
-        np.testing.assert_allclose(y, getattr(tsystem, refattr), rtol=1e-3)
+        np.testing.assert_allclose(y, getattr(tsystem, refattr),
+                                   rtol=1e-3, atol=1e-5)
 
     @pytest.mark.parametrize("tsystem", ["siso_ss1"], indirect=True)
     def test_forced_response_invalid_c(self, tsystem):


### PR DESCRIPTION
Some jobs in the Slycot CI currently fail on two tests. Comparing small floats is hard.