### PR TITLE
in nyquist plots, draw contour at specified magnitude if threshold is exceeded

### DIFF
--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -522,7 +522,7 @@ _nyquist_defaults = {
     'nyquist.mirror_style': '--',
     'nyquist.arrows': 2,
     'nyquist.arrow_size': 8,
-    'nyquist.indent_radius': 1e-3,
+    'nyquist.indent_radius': 1e-2,
     'nyquist.maximum_magnitude': 5,
     'nyquist.indent_direction': 'right',
 }
@@ -899,7 +899,7 @@ def _add_arrows_to_line2D(
         raise ValueError("expected a matplotlib.lines.Line2D object")
     x, y = line.get_xdata(), line.get_ydata()
     x, y = x[np.isfinite(x)], y[np.isfinite(x)]
-    if len(x) == 0: 
+    if len(x) in (0, 1): 
         return []
     arrow_kw = {
         "arrowstyle": arrowstyle,

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -899,7 +899,8 @@ def _add_arrows_to_line2D(
         raise ValueError("expected a matplotlib.lines.Line2D object")
     x, y = line.get_xdata(), line.get_ydata()
     x, y = x[np.isfinite(x)], y[np.isfinite(x)]
-
+    if len(x) == 0: 
+        return []
     arrow_kw = {
         "arrowstyle": arrowstyle,
     }

--- a/control/tests/nyquist_test.py
+++ b/control/tests/nyquist_test.py
@@ -69,7 +69,8 @@ def test_nyquist_basic():
 
     # Make sure that we can turn off frequency modification
     count, contour_indented = ct.nyquist_plot(
-        sys, np.linspace(1e-4, 1e2, 100), return_contour=True)
+        sys, np.linspace(1e-4, 1e2, 100), indent_radius=0.01, 
+        return_contour=True)
     assert not all(contour_indented.real == 0)
     count, contour = ct.nyquist_plot(
         sys, np.linspace(1e-4, 1e2, 100), return_contour=True,
@@ -87,14 +88,17 @@ def test_nyquist_basic():
     assert _Z(sys) == count + _P(sys)
 
     # Nyquist plot with poles on imaginary axis, omega specified
+    # when specifying omega, usually need to specify larger indent radius
     sys = ct.tf([1], [1, 3, 2]) * ct.tf([1], [1, 0, 1])
-    count = ct.nyquist_plot(sys, np.linspace(1e-3, 1e1, 1000))
+    count = ct.nyquist_plot(sys, np.linspace(1e-3, 1e1, 1000), 
+        indent_radius=0.1)
     assert _Z(sys) == count + _P(sys)
 
     # Nyquist plot with poles on imaginary axis, omega specified, with contour
     sys = ct.tf([1], [1, 3, 2]) * ct.tf([1], [1, 0, 1])
     count, contour = ct.nyquist_plot(
-        sys, np.linspace(1e-3, 1e1, 1000), return_contour=True)
+        sys, np.linspace(1e-3, 1e1, 1000), indent_radius=0.1,
+        return_contour=True)
     assert _Z(sys) == count + _P(sys)
 
     # Nyquist plot with poles on imaginary axis, return contour
@@ -193,13 +197,10 @@ def test_nyquist_indent():
     plt.title("Pole at origin; indent_radius=default")
     assert _Z(sys) == count + _P(sys)
 
-    # first value of default omega vector was 0.1, replaced by 0. for contour
-    # indent_radius is larger than 0.1 -> no extra quater circle around origin
+    # confirm that first element of indent is properly indented
     count, contour = ct.nyquist_plot(sys, plot=False, indent_radius=.1007,
                                      return_contour=True)
     np.testing.assert_allclose(contour[0], .1007+0.j)
-    # second value of omega_vector is larger than indent_radius: not indented
-    assert np.all(contour.real[2:] == 0.)
 
     plt.figure();
     count, contour = ct.nyquist_plot(sys, indent_radius=0.01,
@@ -208,7 +209,7 @@ def test_nyquist_indent():
     assert _Z(sys) == count + _P(sys)
     # indent radius is smaller than the start of the default omega vector
     # check that a quarter circle around the pole at origin has been added.
-    np.testing.assert_allclose(contour[:50].real**2 + contour[:50].imag**2,
+    np.testing.assert_allclose(contour[:25].real**2 + contour[:25].imag**2,
                                0.01**2)
 
     plt.figure();

--- a/control/tests/nyquist_test.py
+++ b/control/tests/nyquist_test.py
@@ -141,12 +141,23 @@ def test_nyquist_fbs_examples():
     count = ct.nyquist_plot(sys)
     assert _Z(sys) == count + _P(sys)
 
+    # when omega is specified, no points are added at indentations, leading 
+    # to incorrect encirclement count
+    plt.figure()
+    plt.title("Figure 10.10: L(s) = 3 (s+6)^2 / (s (s+1)^2) [zoom]")
+    count = ct.nyquist_plot(sys, omega=np.linspace(1.5, 1e3, 1000))
+    # assert _Z(sys) == count + _P(sys)
+    assert count == -1
+
+    # when only the range of the frequency is provided, this permits 
+    # extra points to be added at indentations, leading to correct count
     plt.figure()
     plt.title("Figure 10.10: L(s) = 3 (s+6)^2 / (s (s+1)^2) [zoom]")
     count = ct.nyquist_plot(sys, omega_limits=[1.5, 1e3])
     # Frequency limits for zoom give incorrect encirclement count
     # assert _Z(sys) == count + _P(sys)
-    assert count == -1
+    assert count == 0
+
 
 
 @pytest.mark.parametrize("arrows", [
@@ -226,6 +237,10 @@ def test_nyquist_indent():
     count = ct.nyquist_plot(sys)
     plt.title("Imaginary poles; encirclements = %d" % count)
     assert _Z(sys) == count + _P(sys)
+
+    # confirm we can turn off maximum_magitude plot
+    plt.figure();
+    count = ct.nyquist_plot(sys, plot_maximum_magnitude=0)
 
     # Imaginary poles with indentation to the left
     plt.figure();


### PR DESCRIPTION
This pr was motivated by a feedback system in which the default indent radius resulted in a very small, confusing contour. In this PR, the maximum radius is specified explicitly. This also helps visualize -1 point because the nyquist plot has a standard size relative to that point. To do so, the default indent radius is reduced and an extra contour is drawn when the regular contour leaves the plot window.  

Before: 
<img width="420" alt="image" src="https://user-images.githubusercontent.com/58706249/142756751-438ea387-c910-4aa0-a0eb-ec86feb78d4a.png">
<img width="408" alt="image" src="https://user-images.githubusercontent.com/58706249/142756761-aa3f9c2d-69ab-493f-8294-decb0e1311c5.png">
<img width="395" alt="image" src="https://user-images.githubusercontent.com/58706249/142756770-a16b0145-00bd-4fa8-a4ce-810783f71e88.png">
<img width="420" alt="image" src="https://user-images.githubusercontent.com/58706249/142756779-d682e269-91d8-4761-a685-7d3b8e49ae0b.png"> (dt system)
After:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/58706249/142756788-57b7ad87-42da-4738-8bf0-e92e816980e0.png">
<img width="409" alt="image" src="https://user-images.githubusercontent.com/58706249/142756794-e7c091c1-c0dc-4359-8082-6efc0345d882.png">
<img width="403" alt="image" src="https://user-images.githubusercontent.com/58706249/142756796-deb02643-00b4-48a9-9b18-cd50e9912525.png">
<img width="406" alt="image" src="https://user-images.githubusercontent.com/58706249/142756808-36e81c7e-e4d8-4f6e-9149-757b38128910.png">(dt system)
