### PR TITLE
Remove duplicate Slycot error handling, require Slycot >=0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,6 @@ setup(
                       'matplotlib'],
     extras_require={
        'test': ['pytest', 'pytest-timeout'],
+       'slycot': [ 'slycot>=0.4.0' ]
     }
 )


### PR DESCRIPTION
There is a lot of unused code in mateqn.py, because Slycot itself warns and raises its own exceptions in case of invalid inputs or failing numerical routines.

I guess this also overlaps a bit with #670.