### PR TITLE
LQR using SciPy

### DIFF
--- a/control/exception.py
+++ b/control/exception.py
@@ -61,10 +61,13 @@ class ControlNotImplemented(NotImplementedError):
     pass
 
 # Utility function to see if slycot is installed
+slycot_installed = None
 def slycot_check():
-    try:
-        import slycot
-    except:
-        return False
-    else:
-        return True
+    global slycot_installed
+    if slycot_installed is None:
+        try:
+            import slycot
+            slycot_installed = True
+        except:
+            slycot_installed = False
+    return slycot_installed

--- a/control/mateqn.py
+++ b/control/mateqn.py
@@ -35,9 +35,8 @@
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-
 import warnings
-
+import numpy as np
 from numpy import shape, size, asarray, copy, zeros, eye, \
     finfo, inexact, atleast_2d
 from scipy.linalg import eigvals, solve_discrete_are, solve
@@ -52,8 +51,9 @@ except ImportError:
 
 try:
     from slycot import sb03md57
+
     # wrap without the deprecation warning
-    def sb03md(n, C, A, U, dico, job='X',fact='N',trana='N',ldwork=None):
+    def sb03md(n, C, A, U, dico, job='X', fact='N', trana='N', ldwork=None):
         ret = sb03md57(A, U, C, dico, job, fact, trana, ldwork)
         return ret[2:]
 except ImportError:
@@ -89,8 +89,8 @@ def lyap(A, Q, C=None, E=None):
 
         :math:`A X + X A^T + Q = 0`
 
-    where A and Q are square matrices of the same dimension.
-    Further, Q must be symmetric.
+    where A and Q are square matrices of the same dimension.  Q must be
+    symmetric.
 
     X = lyap(A, Q, C) solves the Sylvester equation
 
@@ -103,17 +103,17 @@ def lyap(A, Q, C=None, E=None):
 
         :math:`A X E^T + E X A^T + Q = 0`
 
-    where Q is a symmetric matrix and A, Q and E are square matrices
-    of the same dimension.
+    where Q is a symmetric matrix and A, Q and E are square matrices of the
+    same dimension.
 
     Parameters
     ----------
-    A : 2D array
-        Dynamics matrix
-    C : 2D array, optional
-        If present, solve the Slyvester equation
-    E : 2D array, optional
-        If present, solve the generalized Laypunov equation
+    A, Q : 2D array_like
+        Input matrices for the Lyapunov or Sylvestor equation
+    C : 2D array_like, optional
+        If present, solve the Sylvester equation
+    E : 2D array_like, optional
+        If present, solve the generalized Lyapunov equation
 
     Returns
     -------
@@ -124,6 +124,7 @@ def lyap(A, Q, C=None, E=None):
     -----
     The return type for 2D arrays depends on the default class set for
     state space operations.  See :func:`~control.use_numpy_matrix`.
+
     """
 
     if sb03md is None:
@@ -131,46 +132,25 @@ def lyap(A, Q, C=None, E=None):
     if sb04md is None:
         raise ControlSlycot("can't find slycot module 'sb04md'")
 
-
-    # Reshape 1-d arrays
-    if len(shape(A)) == 1:
-        A = A.reshape(1, A.size)
-
-    if len(shape(Q)) == 1:
-        Q = Q.reshape(1, Q.size)
-
-    if C is not None and len(shape(C)) == 1:
-        C = C.reshape(1, C.size)
-
-    if E is not None and len(shape(E)) == 1:
-        E = E.reshape(1, E.size)
+    # Reshape input arrays
+    A = np.array(A, ndmin=2)
+    Q = np.array(Q, ndmin=2)
+    if C is not None:
+        C = np.array(C, ndmin=2)
+    if E is not None:
+        E = np.array(E, ndmin=2)
 
     # Determine main dimensions
-    if size(A) == 1:
-        n = 1
-    else:
-        n = size(A, 0)
+    n = A.shape[0]
+    m = Q.shape[0]
 
-    if size(Q) == 1:
-        m = 1
-    else:
-        m = size(Q, 0)
+    # Check to make sure input matrices are the right shape and type
+    _check_shape("A", A, n, n, square=True)
 
     # Solve standard Lyapunov equation
     if C is None and E is None:
-        # Check input data for consistency
-        if shape(A) != shape(Q):
-            raise ControlArgument("A and Q must be matrices of identical \
-                                sizes.")
-
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if size(Q) > 1 and shape(Q)[0] != shape(Q)[1]:
-            raise ControlArgument("Q must be a quadratic matrix.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("Q", Q, n, n, square=True, symmetric=True)
 
         # Solve the Lyapunov equation by calling Slycot function sb03md
         with warnings.catch_warnings():
@@ -178,47 +158,25 @@ def lyap(A, Q, C=None, E=None):
             X, scale, sep, ferr, w = \
                 sb03md(n, -Q, A, eye(n, n), 'C', trana='T')
 
-
     # Solve the Sylvester equation
     elif C is not None and E is None:
-        # Check input data for consistency
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if size(Q) > 1 and shape(Q)[0] != shape(Q)[1]:
-            raise ControlArgument("Q must be a quadratic matrix.")
-
-        if (size(C) > 1 and shape(C)[0] != n) or \
-           (size(C) > 1 and shape(C)[1] != m) or \
-           (size(C) == 1 and size(A) != 1) or \
-           (size(C) == 1 and size(Q) != 1):
-            raise ControlArgument("C matrix has incompatible dimensions.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("Q", Q, m, m, square=True)
+        _check_shape("C", C, n, m)
 
         # Solve the Sylvester equation by calling the Slycot function sb04md
         X = sb04md(n, m, A, Q, -C)
 
-
     # Solve the generalized Lyapunov equation
     elif C is None and E is not None:
-        # Check input data for consistency
-        if (size(Q) > 1 and shape(Q)[0] != shape(Q)[1]) or \
-           (size(Q) > 1 and shape(Q)[0] != n) or \
-           (size(Q) == 1 and n > 1):
-            raise ControlArgument("Q must be a square matrix with the same \
-                dimension as A.")
-
-        if (size(E) > 1 and shape(E)[0] != shape(E)[1]) or \
-           (size(E) > 1 and shape(E)[0] != n) or \
-           (size(E) == 1 and n > 1):
-            raise ControlArgument("E must be a square matrix with the same \
-                dimension as A.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("Q", Q, n, n, square=True, symmetric=True)
+        _check_shape("E", E, n, n, square=True)
 
         # Make sure we have access to the write slicot routine
         try:
             from slycot import sg03ad
+
         except ImportError:
             raise ControlSlycot("can't find slycot module 'sg03ad'")
 
@@ -229,6 +187,7 @@ def lyap(A, Q, C=None, E=None):
             A, E, Q, Z, X, scale, sep, ferr, alphar, alphai, beta = \
                 sg03ad('C', 'B', 'N', 'T', 'L', n,
                        A, E, eye(n, n), eye(n, n), -Q)
+
     # Invalid set of input parameters
     else:
         raise ControlArgument("Invalid set of input parameters")
@@ -237,20 +196,20 @@ def lyap(A, Q, C=None, E=None):
 
 
 def dlyap(A, Q, C=None, E=None):
-    """ dlyap(A,Q) solves the discrete-time Lyapunov equation
+    """ dlyap(A, Q) solves the discrete-time Lyapunov equation
 
         :math:`A X A^T - X + Q = 0`
 
     where A and Q are square matrices of the same dimension. Further
     Q must be symmetric.
 
-    dlyap(A,Q,C) solves the Sylvester equation
+    dlyap(A, Q, C) solves the Sylvester equation
 
         :math:`A X Q^T - X + C = 0`
 
     where A and Q are square matrices.
 
-    dlyap(A,Q,None,E) solves the generalized discrete-time Lyapunov
+    dlyap(A, Q, None, E) solves the generalized discrete-time Lyapunov
     equation
 
         :math:`A X A^T - E X E^T + Q = 0`
@@ -266,45 +225,25 @@ def dlyap(A, Q, C=None, E=None):
     if sg03ad is None:
         raise ControlSlycot("can't find slycot module 'sg03ad'")
 
-    # Reshape 1-d arrays
-    if len(shape(A)) == 1:
-        A = A.reshape(1, A.size)
-
-    if len(shape(Q)) == 1:
-        Q = Q.reshape(1, Q.size)
-
-    if C is not None and len(shape(C)) == 1:
-        C = C.reshape(1, C.size)
-
-    if E is not None and len(shape(E)) == 1:
-        E = E.reshape(1, E.size)
+    # Reshape input arrays
+    A = np.array(A, ndmin=2)
+    Q = np.array(Q, ndmin=2)
+    if C is not None:
+        C = np.array(C, ndmin=2)
+    if E is not None:
+        E = np.array(E, ndmin=2)
 
     # Determine main dimensions
-    if size(A) == 1:
-        n = 1
-    else:
-        n = size(A, 0)
+    n = A.shape[0]
+    m = Q.shape[0]
 
-    if size(Q) == 1:
-        m = 1
-    else:
-        m = size(Q, 0)
+    # Check to make sure input matrices are the right shape and type
+    _check_shape("A", A, n, n, square=True)
 
     # Solve standard Lyapunov equation
     if C is None and E is None:
-        # Check input data for consistency
-        if shape(A) != shape(Q):
-            raise ControlArgument("A and Q must be matrices of identical \
-                                 sizes.")
-
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if size(Q) > 1 and shape(Q)[0] != shape(Q)[1]:
-            raise ControlArgument("Q must be a quadratic matrix.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("Q", Q, n, n, square=True, symmetric=True)
 
         # Solve the Lyapunov equation by calling the Slycot function sb03md
         with warnings.catch_warnings():
@@ -314,38 +253,18 @@ def dlyap(A, Q, C=None, E=None):
 
     # Solve the Sylvester equation
     elif C is not None and E is None:
-        # Check input data for consistency
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix")
-
-        if size(Q) > 1 and shape(Q)[0] != shape(Q)[1]:
-            raise ControlArgument("Q must be a quadratic matrix")
-
-        if (size(C) > 1 and shape(C)[0] != n) or \
-           (size(C) > 1 and shape(C)[1] != m) or \
-           (size(C) == 1 and size(A) != 1) or (size(C) == 1 and size(Q) != 1):
-            raise ControlArgument("C matrix has incompatible dimensions")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("Q", Q, m, m, square=True)
+        _check_shape("C", C, n, m)
 
         # Solve the Sylvester equation by calling Slycot function sb04qd
         X = sb04qd(n, m, -A, asarray(Q).T, C)
 
     # Solve the generalized Lyapunov equation
     elif C is None and E is not None:
-        # Check input data for consistency
-        if (size(Q) > 1 and shape(Q)[0] != shape(Q)[1]) or \
-           (size(Q) > 1 and shape(Q)[0] != n) or \
-           (size(Q) == 1 and n > 1):
-            raise ControlArgument("Q must be a square matrix with the same \
-                dimension as A.")
-
-        if (size(E) > 1 and shape(E)[0] != shape(E)[1]) or \
-           (size(E) > 1 and shape(E)[0] != n) or \
-           (size(E) == 1 and n > 1):
-            raise ControlArgument("E must be a square matrix with the same \
-                dimension as A.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("Q", Q, n, n, square=True, symmetric=True)
+        _check_shape("E", E, n, n, square=True)
 
         # Solve the generalized Lyapunov equation by calling Slycot
         # function sg03ad
@@ -354,6 +273,7 @@ def dlyap(A, Q, C=None, E=None):
             A, E, Q, Z, X, scale, sep, ferr, alphar, alphai, beta = \
                 sg03ad('D', 'B', 'N', 'T', 'L', n,
                        A, E, eye(n, n), eye(n, n), -Q)
+
     # Invalid set of input parameters
     else:
         raise ControlArgument("Invalid set of input parameters")
@@ -364,7 +284,6 @@ def dlyap(A, Q, C=None, E=None):
 #
 # Riccati equation solvers care and dare
 #
-
 
 def care(A, B, Q, R=None, S=None, E=None, stabilizing=True):
     """(X, L, G) = care(A, B, Q, R=None) solves the continuous-time
@@ -391,9 +310,9 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True):
 
     Parameters
     ----------
-    A, B, Q : 2D arrays
+    A, B, Q : 2D array_like
         Input matrices for the Riccati equation
-    R, S, E : 2D arrays, optional
+    R, S, E : 2D array_like, optional
         Input matrices for generalized Riccati equation
 
     Returns
@@ -412,7 +331,7 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True):
 
     """
 
-    # Make sure we can import required slycot routine
+    # Make sure we can import required slycot routines
     try:
         from slycot import sb02md
     except ImportError:
@@ -429,60 +348,28 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True):
     except ImportError:
         raise ControlSlycot("can't find slycot module 'sg02ad'")
 
-    # Reshape 1-d arrays
-    if len(shape(A)) == 1:
-        A = A.reshape(1, A.size)
-
-    if len(shape(B)) == 1:
-        B = B.reshape(1, B.size)
-
-    if len(shape(Q)) == 1:
-        Q = Q.reshape(1, Q.size)
-
-    if R is not None and len(shape(R)) == 1:
-        R = R.reshape(1, R.size)
-
-    if S is not None and len(shape(S)) == 1:
-        S = S.reshape(1, S.size)
-
-    if E is not None and len(shape(E)) == 1:
-        E = E.reshape(1, E.size)
+    # Reshape input arrays
+    A = np.array(A, ndmin=2)
+    B = np.array(B, ndmin=2)
+    Q = np.array(Q, ndmin=2)
+    R = np.eye(B.shape[1]) if R is None else np.array(R, ndmin=2)
+    if S is not None:
+        S = np.array(S, ndmin=2)
+    if E is not None:
+        E = np.array(E, ndmin=2)
 
     # Determine main dimensions
-    if size(A) == 1:
-        n = 1
-    else:
-        n = size(A, 0)
+    n = A.shape[0]
+    m = B.shape[1]
 
-    if size(B) == 1:
-        m = 1
-    else:
-        m = size(B, 1)
-    if R is None:
-        R = eye(m, m)
+    # Check to make sure input matrices are the right shape and type
+    _check_shape("A", A, n, n, square=True)
+    _check_shape("B", B, n, m)
+    _check_shape("Q", Q, n, n, square=True, symmetric=True)
+    _check_shape("R", R, m, m, square=True, symmetric=True)
 
     # Solve the standard algebraic Riccati equation
     if S is None and E is None:
-        # Check input data for consistency
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if (size(Q) > 1 and shape(Q)[0] != shape(Q)[1]) or \
-           (size(Q) > 1 and shape(Q)[0] != n) or \
-           size(Q) == 1 and n > 1:
-            raise ControlArgument("Q must be a quadratic matrix of the same \
-                dimension as A.")
-
-        if (size(B) > 1 and shape(B)[0] != n) or \
-           size(B) == 1 and n > 1:
-            raise ControlArgument("Incompatible dimensions of B matrix.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
-
-        if not _is_symmetric(R):
-            raise ControlArgument("R must be a symmetric matrix.")
-
         # Create back-up of arrays needed for later computations
         R_ba = copy(R)
         B_ba = copy(B)
@@ -506,43 +393,9 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True):
 
     # Solve the generalized algebraic Riccati equation
     elif S is not None and E is not None:
-        # Check input data for consistency
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if (size(Q) > 1 and shape(Q)[0] != shape(Q)[1]) or \
-           (size(Q) > 1 and shape(Q)[0] != n) or \
-           size(Q) == 1 and n > 1:
-            raise ControlArgument("Q must be a quadratic matrix of the same \
-                dimension as A.")
-
-        if (size(B) > 1 and shape(B)[0] != n) or \
-           size(B) == 1 and n > 1:
-            raise ControlArgument("Incompatible dimensions of B matrix.")
-
-        if (size(E) > 1 and shape(E)[0] != shape(E)[1]) or \
-           (size(E) > 1 and shape(E)[0] != n) or \
-           size(E) == 1 and n > 1:
-            raise ControlArgument("E must be a quadratic matrix of the same \
-                dimension as A.")
-
-        if (size(R) > 1 and shape(R)[0] != shape(R)[1]) or \
-           (size(R) > 1 and shape(R)[0] != m) or \
-           size(R) == 1 and m > 1:
-            raise ControlArgument("R must be a quadratic matrix of the same \
-                dimension as the number of columns in the B matrix.")
-
-        if (size(S) > 1 and shape(S)[0] != n) or \
-           (size(S) > 1 and shape(S)[1] != m) or \
-           size(S) == 1 and n > 1 or \
-           size(S) == 1 and m > 1:
-            raise ControlArgument("Incompatible dimensions of S matrix.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
-
-        if not _is_symmetric(R):
-            raise ControlArgument("R must be a symmetric matrix.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("E", E, n, n, square=True)
+        _check_shape("S", S, n, m)
 
         # Create back-up of arrays needed for later computations
         R_b = copy(R)
@@ -577,7 +430,7 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True):
 
     # Invalid set of input parameters
     else:
-        raise ControlArgument("Invalid set of input parameters.")
+        raise ControlArgument("Invalid set of input parameters")
 
 
 def dare(A, B, Q, R, S=None, E=None, stabilizing=True):
@@ -623,9 +476,31 @@ def dare(A, B, Q, R, S=None, E=None, stabilizing=True):
     state space operations.  See :func:`~control.use_numpy_matrix`.
 
     """
+    # Reshape input arrays
+    A = np.array(A, ndmin=2)
+    B = np.array(B, ndmin=2)
+    Q = np.array(Q, ndmin=2)
+    R = np.eye(B.shape[1]) if R is None else np.array(R, ndmin=2)
+    if S is not None:
+        S = np.array(S, ndmin=2)
+    if E is not None:
+        E = np.array(E, ndmin=2)
+
+    # Determine main dimensions
+    n = A.shape[0]
+    m = B.shape[1]
+
+    # Check to make sure input matrices are the right shape and type
+    _check_shape("A", A, n, n, square=True)
+
     if S is not None or E is not None or not stabilizing:
         return dare_old(A, B, Q, R, S, E, stabilizing)
+
     else:
+        _check_shape("B", B, n, m)
+        _check_shape("Q", Q, n, n, square=True, symmetric=True)
+        _check_shape("R", R, m, m, square=True, symmetric=True)
+
         Rmat = _ssmatrix(R)
         Qmat = _ssmatrix(Q)
         X = solve_discrete_are(A, B, Qmat, Rmat)
@@ -652,58 +527,28 @@ def dare_old(A, B, Q, R, S=None, E=None, stabilizing=True):
     except ImportError:
         raise ControlSlycot("can't find slycot module 'sg02ad'")
 
-    # Reshape 1-d arrays
-    if len(shape(A)) == 1:
-        A = A.reshape(1, A.size)
-
-    if len(shape(B)) == 1:
-        B = B.reshape(1, B.size)
-
-    if len(shape(Q)) == 1:
-        Q = Q.reshape(1, Q.size)
-
-    if R is not None and len(shape(R)) == 1:
-        R = R.reshape(1, R.size)
-
-    if S is not None and len(shape(S)) == 1:
-        S = S.reshape(1, S.size)
-
-    if E is not None and len(shape(E)) == 1:
-        E = E.reshape(1, E.size)
+    # Reshape input arrays
+    A = np.array(A, ndmin=2)
+    B = np.array(B, ndmin=2)
+    Q = np.array(Q, ndmin=2)
+    R = np.eye(B.shape[1]) if R is None else np.array(R, ndmin=2)
+    if S is not None:
+        S = np.array(S, ndmin=2)
+    if E is not None:
+        E = np.array(E, ndmin=2)
 
     # Determine main dimensions
-    if size(A) == 1:
-        n = 1
-    else:
-        n = size(A, 0)
+    n = A.shape[0]
+    m = B.shape[1]
 
-    if size(B) == 1:
-        m = 1
-    else:
-        m = size(B, 1)
+    # Check to make sure input matrices are the right shape and type
+    _check_shape("A", A, n, n, square=True)
+    _check_shape("B", B, n, m)
+    _check_shape("Q", Q, n, n, square=True, symmetric=True)
+    _check_shape("R", R, m, m, square=True, symmetric=True)
 
     # Solve the standard algebraic Riccati equation
     if S is None and E is None:
-        # Check input data for consistency
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if (size(Q) > 1 and shape(Q)[0] != shape(Q)[1]) or \
-           (size(Q) > 1 and shape(Q)[0] != n) or \
-           size(Q) == 1 and n > 1:
-            raise ControlArgument("Q must be a quadratic matrix of the same \
-                dimension as A.")
-
-        if (size(B) > 1 and shape(B)[0] != n) or \
-           size(B) == 1 and n > 1:
-            raise ControlArgument("Incompatible dimensions of B matrix.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
-
-        if not _is_symmetric(R):
-            raise ControlArgument("R must be a symmetric matrix.")
-
         # Create back-up of arrays needed for later computations
         A_ba = copy(A)
         R_ba = copy(R)
@@ -730,43 +575,9 @@ def dare_old(A, B, Q, R, S=None, E=None, stabilizing=True):
 
     # Solve the generalized algebraic Riccati equation
     elif S is not None and E is not None:
-        # Check input data for consistency
-        if size(A) > 1 and shape(A)[0] != shape(A)[1]:
-            raise ControlArgument("A must be a quadratic matrix.")
-
-        if (size(Q) > 1 and shape(Q)[0] != shape(Q)[1]) or \
-           (size(Q) > 1 and shape(Q)[0] != n) or \
-           size(Q) == 1 and n > 1:
-            raise ControlArgument("Q must be a quadratic matrix of the same \
-                dimension as A.")
-
-        if (size(B) > 1 and shape(B)[0] != n) or \
-           size(B) == 1 and n > 1:
-            raise ControlArgument("Incompatible dimensions of B matrix.")
-
-        if (size(E) > 1 and shape(E)[0] != shape(E)[1]) or \
-           (size(E) > 1 and shape(E)[0] != n) or \
-           size(E) == 1 and n > 1:
-            raise ControlArgument("E must be a quadratic matrix of the same \
-                dimension as A.")
-
-        if (size(R) > 1 and shape(R)[0] != shape(R)[1]) or \
-           (size(R) > 1 and shape(R)[0] != m) or \
-           size(R) == 1 and m > 1:
-            raise ControlArgument("R must be a quadratic matrix of the same \
-                dimension as the number of columns in the B matrix.")
-
-        if (size(S) > 1 and shape(S)[0] != n) or \
-           (size(S) > 1 and shape(S)[1] != m) or \
-           size(S) == 1 and n > 1 or \
-           size(S) == 1 and m > 1:
-            raise ControlArgument("Incompatible dimensions of S matrix.")
-
-        if not _is_symmetric(Q):
-            raise ControlArgument("Q must be a symmetric matrix.")
-
-        if not _is_symmetric(R):
-            raise ControlArgument("R must be a symmetric matrix.")
+        # Check to make sure input matrices are the right shape and type
+        _check_shape("E", E, n, n, square=True)
+        _check_shape("S", S, n, m)
 
         # Create back-up of arrays needed for later computations
         A_b = copy(A)
@@ -803,11 +614,24 @@ def dare_old(A, B, Q, R, S=None, E=None, stabilizing=True):
 
     # Invalid set of input parameters
     else:
-        raise ControlArgument("Invalid set of input parameters.")
+        raise ControlArgument("Invalid set of input parameters")
 
 
+# Utility function to check matrix dimensions
+def _check_shape(name, M, n, m, square=False, symmetric=False):
+    if square and M.shape[0] != M.shape[1]:
+        raise ControlArgument("%s must be a square matrix" % name)
+
+    if symmetric and not _is_symmetric(M):
+        raise ControlArgument("%s must be a symmetric matrix" % name)
+
+    if M.shape[0] != n or M.shape[1] != m:
+        raise ControlArgument("Incompatible dimensions of %s matrix" % name)
+
+
+# Utility function to check if a matrix is symmetric
 def _is_symmetric(M):
-    M = atleast_2d(M)
+    M = np.atleast_2d(M)
     if isinstance(M[0, 0], inexact):
         eps = finfo(M.dtype).eps
         return ((M - M.T) < eps).all()

--- a/control/mateqn.py
+++ b/control/mateqn.py
@@ -189,7 +189,7 @@ def lyap(A, Q, C=None, E=None, method=None):
         _check_shape("E", E, n, n, square=True)
 
         if method == 'scipy':
-            raise ValueError(
+            raise ControlArgument(
                 "method='scipy' not valid for generalized Lyapunov equation")
 
         # Make sure we have access to the write slicot routine
@@ -308,7 +308,7 @@ def dlyap(A, Q, C=None, E=None, method=None):
         _check_shape("C", C, n, m)
 
         if method == 'scipy':
-            raise ValueError(
+            raise ControlArgument(
                 "method='scipy' not valid for Sylvester equation")
 
         # Solve the Sylvester equation by calling Slycot function sb04qd
@@ -321,7 +321,7 @@ def dlyap(A, Q, C=None, E=None, method=None):
         _check_shape("E", E, n, n, square=True)
 
         if method == 'scipy':
-            raise ValueError(
+            raise ControlArgument(
                 "method='scipy' not valid for generalized Lyapunov equation")
 
         # Solve the generalized Lyapunov equation by calling Slycot
@@ -438,7 +438,7 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True, method=None):
         # See if we should solve this using SciPy
         if method == 'scipy':
             if not stabilizing:
-                raise ValueError(
+                raise ControlArgument(
                     "method='scipy' not valid when stabilizing is not True")
 
             X = sp.linalg.solve_continuous_are(A, B, Q, R)
@@ -477,7 +477,7 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True, method=None):
         # See if we should solve this using SciPy
         if method == 'scipy':
             if not stabilizing:
-                raise ValueError(
+                raise ControlArgument(
                     "method='scipy' not valid when stabilizing is not True")
 
             X = sp.linalg.solve_continuous_are(A, B, Q, R, s=S, e=E)
@@ -579,7 +579,7 @@ def dare(A, B, Q, R, S=None, E=None, stabilizing=True, method=None):
 
     # Figure out how to solve the problem
     if method == 'scipy' and not stabilizing:
-        raise ValueError(
+        raise ControlArgument(
             "method='scipy' not valid when stabilizing is not True")
 
     elif method == 'slycot':
@@ -683,7 +683,7 @@ def _slycot_or_scipy(method):
     elif method == 'scipy' or (method is None and not slycot_check()):
         return 'scipy'
     else:
-        raise ValueError("Unknown method %s" % method)
+        raise ControlArgument("Unknown method %s" % method)
 
 
 # Utility function to check matrix dimensions

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -304,6 +304,10 @@ def lqe(*args, **keywords):
         Process and sensor noise covariance matrices
     N : 2D array, optional
         Cross covariance matrix.  Not currently implemented.
+    method : str, optional
+        Set the method used for computing the result.  Current methods are
+        'slycot' and 'scipy'.  If set to None (default), try 'slycot' first
+        and then 'scipy'.
 
     Returns
     -------
@@ -326,8 +330,8 @@ def lqe(*args, **keywords):
 
     Examples
     --------
-    >>> L, P, E = lqe(A, G, C, QN, RN)
-    >>> L, P, E = lqe(A, G, C, QN, RN, NN)
+    >>> L, P, E = lqe(A, G, C, Q, R)
+    >>> L, P, E = lqe(A, G, C, Q, R, N)
 
     See Also
     --------
@@ -344,6 +348,9 @@ def lqe(*args, **keywords):
     #
     # Process the arguments and figure out what inputs we received
     #
+
+    # Get the method to use (if specified as a keyword)
+    method = keywords.get('method', None)
 
     # Get the system description
     if (len(args) < 3):
@@ -393,7 +400,7 @@ def lqe(*args, **keywords):
           N.shape[0] != ninputs or N.shape[1] != noutputs):
         raise ControlDimension("incorrect covariance matrix dimensions")
 
-    P, E, LT = care(A.T, C.T, G @ Q @ G.T, R)
+    P, E, LT = care(A.T, C.T, G @ Q @ G.T, R, method=method)
     return _ssmatrix(LT.T), _ssmatrix(P), E
 
 
@@ -505,24 +512,12 @@ def lqr(*args, **keywords):
 
     """
 
-    # Figure out what method to use
-    method = keywords.get('method', None)
-    if method == 'slycot' or method is None:
-        # Make sure that SLICOT is installed
-        try:
-            from slycot import sb02md
-            from slycot import sb02mt
-            method = 'slycot'
-        except ImportError:
-            if method == 'slycot':
-                raise ControlSlycot(
-                    "can't find slycot module 'sb02md' or 'sb02nt'")
-            else:
-                method = 'scipy'
-
     #
     # Process the arguments and figure out what inputs we received
     #
+
+    # Get the method to use (if specified as a keyword)
+    method = keywords.get('method', None)
 
     # Get the system description
     if (len(args) < 3):
@@ -546,43 +541,11 @@ def lqr(*args, **keywords):
     if (len(args) > index + 2):
         N = np.array(args[index+2], ndmin=2, dtype=float)
     else:
-        N = np.zeros((Q.shape[0], R.shape[1]))
+        N = None
 
-    # Check dimensions for consistency
-    nstates = B.shape[0]
-    ninputs = B.shape[1]
-    if (A.shape[0] != nstates or A.shape[1] != nstates):
-        raise ControlDimension("inconsistent system dimensions")
-
-    elif (Q.shape[0] != nstates or Q.shape[1] != nstates or
-          R.shape[0] != ninputs or R.shape[1] != ninputs or
-          N.shape[0] != nstates or N.shape[1] != ninputs):
-        raise ControlDimension("incorrect weighting matrix dimensions")
-
-    if method == 'slycot':
-        # Compute the G matrix required by SB02MD
-        A_b, B_b, Q_b, R_b, L_b, ipiv, oufact, G = \
-            sb02mt(nstates, ninputs, B, R, A, Q, N, jobl='N')
-
-        # Call the SLICOT function
-        X, rcond, w, S, U, A_inv = sb02md(nstates, A_b, G, Q_b, 'C')
-
-        # Now compute the return value
-        # We assume that R is positive definite and, hence, invertible
-        K = np.linalg.solve(R, np.dot(B.T, X) + N.T)
-        S = X
-        E = w[0:nstates]
-
-    elif method == 'scipy':
-        import scipy as sp
-        S = sp.linalg.solve_continuous_are(A, B, Q, R, s=N)
-        K = np.linalg.solve(R, B.T @ S + N.T)
-        E, _ = np.linalg.eig(A - B @ K)
-
-    else:
-        raise ValueError("unknown method: %s" % method)
-
-    return _ssmatrix(K), _ssmatrix(S), E
+    # Solve continuous algebraic Riccati equation
+    X, L, G = care(A, B, Q, R, N, None, method=method)
+    return G, X, L
 
 
 def ctrb(A, B):

--- a/control/tests/mateqn_test.py
+++ b/control/tests/mateqn_test.py
@@ -120,7 +120,7 @@ class TestMatrixEquations:
         A = array([[-0.6, 0],[-0.1, -0.4]])
         Q = array([[3, 1],[1, 1]])
         E = array([[1, 1],[2, 1]])
-        X = dlyap(A,Q,None,E)
+        X = dlyap(A, Q, None, E)
         # print("The solution obtained is ", X)
         assert_array_almost_equal(A @ X @ A.T - E @ X @ E.T + Q,
                                   zeros((2,2)))

--- a/control/tests/mateqn_test.py
+++ b/control/tests/mateqn_test.py
@@ -99,7 +99,7 @@ class TestMatrixEquations:
                                   zeros((2,2)))
 
         # Make sure that trying to solve with SciPy generates an error
-        with pytest.raises(ValueError, match="'scipy' not valid"):
+        with pytest.raises(ControlArgument, match="'scipy' not valid"):
             X = lyap(A, Q, None, E, method='scipy')
 
     def test_dlyap(self):
@@ -126,7 +126,7 @@ class TestMatrixEquations:
                                   zeros((2,2)))
 
         # Make sure that trying to solve with SciPy generates an error
-        with pytest.raises(ValueError, match="'scipy' not valid"):
+        with pytest.raises(ControlArgument, match="'scipy' not valid"):
             X = dlyap(A, Q, None, E, method='scipy')
 
     @slycotonly
@@ -146,7 +146,7 @@ class TestMatrixEquations:
         assert_array_almost_equal(A @ X @ B.T - X + C, zeros((2,2)))
 
         # Make sure that trying to solve with SciPy generates an error
-        with pytest.raises(ValueError, match="'scipy' not valid"):
+        with pytest.raises(ControlArgument, match="'scipy' not valid"):
             X = dlyap(A, B, C, method='scipy')
 
     def test_care(self):

--- a/control/tests/mateqn_test.py
+++ b/control/tests/mateqn_test.py
@@ -41,7 +41,7 @@ from scipy.linalg import eigvals, solve
 
 import control as ct
 from control.mateqn import lyap, dlyap, care, dare
-from control.exception import ControlArgument, slycot_check
+from control.exception import ControlArgument, ControlDimension, slycot_check
 from control.tests.conftest import slycotonly
 
 
@@ -334,21 +334,21 @@ class TestMatrixEquations:
         Efq = array([[2, 1, 0], [1, 2, 0]])
 
         for cdlyap in [lyap, dlyap]:
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(Afq, Q)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(A, Qfq)
             with pytest.raises(ControlArgument):
                 cdlyap(A, Qfs)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(Afq, Q, C)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(A, Qfq, C)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(A, Q, Cfd)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(A, Qfq, None, E)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdlyap(A, Q, None, Efq)
             with pytest.raises(ControlArgument):
                 cdlyap(A, Qfs, None, E)
@@ -365,30 +365,30 @@ class TestMatrixEquations:
         E = array([[2, 1], [1, 2]])
         Ef = array([[2, 1], [1, 2], [1, 2]])
 
-        with pytest.raises(ControlArgument):
+        with pytest.raises(ControlDimension):
             care(Afq, B, Q)
-        with pytest.raises(ControlArgument):
+        with pytest.raises(ControlDimension):
             care(A, B, Qfq)
-        with pytest.raises(ControlArgument):
+        with pytest.raises(ControlDimension):
             care(A, Bf, Q)
-        with pytest.raises(ControlArgument):
+        with pytest.raises(ControlDimension):
             care(1, B, 1)
         with pytest.raises(ControlArgument):
             care(A, B, Qfs)
         with pytest.raises(ControlArgument):
             dare(A, B, Q, Rfs)
         for cdare in [care, dare]:
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdare(Afq, B, Q, R, S, E)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdare(A, B, Qfq, R, S, E)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdare(A, Bf, Q, R, S, E)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdare(A, B, Q, R, S, Ef)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdare(A, B, Q, Rfq, S, E)
-            with pytest.raises(ControlArgument):
+            with pytest.raises(ControlDimension):
                 cdare(A, B, Q, R, Sf, E)
             with pytest.raises(ControlArgument):
                 cdare(A, B, Qfs, R, S, E)

--- a/control/tests/matlab_test.py
+++ b/control/tests/matlab_test.py
@@ -507,7 +507,6 @@ class TestMatlab:
         """Call acker()"""
         acker(siso.ss1.A, siso.ss1.B, [-2, -2.5])
 
-    @slycotonly
     def testLQR(self, siso):
         """Call lqr()"""
         (K, S, E) = lqr(siso.ss1.A, siso.ss1.B, np.eye(2), np.eye(1))

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -8,7 +8,8 @@ import pytest
 
 import control as ct
 from control import lqe, pole, rss, ss, tf
-from control.exception import ControlDimension, ControlSlycot, slycot_check
+from control.exception import ControlDimension, ControlSlycot, \
+    ControlArgument, slycot_check
 from control.mateqn import care, dare
 from control.statefbk import ctrb, obsv, place, place_varga, lqr, gram, acker
 from control.tests.conftest import (slycotonly, check_deprecated_matrix,
@@ -324,7 +325,7 @@ class TestStatefbk:
 
     def test_lqr_badmethod(self):
         A, B, Q, R = 0, 1, 10, 2
-        with pytest.raises(ValueError, match="Unknown method"):
+        with pytest.raises(ControlArgument, match="Unknown method"):
             K, S, poles = lqr(A, B, Q, R, method='nosuchmethod')
 
     def test_lqr_slycot_not_installed(self):
@@ -450,7 +451,7 @@ class TestStatefbk:
             X, L, G = care(A, B, Q, R, S, E, stabilizing=False)
             assert np.all(np.real(L) > 0)
         else:
-            with pytest.raises(ValueError, match="'scipy' not valid"):
+            with pytest.raises(ControlArgument, match="'scipy' not valid"):
                 X, L, G = care(A, B, Q, R, S, E, stabilizing=False)
 
     def test_dare(self, matarrayin):
@@ -466,8 +467,8 @@ class TestStatefbk:
         assert np.all(np.abs(L) < 1)
 
         if slycot_check():
-            X, L, G = care(A, B, Q, R, S, E, stabilizing=False)
-            assert np.all(np.real(L) > 0)
+            X, L, G = dare(A, B, Q, R, S, E, stabilizing=False)
+            assert np.all(np.abs(L) > 1)
         else:
-            with pytest.raises(ValueError, match="'scipy' not valid"):
-                X, L, G = care(A, B, Q, R, S, E, stabilizing=False)
+            with pytest.raises(ControlArgument, match="'scipy' not valid"):
+                X, L, G = dare(A, B, Q, R, S, E, stabilizing=False)

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -324,13 +324,13 @@ class TestStatefbk:
 
     def test_lqr_badmethod(self):
         A, B, Q, R = 0, 1, 10, 2
-        with pytest.raises(ValueError, match="unknown"):
+        with pytest.raises(ValueError, match="Unknown method"):
             K, S, poles = lqr(A, B, Q, R, method='nosuchmethod')
 
     def test_lqr_slycot_not_installed(self):
         A, B, Q, R = 0, 1, 10, 2
         if not slycot_check():
-            with pytest.raises(ControlSlycot, match="can't find slycot"):
+            with pytest.raises(ControlSlycot, match="Can't find slycot"):
                 K, S, poles = lqr(A, B, Q, R, method='slycot')
 
     @pytest.mark.xfail(reason="warning not implemented")
@@ -378,11 +378,11 @@ class TestStatefbk:
         np.testing.assert_array_almost_equal(Eref, E)
 
         # Inconsistent system dimensions
-        with pytest.raises(ct.ControlDimension, match="inconsistent system"):
+        with pytest.raises(ct.ControlDimension, match="Incompatible dimen"):
             K, S, E = lqr(sys.A, sys.C, Q, R)
 
         # incorrect covariance matrix dimensions
-        with pytest.raises(ct.ControlDimension, match="incorrect weighting"):
+        with pytest.raises(ct.ControlDimension, match="Q must be a square"):
             K, S, E = lqr(sys.A, sys.B, sys.C, R, Q)
 
     def check_LQE(self, L, P, poles, G, QN, RN):
@@ -420,7 +420,7 @@ class TestStatefbk:
         sys_siso = rss(4, 1, 1)
         L_ss, P_ss, E_ss = lqe(sys_siso, np.eye(1), np.eye(1))
         L_tf, P_tf, E_tf = lqe(tf(sys_siso), np.eye(1), np.eye(1))
-        np.testing.assert_array_almost_equal(E_ss, E_tf)
+        np.testing.assert_array_almost_equal(np.sort(E_ss), np.sort(E_tf))
 
         # Make sure we get an error if we specify N
         with pytest.raises(ct.ControlNotImplemented):


### PR DESCRIPTION
This PR updates the `mateqn` module to allow the use of SciPy linear algebra functions as a replacement for Slycot functions.  Among other things, this allows the use of the `lqr` command without having to install Slycot.

I implemented this by changing all of the `mateqn` functions (`lyap`, `care`, `dare`, etc) to accept at `method` keyword that can either be `scipy` or `slycot`.  The default value for `method` is `slycot` if it is installed, otherwise `scipy`, so there is no change in behavior if you have Slycot. 

Other changes:
* Updated `lqr` to call `care` rather than replicating the code and cleaned up a lot of the code in `mateqn` to be more Pythonic.
* Modified the `slycot_check` function so that it stores the result of checking whether `slycot` can be imported rather than trying to import every time the function is called.
* Implemented a function for checking size and properties of matrices passed to `mateqn` functions (`mateqn._check_shape`) that provides more consistent errors (this also required updating some of the unit tests).
* Modified `dare` to solve the generalized Sylvester equation using `slycot.sg02ad` rather than using `slycot.sg02md` to solve the simplified form of the discrete algebraic Riccati equation because there seems to be an error in the way that `stabilizing` is handled in `sg02md` (it returns the closed loop eigenvalues in the wrong order).  (I'm working on generating a concrete counterexample for posting to Slycot.)