### PR TITLE
Add documentation about use of axis('equal') in pzmap, rlocus

### DIFF
--- a/control/pzmap.py
+++ b/control/pzmap.py
@@ -59,8 +59,7 @@ _pzmap_defaults = {
 #    http://matplotlib.sourceforge.net/examples/axes_grid/demo_axisline_style.html
 #    http://matplotlib.sourceforge.net/examples/axes_grid/demo_curvelinear_grid.html
 def pzmap(sys, plot=None, grid=None, title='Pole Zero Map', **kwargs):
-    """
-    Plot a pole/zero map for a linear system.
+    """Plot a pole/zero map for a linear system.
 
     Parameters
     ----------
@@ -78,6 +77,14 @@ def pzmap(sys, plot=None, grid=None, title='Pole Zero Map', **kwargs):
         The systems poles
     zeros: array
         The system's zeros.
+
+    Notes
+    -----
+    The pzmap function calls matplotlib.pyplot.axis('equal'), which means
+    that trying to reset the axis limits may not behave as expected.  To
+    change the axis limits, use matplotlib.pyplot.gca().axis('auto') and
+    then set the axis limits to the desired values.
+
     """
     # Check to see if legacy 'Plot' keyword was used
     if 'Plot' in kwargs:

--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -114,6 +114,14 @@ def root_locus(sys, kvect=None, xlim=None, ylim=None,
         Computed root locations, given as a 2D array
     klist : ndarray or list
         Gains used.  Same as klist keyword argument if provided.
+
+    Notes
+    -----
+    The root_locus function calls matplotlib.pyplot.axis('equal'), which
+    means that trying to reset the axis limits may not behave as expected.
+    To change the axis limits, use matplotlib.pyplot.gca().axis('auto') and
+    then set the axis limits to the desired values.
+
     """
     # Check to see if legacy 'Plot' keyword was used
     if 'Plot' in kwargs:


### PR DESCRIPTION
This PR partially addresses #340 by adding documentation to describe why calling plt.xlim() doesn't change pzmap plots.  Should be enough for 0.9.1 release.
