### PR TITLE
Change InputOutputSystem repr to show type, name, inputs, and outputs

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -181,7 +181,8 @@ class InputOutputSystem(object):
     nstates = 0
 
     def __repr__(self):
-        return self.name if self.name is not None else str(type(self))
+        return f'<{self.__class__.__name__}:{self.name}:{list(self.input_index)}->{list(self.output_index)}>'
+
 
     def __str__(self):
         """String representation of an input/output system"""


### PR DESCRIPTION
I didn't know about `InputOutputSystem` 's `__str__` implementation, and I find the `__repr__` a bit bare-bones.  With this change:

```ipython
In [8]: import control as ct
   ...: P1 = ct.LinearIOSystem(ct.rss(2,1,1), inputs='u1', outputs='y1')
   ...: P2 = ct.LinearIOSystem(ct.rss(2,1,1), inputs='y1', outputs='y2')
   ...: 

In [9]: display(P1)
   ...: 
<LinearIOSystem:sys[6]:['u1']->['y1']>

In [10]: ct.interconnect([P1, P2], inputs=['u1'], outputs=['y2'])
    ...: 
Out[10]: <LinearICSystem:y2:['u1']->['y2']>

In [11]: display(ct.InputOutputSystem())
    ...: 
<InputOutputSystem:sys[9]:[]->[]>
```

This is a draft for comment - if it looks OK, I'll (eventually) improve it and add tests.  One improvement I can see already: make the input and output lists a little prettier by removing the quotes.