### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
     author='Python Control Developers',
     author_email='python-control-developers@lists.sourceforge.net',
     url='http://python-control.org',
+    project_urls={
+        'Source': 'https://github.com/python-control/python-control',
+    },
     description='Python Control Systems Library',
     long_description=long_description,
     packages=find_packages(exclude=['benchmarks']),


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)