### PR TITLE
I/O system enhancements

### DIFF
--- a/control/frdata.py
+++ b/control/frdata.py
@@ -204,7 +204,7 @@ class FrequencyResponseData(LTI):
                         w=1.0/(absolute(self.fresp[i, j, :]) + 0.001), s=0.0)
         else:
             self.ifunc = None
-        LTI.__init__(self, self.fresp.shape[1], self.fresp.shape[0])
+        super().__init__(self.fresp.shape[1], self.fresp.shape[0])
 
     def __str__(self):
         """String representation of the transfer function."""

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -31,6 +31,7 @@ import scipy as sp
 import copy
 from warnings import warn
 
+from .namedio import _NamedIOStateObject, _process_signal_list
 from .statesp import StateSpace, tf2ss, _convert_to_statespace
 from .statesp import _ss, _rss_generate
 from .xferfcn import TransferFunction
@@ -54,7 +55,7 @@ _iosys_defaults = {
 }
 
 
-class InputOutputSystem(object):
+class InputOutputSystem(_NamedIOStateObject):
     """A class for representing input/output systems.
 
     The InputOutputSystem class allows (possibly nonlinear) input/output
@@ -125,14 +126,6 @@ class InputOutputSystem(object):
     # Allow ndarray * InputOutputSystem to give IOSystem._rmul_() priority
     __array_priority__ = 12     # override ndarray, matrix, SS types
 
-    _idCounter = 0
-
-    def _name_or_default(self, name=None):
-        if name is None:
-            name = "sys[{}]".format(InputOutputSystem._idCounter)
-            InputOutputSystem._idCounter += 1
-        return name
-
     def __init__(self, inputs=None, outputs=None, states=None, params={},
                  name=None, **kwargs):
         """Create an input/output system.
@@ -145,59 +138,19 @@ class InputOutputSystem(object):
         :class:`~control.InterconnectedSystem`.
 
         """
-        # Store the input arguments
+        # Store the system name, inputs, outputs, and states
+        _NamedIOStateObject.__init__(
+            self, inputs=inputs, outputs=outputs, states=states, name=name)
 
         # default parameters
         self.params = params.copy()
+
         # timebase
-        self.dt = kwargs.get('dt', config.defaults['control.default_dt'])
-        # system name
-        self.name = self._name_or_default(name)
+        self.dt = kwargs.pop('dt', config.defaults['control.default_dt'])
 
-        # Parse and store the number of inputs, outputs, and states
-        self.set_inputs(inputs)
-        self.set_outputs(outputs)
-        self.set_states(states)
-
-    #
-    # Class attributes
-    #
-    # These attributes are defined as class attributes so that they are
-    # documented properly.  They are "overwritten" in __init__.
-    #
-
-    #: Number of system inputs.
-    #:
-    #: :meta hide-value:
-    ninputs = 0
-
-    #: Number of system outputs.
-    #:
-    #: :meta hide-value:
-    noutputs = 0
-
-    #: Number of system states.
-    #:
-    #: :meta hide-value:
-    nstates = 0
-
-    def __repr__(self):
-        return str(type(self)) + ": " + self.name if self.name is not None \
-            else str(type(self))
-
-    def __str__(self):
-        """String representation of an input/output system"""
-        str = "System: " + (self.name if self.name else "(None)") + "\n"
-        str += "Inputs (%s): " % self.ninputs
-        for key in self.input_index:
-            str += key + ", "
-        str += "\nOutputs (%s): " % self.noutputs
-        for key in self.output_index:
-            str += key + ", "
-        str += "\nStates (%s): " % self.nstates
-        for key in self.state_index:
-            str += key + ", "
-        return str
+        # Make sure there were no extraneous keyworks
+        if kwargs:
+            raise TypeError("unrecognized keywords: ", str(kwargs))
 
     def __mul__(sys2, sys1):
         """Multiply two input/output systems (series interconnection)"""
@@ -395,34 +348,6 @@ class InputOutputSystem(object):
         # Return the newly created system
         return newsys
 
-    def _isstatic(self):
-        """Check to see if a system is a static system (no states)"""
-        return self.nstates == 0
-
-    # Utility function to parse a list of signals
-    def _process_signal_list(self, signals, prefix='s'):
-        if signals is None:
-            # No information provided; try and make it up later
-            return None, {}
-
-        elif isinstance(signals, int):
-            # Number of signals given; make up the names
-            return signals, {'%s[%d]' % (prefix, i): i for i in range(signals)}
-
-        elif isinstance(signals, str):
-            # Single string given => single signal with given name
-            return 1, {signals: 0}
-
-        elif all(isinstance(s, str) for s in signals):
-            # Use the list of strings as the signal names
-            return len(signals), {signals[i]: i for i in range(len(signals))}
-
-        else:
-            raise TypeError("Can't parse signal list %s" % str(signals))
-
-    # Find a signal by name
-    def _find_signal(self, name, sigdict): return sigdict.get(name, None)
-
     # Update parameters used for _rhs, _out (used by subclasses)
     def _update_params(self, params, warning=False):
         if warning:
@@ -509,82 +434,6 @@ class InputOutputSystem(object):
         y : ndarray
         """
         return self._out(t, x, u)
-
-    def set_inputs(self, inputs, prefix='u'):
-        """Set the number/names of the system inputs.
-
-        Parameters
-        ----------
-        inputs : int, list of str, or None
-            Description of the system inputs.  This can be given as an integer
-            count or as a list of strings that name the individual signals.
-            If an integer count is specified, the names of the signal will be
-            of the form `u[i]` (where the prefix `u` can be changed using the
-            optional prefix parameter).
-        prefix : string, optional
-            If `inputs` is an integer, create the names of the states using
-            the given prefix (default = 'u').  The names of the input will be
-            of the form `prefix[i]`.
-
-        """
-        self.ninputs, self.input_index = \
-            self._process_signal_list(inputs, prefix=prefix)
-
-    def set_outputs(self, outputs, prefix='y'):
-        """Set the number/names of the system outputs.
-
-        Parameters
-        ----------
-        outputs : int, list of str, or None
-            Description of the system outputs.  This can be given as an integer
-            count or as a list of strings that name the individual signals.
-            If an integer count is specified, the names of the signal will be
-            of the form `u[i]` (where the prefix `u` can be changed using the
-            optional prefix parameter).
-        prefix : string, optional
-            If `outputs` is an integer, create the names of the states using
-            the given prefix (default = 'y').  The names of the input will be
-            of the form `prefix[i]`.
-
-        """
-        self.noutputs, self.output_index = \
-            self._process_signal_list(outputs, prefix=prefix)
-
-    def set_states(self, states, prefix='x'):
-        """Set the number/names of the system states.
-
-        Parameters
-        ----------
-        states : int, list of str, or None
-            Description of the system states.  This can be given as an integer
-            count or as a list of strings that name the individual signals.
-            If an integer count is specified, the names of the signal will be
-            of the form `u[i]` (where the prefix `u` can be changed using the
-            optional prefix parameter).
-        prefix : string, optional
-            If `states` is an integer, create the names of the states using
-            the given prefix (default = 'x').  The names of the input will be
-            of the form `prefix[i]`.
-
-        """
-        self.nstates, self.state_index = \
-            self._process_signal_list(states, prefix=prefix)
-
-    def find_input(self, name):
-        """Find the index for an input given its name (`None` if not found)"""
-        return self.input_index.get(name, None)
-
-    def find_output(self, name):
-        """Find the index for an output given its name (`None` if not found)"""
-        return self.output_index.get(name, None)
-
-    def find_state(self, name):
-        """Find the index for a state given its name (`None` if not found)"""
-        return self.state_index.get(name, None)
-
-    def issiso(self):
-        """Check to see if a system is single input, single output"""
-        return self.ninputs == 1 and self.noutputs == 1
 
     def feedback(self, other=1, sign=-1, params={}):
         """Feedback interconnection between two input/output systems
@@ -801,6 +650,7 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
                             "or transfer function object")
 
         # Look for 'input' and 'output' parameter name variants
+        states = _parse_signal_parameter(states, 'state', kwargs)
         inputs = _parse_signal_parameter(inputs, 'input', kwargs)
         outputs = _parse_signal_parameter(outputs, 'output', kwargs, end=True)
 
@@ -814,15 +664,15 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
 
         # Process input, output, state lists, if given
         # Make sure they match the size of the linear system
-        ninputs, self.input_index = self._process_signal_list(
+        ninputs, self.input_index = _process_signal_list(
             inputs if inputs is not None else linsys.ninputs, prefix='u')
         if ninputs is not None and linsys.ninputs != ninputs:
             raise ValueError("Wrong number/type of inputs given.")
-        noutputs, self.output_index = self._process_signal_list(
+        noutputs, self.output_index = _process_signal_list(
             outputs if outputs is not None else linsys.noutputs, prefix='y')
         if noutputs is not None and linsys.noutputs != noutputs:
             raise ValueError("Wrong number/type of outputs given.")
-        nstates, self.state_index = self._process_signal_list(
+        nstates, self.state_index = _process_signal_list(
             states if states is not None else linsys.nstates, prefix='x')
         if nstates is not None and linsys.nstates != nstates:
             raise ValueError("Wrong number/type of states given.")
@@ -1110,12 +960,12 @@ class InterconnectedSystem(InputOutputSystem):
         # If input or output list was specified, update it
         if inputs is not None:
             nsignals, self.input_index = \
-                self._process_signal_list(inputs, prefix='u')
+                _process_signal_list(inputs, prefix='u')
             if nsignals is not None and len(inplist) != nsignals:
                 raise ValueError("Wrong number/type of inputs given.")
         if outputs is not None:
             nsignals, self.output_index = \
-                self._process_signal_list(outputs, prefix='y')
+                _process_signal_list(outputs, prefix='y')
             if nsignals is not None and len(outlist) != nsignals:
                 raise ValueError("Wrong number/type of outputs given.")
 
@@ -2269,11 +2119,89 @@ def _find_size(sysval, vecval):
 
 # Define a state space object that is an I/O system
 def ss(*args, **kwargs):
-    return LinearIOSystem(_ss(*args, **kwargs))
-ss.__doc__ = _ss.__doc__
+    """ss(A, B, C, D[, dt])
+
+    Create a state space system.
+
+    The function accepts either 1, 4 or 5 parameters:
+
+    ``ss(sys)``
+        Convert a linear system into space system form. Always creates a
+        new system, even if sys is already a state space system.
+
+    ``ss(A, B, C, D)``
+        Create a state space system from the matrices of its state and
+        output equations:
+
+        .. math::
+            \\dot x = A \\cdot x + B \\cdot u
+
+            y = C \\cdot x + D \\cdot u
+
+    ``ss(A, B, C, D, dt)``
+        Create a discrete-time state space system from the matrices of
+        its state and output equations:
+
+        .. math::
+            x[k+1] = A \\cdot x[k] + B \\cdot u[k]
+
+            y[k] = C \\cdot x[k] + D \\cdot u[ki]
+
+        The matrices can be given as *array like* data types or strings.
+        Everything that the constructor of :class:`numpy.matrix` accepts is
+        permissible here too.
+
+    Parameters
+    ----------
+    sys : StateSpace or TransferFunction
+        A linear system.
+    A, B, C, D : array_like or string
+        System, control, output, and feed forward matrices.
+    dt : None, True or float, optional
+        System timebase. 0 (default) indicates continuous
+        time, True indicates discrete time with unspecified sampling
+        time, positive number is discrete time with specified
+        sampling time, None indicates unspecified timebase (either
+        continuous or discrete time).
+    inputs, outputs, states : str, or list of str, optional
+        List of strings that name the individual signals.  If this parameter
+        is not given or given as `None`, the signal names will be of the
+        form `s[i]` (where `s` is one of `u`, `y`, or `x`).
+    name : string, optional
+        System name (used for specifying signals). If unspecified, a generic
+        name <sys[id]> is generated with a unique integer id.
+
+    Returns
+    -------
+    out: :class:`LinearIOSystem`
+        Linear input/output system.
+
+    Raises
+    ------
+    ValueError
+        If matrix sizes are not self-consistent.
+
+    See Also
+    --------
+    tf
+    ss2tf
+    tf2ss
+
+    Examples
+    --------
+    >>> # Create a Linear I/O system object from from for matrices
+    >>> sys1 = ss([[1, -2], [3 -4]], [[5], [7]], [[6, 8]], [[9]])
+
+    >>> # Convert a TransferFunction to a StateSpace object.
+    >>> sys_tf = tf([2.], [1., 3])
+    >>> sys2 = ss(sys_tf)
+
+    """
+    sys = _ss(*args, keywords=kwargs)
+    return LinearIOSystem(sys, **kwargs)
 
 
-def rss(states=1, outputs=1, inputs=1, strictly_proper=False):
+def rss(states=1, outputs=1, inputs=1, strictly_proper=False, **kwargs):
     """
     Create a stable *continuous* random state space object.
 
@@ -2309,12 +2237,18 @@ def rss(states=1, outputs=1, inputs=1, strictly_proper=False):
     will always have a negative real part.
 
     """
+    # Process states, inputs, outputs (ignoring names)
+    nstates, _ = _process_signal_list(states)
+    ninputs, _ = _process_signal_list(inputs)
+    noutputs, _ = _process_signal_list(outputs)
 
-    return LinearIOSystem(_rss_generate(
-        states, inputs, outputs, 'c', strictly_proper=strictly_proper))
+    sys = _rss_generate(
+        nstates, ninputs, noutputs, 'c', strictly_proper=strictly_proper)
+    return LinearIOSystem(
+        sys, states=states, inputs=inputs, outputs=outputs, **kwargs)
 
 
-def drss(states=1, outputs=1, inputs=1, strictly_proper=False):
+def drss(states=1, outputs=1, inputs=1, strictly_proper=False, **kwargs):
     """
     Create a stable *discrete* random state space object.
 
@@ -2350,9 +2284,15 @@ def drss(states=1, outputs=1, inputs=1, strictly_proper=False):
     will always have a magnitude less than 1.
 
     """
+    # Process states, inputs, outputs (ignoring names)
+    nstates, _ = _process_signal_list(states)
+    ninputs, _ = _process_signal_list(inputs)
+    noutputs, _ = _process_signal_list(outputs)
 
-    return LinearIOSystem(_rss_generate(
-        states, inputs, outputs, 'd', strictly_proper=strictly_proper))
+    sys = _rss_generate(
+        nstates, ninputs, noutputs, 'd', strictly_proper=strictly_proper)
+    return LinearIOSystem(
+        sys, states=states, inputs=inputs, outputs=outputs, **kwargs)
 
 
 # Convert a state space system into an input/output system (wrapper)

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -31,7 +31,7 @@ import scipy as sp
 import copy
 from warnings import warn
 
-from .namedio import _NamedIOStateObject, _process_signal_list
+from .namedio import _NamedIOStateSystem, _process_signal_list
 from .statesp import StateSpace, tf2ss, _convert_to_statespace
 from .statesp import _ss, _rss_generate
 from .xferfcn import TransferFunction
@@ -55,7 +55,7 @@ _iosys_defaults = {
 }
 
 
-class InputOutputSystem(_NamedIOStateObject):
+class InputOutputSystem(_NamedIOStateSystem):
     """A class for representing input/output systems.
 
     The InputOutputSystem class allows (possibly nonlinear) input/output
@@ -139,7 +139,7 @@ class InputOutputSystem(_NamedIOStateObject):
 
         """
         # Store the system name, inputs, outputs, and states
-        _NamedIOStateObject.__init__(
+        _NamedIOStateSystem.__init__(
             self, inputs=inputs, outputs=outputs, states=states, name=name)
 
         # default parameters
@@ -886,7 +886,7 @@ class InterconnectedSystem(InputOutputSystem):
 
         # Look for 'input' and 'output' parameter name variants
         inputs = _parse_signal_parameter(inputs, 'input', kwargs)
-        outputs =  _parse_signal_parameter(outputs, 'output', kwargs, end=True)
+        outputs = _parse_signal_parameter(outputs, 'output', kwargs, end=True)
 
         # Convert input and output names to lists if they aren't already
         if not isinstance(inplist, (list, tuple)):
@@ -2526,9 +2526,8 @@ def interconnect(syslist, connections=None, inplist=[], outlist=[],
         raise ValueError('check_unused is False, but either '
                          + 'ignore_inputs or ignore_outputs non-empty')
 
-    if (connections is False
-        and not inplist and not outlist
-        and not inputs and not outputs):
+    if connections is False and not inplist and not outlist \
+       and not inputs and not outputs:
         # user has disabled auto-connect, and supplied neither input
         # nor output mappings; assume they know what they're doing
         check_unused = False

--- a/control/lti.py
+++ b/control/lti.py
@@ -16,13 +16,12 @@ import numpy as np
 from numpy import absolute, real, angle, abs
 from warnings import warn
 from . import config
-from .namedio import _NamedIOObject
 
 __all__ = ['issiso', 'timebase', 'common_timebase', 'timebaseEqual',
            'isdtime', 'isctime', 'pole', 'zero', 'damp', 'evalfr',
            'freqresp', 'dcgain']
 
-class LTI(_NamedIOObject):
+class LTI:
     """LTI is a parent class to linear time-invariant (LTI) system objects.
 
     LTI is the parent to the StateSpace and TransferFunction child classes. It

--- a/control/lti.py
+++ b/control/lti.py
@@ -16,12 +16,13 @@ import numpy as np
 from numpy import absolute, real, angle, abs
 from warnings import warn
 from . import config
+from .namedio import _NamedIOObject
 
 __all__ = ['issiso', 'timebase', 'common_timebase', 'timebaseEqual',
            'isdtime', 'isctime', 'pole', 'zero', 'damp', 'evalfr',
            'freqresp', 'dcgain']
 
-class LTI:
+class LTI(_NamedIOObject):
     """LTI is a parent class to linear time-invariant (LTI) system objects.
 
     LTI is the parent to the StateSpace and TransferFunction child classes. It

--- a/control/matlab/__init__.py
+++ b/control/matlab/__init__.py
@@ -62,6 +62,7 @@ if not ('.config' in sys.modules):
 
 # Control system library
 from ..statesp import *
+from ..iosys import ss, rss, drss       # moved from .statesp
 from ..xferfcn import *
 from ..lti import *
 from ..frdata import *

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -3,7 +3,7 @@ Wrappers for the MATLAB compatibility module
 """
 
 import numpy as np
-from ..statesp import ss
+from ..iosys import ss
 from ..xferfcn import tf
 from ..ctrlutil import issys
 from ..exception import ControlArgument

--- a/control/namedio.py
+++ b/control/namedio.py
@@ -1,0 +1,212 @@
+# namedio.py - internal named I/O object class
+# RMM, 13 Mar 2022
+#
+# This file implements the _NamedIOObject and _NamedIOStateObject classes,
+# which are used as a parent classes for FrequencyResponseData,
+# InputOutputSystem, LTI, TimeResponseData, and other similar classes to
+# allow naming of signals.
+
+import numpy as np
+
+class _NamedIOObject(object):
+    _idCounter = 0
+
+    def _name_or_default(self, name=None):
+        if name is None:
+            name = "sys[{}]".format(_NamedIOObject._idCounter)
+            _NamedIOObject._idCounter += 1
+        return name
+
+    def __init__(
+            self, inputs=None, outputs=None, name=None):
+
+        # system name
+        self.name = self._name_or_default(name)
+
+        # Parse and store the number of inputs and outputs
+        self.set_inputs(inputs)
+        self.set_outputs(outputs)
+
+    #
+    # Class attributes
+    #
+    # These attributes are defined as class attributes so that they are
+    # documented properly.  They are "overwritten" in __init__.
+    #
+
+    #: Number of system inputs.
+    #:
+    #: :meta hide-value:
+    ninputs = 0
+    
+    #: Number of system outputs.
+    #:
+    #: :meta hide-value:
+    noutputs = 0
+
+    def __repr__(self):
+        return str(type(self)) + ": " + self.name if self.name is not None \
+            else str(type(self))
+
+    def __str__(self):
+        """String representation of an input/output object"""
+        str = "Object: " + (self.name if self.name else "(None)") + "\n"
+        str += "Inputs (%s): " % self.ninputs
+        for key in self.input_index:
+            str += key + ", "
+        str += "\nOutputs (%s): " % self.noutputs
+        for key in self.output_index:
+            str += key + ", "
+        return str
+
+    # Find a signal by name
+    def _find_signal(self, name, sigdict):
+        return sigdict.get(name, None)
+
+    def set_inputs(self, inputs, prefix='u'):
+        """Set the number/names of the system inputs.
+
+        Parameters
+        ----------
+        inputs : int, list of str, or None
+            Description of the system inputs.  This can be given as an integer
+            count or as a list of strings that name the individual signals.
+            If an integer count is specified, the names of the signal will be
+            of the form `u[i]` (where the prefix `u` can be changed using the
+            optional prefix parameter).
+        prefix : string, optional
+            If `inputs` is an integer, create the names of the states using
+            the given prefix (default = 'u').  The names of the input will be
+            of the form `prefix[i]`.
+
+        """
+        self.ninputs, self.input_index = \
+            _process_signal_list(inputs, prefix=prefix)
+
+    def find_input(self, name):
+        """Find the index for an input given its name (`None` if not found)"""
+        return self.input_index.get(name, None)
+
+    # Property for getting and setting list of input signals
+    input_list = property(
+        lambda self: list(self.input_index.keys()),     # getter
+        set_inputs)                                     # setter
+
+    def set_outputs(self, outputs, prefix='y'):
+        """Set the number/names of the system outputs.
+
+        Parameters
+        ----------
+        outputs : int, list of str, or None
+            Description of the system outputs.  This can be given as an integer
+            count or as a list of strings that name the individual signals.
+            If an integer count is specified, the names of the signal will be
+            of the form `u[i]` (where the prefix `u` can be changed using the
+            optional prefix parameter).
+        prefix : string, optional
+            If `outputs` is an integer, create the names of the states using
+            the given prefix (default = 'y').  The names of the input will be
+            of the form `prefix[i]`.
+
+        """
+        self.noutputs, self.output_index = \
+            _process_signal_list(outputs, prefix=prefix)
+
+    def find_output(self, name):
+        """Find the index for an output given its name (`None` if not found)"""
+        return self.output_index.get(name, None)
+
+    # Property for getting and setting list of output signals
+    output_list = property(
+        lambda self: list(self.output_index.keys()),     # getter
+        set_outputs)                                     # setter
+
+    def issiso(self):
+        """Check to see if a system is single input, single output"""
+        return self.ninputs == 1 and self.noutputs == 1
+
+        
+class _NamedIOStateObject(_NamedIOObject):
+    def __init__(
+            self, inputs=None, outputs=None, states=None, name=None):
+        # Parse and store the system name, inputs, and outputs
+        _NamedIOObject.__init__(
+            self, inputs=inputs, outputs=outputs, name=name)
+        
+        # Parse and store the number of states
+        self.set_states(states)
+
+        
+    #
+    # Class attributes
+    #
+    # These attributes are defined as class attributes so that they are
+    # documented properly.  They are "overwritten" in __init__.
+    #
+
+    #: Number of system states.
+    #:
+    #: :meta hide-value:
+    nstates = 0
+
+    def __str__(self):
+        """String representation of an input/output system"""
+        str = _NamedIOObject.__str__(self)
+        str += "\nStates (%s): " % self.nstates
+        for key in self.state_index:
+            str += key + ", "
+        return str
+        
+    def _isstatic(self):
+        """Check to see if a system is a static system (no states)"""
+        return self.nstates == 0
+
+    def set_states(self, states, prefix='x'):
+        """Set the number/names of the system states.
+
+        Parameters
+        ----------
+        states : int, list of str, or None
+            Description of the system states.  This can be given as an integer
+            count or as a list of strings that name the individual signals.
+            If an integer count is specified, the names of the signal will be
+            of the form `u[i]` (where the prefix `u` can be changed using the
+            optional prefix parameter).
+        prefix : string, optional
+            If `states` is an integer, create the names of the states using
+            the given prefix (default = 'x').  The names of the input will be
+            of the form `prefix[i]`.
+
+        """
+        self.nstates, self.state_index = \
+            _process_signal_list(states, prefix=prefix)
+
+    def find_state(self, name):
+        """Find the index for a state given its name (`None` if not found)"""
+        return self.state_index.get(name, None)
+
+    # Property for getting and setting list of state signals
+    state_list = property(
+        lambda self: list(self.state_index.keys()),     # getter
+        set_states)                                     # setter
+
+# Utility function to parse a list of signals
+def _process_signal_list(signals, prefix='s'):
+    if signals is None:
+        # No information provided; try and make it up later
+        return None, {}
+
+    elif isinstance(signals, (int, np.integer)):
+        # Number of signals given; make up the names
+        return signals, {'%s[%d]' % (prefix, i): i for i in range(signals)}
+
+    elif isinstance(signals, str):
+        # Single string given => single signal with given name
+        return 1, {signals: 0}
+
+    elif all(isinstance(s, str) for s in signals):
+        # Use the list of strings as the signal names
+        return len(signals), {signals[i]: i for i in range(len(signals))}
+
+    else:
+        raise TypeError("Can't parse signal list %s" % str(signals))

--- a/control/namedio.py
+++ b/control/namedio.py
@@ -1,20 +1,21 @@
 # namedio.py - internal named I/O object class
 # RMM, 13 Mar 2022
 #
-# This file implements the _NamedIOObject and _NamedIOStateObject classes,
+# This file implements the _NamedIOSystem and _NamedIOStateSystem classes,
 # which are used as a parent classes for FrequencyResponseData,
 # InputOutputSystem, LTI, TimeResponseData, and other similar classes to
 # allow naming of signals.
 
 import numpy as np
 
-class _NamedIOObject(object):
+
+class _NamedIOSystem(object):
     _idCounter = 0
 
     def _name_or_default(self, name=None):
         if name is None:
-            name = "sys[{}]".format(_NamedIOObject._idCounter)
-            _NamedIOObject._idCounter += 1
+            name = "sys[{}]".format(_NamedIOSystem._idCounter)
+            _NamedIOSystem._idCounter += 1
         return name
 
     def __init__(
@@ -38,7 +39,7 @@ class _NamedIOObject(object):
     #:
     #: :meta hide-value:
     ninputs = 0
-    
+
     #: Number of system outputs.
     #:
     #: :meta hide-value:
@@ -88,7 +89,7 @@ class _NamedIOObject(object):
         return self.input_index.get(name, None)
 
     # Property for getting and setting list of input signals
-    input_list = property(
+    input_labels = property(
         lambda self: list(self.input_index.keys()),     # getter
         set_inputs)                                     # setter
 
@@ -117,7 +118,7 @@ class _NamedIOObject(object):
         return self.output_index.get(name, None)
 
     # Property for getting and setting list of output signals
-    output_list = property(
+    output_labels = property(
         lambda self: list(self.output_index.keys()),     # getter
         set_outputs)                                     # setter
 
@@ -125,18 +126,17 @@ class _NamedIOObject(object):
         """Check to see if a system is single input, single output"""
         return self.ninputs == 1 and self.noutputs == 1
 
-        
-class _NamedIOStateObject(_NamedIOObject):
+
+class _NamedIOStateSystem(_NamedIOSystem):
     def __init__(
             self, inputs=None, outputs=None, states=None, name=None):
         # Parse and store the system name, inputs, and outputs
-        _NamedIOObject.__init__(
+        _NamedIOSystem.__init__(
             self, inputs=inputs, outputs=outputs, name=name)
-        
+
         # Parse and store the number of states
         self.set_states(states)
 
-        
     #
     # Class attributes
     #
@@ -151,12 +151,12 @@ class _NamedIOStateObject(_NamedIOObject):
 
     def __str__(self):
         """String representation of an input/output system"""
-        str = _NamedIOObject.__str__(self)
+        str = _NamedIOSystem.__str__(self)
         str += "\nStates (%s): " % self.nstates
         for key in self.state_index:
             str += key + ", "
         return str
-        
+
     def _isstatic(self):
         """Check to see if a system is a static system (no states)"""
         return self.nstates == 0
@@ -186,9 +186,10 @@ class _NamedIOStateObject(_NamedIOObject):
         return self.state_index.get(name, None)
 
     # Property for getting and setting list of state signals
-    state_list = property(
+    state_labels = property(
         lambda self: list(self.state_index.keys()),     # getter
         set_states)                                     # setter
+
 
 # Utility function to parse a list of signals
 def _process_signal_list(signals, prefix='s'):

--- a/control/namedio.py
+++ b/control/namedio.py
@@ -131,8 +131,7 @@ class _NamedIOStateSystem(_NamedIOSystem):
     def __init__(
             self, inputs=None, outputs=None, states=None, name=None):
         # Parse and store the system name, inputs, and outputs
-        _NamedIOSystem.__init__(
-            self, inputs=inputs, outputs=outputs, name=name)
+        super().__init__(inputs=inputs, outputs=outputs, name=name)
 
         # Parse and store the number of states
         self.set_states(states)

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -5,7 +5,7 @@ from .freqplot import bode_plot
 from .timeresp import step_response
 from .lti import issiso, isdtime
 from .xferfcn import tf
-from .statesp import ss
+from .iosys import ss
 from .bdalg import append, connect
 from .iosys import tf2io, ss2io, summing_junction, interconnect
 from control.statesp import _convert_to_statespace, StateSpace

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -608,6 +608,13 @@ def lqr(*args, **kwargs):
         State and input weight matrices
     N : 2D array, optional
         Cross weight matrix
+    integral_action : ndarray, optional
+        If this keyword is specified, the controller includes integral action
+        in addition to state feedback.  The value of the `integral_action``
+        keyword should be an ndarray that will be multiplied by the current to
+        generate the error for the internal integrator states of the control
+        law.  The number of outputs that are to be integrated must match the
+        number of additional rows and columns in the ``Q`` matrix.
     method : str, optional
         Set the method used for computing the result.  Current methods are
         'slycot' and 'scipy'.  If set to None (default), try 'slycot' first
@@ -750,6 +757,17 @@ def dlqr(*args, **kwargs):
         State and input weight matrices
     N : 2D array, optional
         Cross weight matrix
+    integral_action : ndarray, optional
+        If this keyword is specified, the controller includes integral action
+        in addition to state feedback.  The value of the `integral_action``
+        keyword should be an ndarray that will be multiplied by the current to
+        generate the error for the internal integrator states of the control
+        law.  The number of outputs that are to be integrated must match the
+        number of additional rows and columns in the ``Q`` matrix.
+    method : str, optional
+        Set the method used for computing the result.  Current methods are
+        'slycot' and 'scipy'.  If set to None (default), try 'slycot' first
+        and then 'scipy'.
 
     Returns
     -------

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -698,7 +698,7 @@ def lqr(*args, **kwargs):
             raise ControlArgument("Integral action must pass an array")
         elif integral_action.shape[1] != nstates:
             raise ControlArgument(
-                "Integral gain output size must match system input size")
+                "Integral gain size must match system state size")
 
         # Process the states to be integrated
         nintegrators = integral_action.shape[0]
@@ -829,7 +829,7 @@ def dlqr(*args, **kwargs):
             raise ControlArgument("Integral action must pass an array")
         elif integral_action.shape[1] != nstates:
             raise ControlArgument(
-                "Integral gain output size must match system input size")
+                "Integral gain size must match system state size")
         else:
             nintegrators = integral_action.shape[0]
             C = integral_action
@@ -951,7 +951,7 @@ def create_statefbk_iosystem(
             raise ControlArgument("Integral action must pass an array")
         elif integral_action.shape[1] != sys.nstates:
             raise ControlArgument(
-                "Integral gain output size must match system input size")
+                "Integral gain size must match system state size")
         else:
             nintegrators = integral_action.shape[0]
             C = integral_action

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -59,7 +59,7 @@ from scipy.signal import cont2discrete
 from scipy.signal import StateSpace as signalStateSpace
 from warnings import warn
 from .lti import LTI, common_timebase, isdtime, _process_frequency_response
-from .namedio import _NamedIOStateObject, _process_signal_list
+from .namedio import _NamedIOStateSystem, _process_signal_list
 from . import config
 from copy import deepcopy
 
@@ -153,7 +153,7 @@ def _f2s(f):
     return s
 
 
-class StateSpace(LTI, _NamedIOStateObject):
+class StateSpace(LTI, _NamedIOStateSystem):
     """StateSpace(A, B, C, D[, dt])
 
     A class for representing state-space models.

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -309,8 +309,7 @@ class StateSpace(LTI, _NamedIOStateSystem):
             D = np.zeros((C.shape[0], B.shape[1]))
         D = _ssmatrix(D)
 
-        # TODO: use super here?
-        LTI.__init__(self, inputs=D.shape[1], outputs=D.shape[0])
+        super().__init__(inputs=D.shape[1], outputs=D.shape[0])
         self.A = A
         self.B = B
         self.C = C

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -62,8 +62,7 @@ from .lti import LTI, common_timebase, isdtime, _process_frequency_response
 from . import config
 from copy import deepcopy
 
-__all__ = ['StateSpace', 'ss', 'rss', 'drss', 'tf2ss', 'ssdata']
-
+__all__ = ['StateSpace', 'tf2ss', 'ssdata']
 
 # Define module default parameter values
 _statesp_defaults = {
@@ -1768,7 +1767,7 @@ def _mimo2simo(sys, input, warn_conversion=False):
     return sys
 
 
-def ss(*args, **kwargs):
+def _ss(*args, **kwargs):
     """ss(A, B, C, D[, dt])
 
     Create a state space system.
@@ -1930,89 +1929,6 @@ def tf2ss(*args):
         return _convert_to_statespace(sys)
     else:
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
-
-
-def rss(states=1, outputs=1, inputs=1, strictly_proper=False):
-    """
-    Create a stable *continuous* random state space object.
-
-    Parameters
-    ----------
-    states : int
-        Number of state variables
-    outputs : int
-        Number of system outputs
-    inputs : int
-        Number of system inputs
-    strictly_proper : bool, optional
-        If set to 'True', returns a proper system (no direct term).
-
-    Returns
-    -------
-    sys : StateSpace
-        The randomly created linear system
-
-    Raises
-    ------
-    ValueError
-        if any input is not a positive integer
-
-    See Also
-    --------
-    drss
-
-    Notes
-    -----
-    If the number of states, inputs, or outputs is not specified, then the
-    missing numbers are assumed to be 1.  The poles of the returned system
-    will always have a negative real part.
-
-    """
-
-    return _rss_generate(states, inputs, outputs, 'c',
-                         strictly_proper=strictly_proper)
-
-
-def drss(states=1, outputs=1, inputs=1, strictly_proper=False):
-    """
-    Create a stable *discrete* random state space object.
-
-    Parameters
-    ----------
-    states : int
-        Number of state variables
-    inputs : integer
-        Number of system inputs
-    outputs : int
-        Number of system outputs
-    strictly_proper: bool, optional
-        If set to 'True', returns a proper system (no direct term).
-
-
-    Returns
-    -------
-    sys : StateSpace
-        The randomly created linear system
-
-    Raises
-    ------
-    ValueError
-        if any input is not a positive integer
-
-    See Also
-    --------
-    rss
-
-    Notes
-    -----
-    If the number of states, inputs, or outputs is not specified, then the
-    missing numbers are assumed to be 1.  The poles of the returned system
-    will always have a magnitude less than 1.
-
-    """
-
-    return _rss_generate(states, inputs, outputs, 'd',
-                         strictly_proper=strictly_proper)
 
 
 def ssdata(sys):

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1016,7 +1016,7 @@ class TestIOSys:
 
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
         ct.config.use_numpy_matrix(False)       # np.matrix deprecated
-        ct.namedio._NamedIOObject._idCounter = 0
+        ct.namedio._NamedIOSystem._idCounter = 0
         sys = ct.LinearIOSystem(tsys.mimo_linsys1)
 
         assert sys.name == "sys[0]"
@@ -1080,7 +1080,7 @@ class TestIOSys:
 
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
         ct.config.use_numpy_matrix(False)       # np.matrix deprecated
-        ct.namedio._NamedIOObject._idCounter = 0
+        ct.namedio._NamedIOSystem._idCounter = 0
         sys = ct.LinearIOSystem(tsys.mimo_linsys1)
         for statename in ["x[0]", "x[1]"]:
             assert statename in sys.state_index

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1016,7 +1016,7 @@ class TestIOSys:
 
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
         ct.config.use_numpy_matrix(False)       # np.matrix deprecated
-        ct.InputOutputSystem._idCounter = 0
+        ct.namedio._NamedIOObject._idCounter = 0
         sys = ct.LinearIOSystem(tsys.mimo_linsys1)
 
         assert sys.name == "sys[0]"
@@ -1080,7 +1080,7 @@ class TestIOSys:
 
         ct.config.use_legacy_defaults('0.8.4')  # changed delims in 0.9.0
         ct.config.use_numpy_matrix(False)       # np.matrix deprecated
-        ct.InputOutputSystem._idCounter = 0
+        ct.namedio._NamedIOObject._idCounter = 0
         sys = ct.LinearIOSystem(tsys.mimo_linsys1)
         for statename in ["x[0]", "x[1]"]:
             assert statename in sys.state_index

--- a/control/tests/namedio_test.py
+++ b/control/tests/namedio_test.py
@@ -1,0 +1,51 @@
+"""namedio_test.py - test named input/output object operations
+
+RMM, 13 Mar 2022
+
+This test suite checks to make sure that named input/output class
+operations are working.  It doesn't do exhaustive testing of
+operations on input/output objects.  Separate unit tests should be
+created for that purpose.
+"""
+
+import re
+
+import numpy as np
+import control as ct
+import pytest
+
+def test_named_ss():
+    # Create a system to play with
+    sys = ct.rss(2, 2, 2)
+    assert sys.input_list == ['u[0]', 'u[1]']
+    assert sys.output_list == ['y[0]', 'y[1]']
+    assert sys.state_list == ['x[0]', 'x[1]']
+
+    # Get the state matrices for later use
+    A, B, C, D = sys.A, sys.B, sys.C, sys.D
+    
+    # Set up a named state space systems with default names
+    ct.namedio._NamedIOObject._idCounter = 0
+    sys = ct.ss(A, B, C, D)
+    assert sys.name == 'sys[0]'
+    assert sys.input_list == ['u[0]', 'u[1]']
+    assert sys.output_list == ['y[0]', 'y[1]']
+    assert sys.state_list == ['x[0]', 'x[1]']
+
+    # Pass the names as arguments
+    sys = ct.ss(
+        A, B, C, D, name='system',
+        inputs=['u1', 'u2'], outputs=['y1', 'y2'], states=['x1', 'x2'])
+    assert sys.name == 'system'
+    assert ct.namedio._NamedIOObject._idCounter == 1
+    assert sys.input_list == ['u1', 'u2']
+    assert sys.output_list == ['y1', 'y2']
+    assert sys.state_list == ['x1', 'x2']
+
+    # Do the same with rss
+    sys = ct.rss(['x1', 'x2', 'x3'], ['y1', 'y2'], 'u1', name='random')
+    assert sys.name == 'random'
+    assert ct.namedio._NamedIOObject._idCounter == 1
+    assert sys.input_list == ['u1']
+    assert sys.output_list == ['y1', 'y2']
+    assert sys.state_list == ['x1', 'x2', 'x3']

--- a/control/tests/namedio_test.py
+++ b/control/tests/namedio_test.py
@@ -17,35 +17,35 @@ import pytest
 def test_named_ss():
     # Create a system to play with
     sys = ct.rss(2, 2, 2)
-    assert sys.input_list == ['u[0]', 'u[1]']
-    assert sys.output_list == ['y[0]', 'y[1]']
-    assert sys.state_list == ['x[0]', 'x[1]']
+    assert sys.input_labels == ['u[0]', 'u[1]']
+    assert sys.output_labels == ['y[0]', 'y[1]']
+    assert sys.state_labels == ['x[0]', 'x[1]']
 
     # Get the state matrices for later use
     A, B, C, D = sys.A, sys.B, sys.C, sys.D
     
     # Set up a named state space systems with default names
-    ct.namedio._NamedIOObject._idCounter = 0
+    ct.namedio._NamedIOSystem._idCounter = 0
     sys = ct.ss(A, B, C, D)
     assert sys.name == 'sys[0]'
-    assert sys.input_list == ['u[0]', 'u[1]']
-    assert sys.output_list == ['y[0]', 'y[1]']
-    assert sys.state_list == ['x[0]', 'x[1]']
+    assert sys.input_labels == ['u[0]', 'u[1]']
+    assert sys.output_labels == ['y[0]', 'y[1]']
+    assert sys.state_labels == ['x[0]', 'x[1]']
 
     # Pass the names as arguments
     sys = ct.ss(
         A, B, C, D, name='system',
         inputs=['u1', 'u2'], outputs=['y1', 'y2'], states=['x1', 'x2'])
     assert sys.name == 'system'
-    assert ct.namedio._NamedIOObject._idCounter == 1
-    assert sys.input_list == ['u1', 'u2']
-    assert sys.output_list == ['y1', 'y2']
-    assert sys.state_list == ['x1', 'x2']
+    assert ct.namedio._NamedIOSystem._idCounter == 1
+    assert sys.input_labels == ['u1', 'u2']
+    assert sys.output_labels == ['y1', 'y2']
+    assert sys.state_labels == ['x1', 'x2']
 
     # Do the same with rss
     sys = ct.rss(['x1', 'x2', 'x3'], ['y1', 'y2'], 'u1', name='random')
     assert sys.name == 'random'
-    assert ct.namedio._NamedIOObject._idCounter == 1
-    assert sys.input_list == ['u1']
-    assert sys.output_list == ['y1', 'y2']
-    assert sys.state_list == ['x1', 'x2', 'x3']
+    assert ct.namedio._NamedIOSystem._idCounter == 1
+    assert sys.input_labels == ['u1']
+    assert sys.output_labels == ['y1', 'y2']
+    assert sys.state_labels == ['x1', 'x2', 'x3']

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -18,8 +18,9 @@ import control as ct
 from control.config import defaults
 from control.dtime import sample_system
 from control.lti import evalfr
-from control.statesp import (StateSpace, _convert_to_statespace, drss,
-                             rss, ss, tf2ss, _statesp_defaults, _rss_generate)
+from control.statesp import StateSpace, _convert_to_statespace, tf2ss, \
+    _statesp_defaults, _rss_generate
+from control.iosys import ss, rss, drss
 from control.tests.conftest import ismatarrayout, slycotonly
 from control.xferfcn import TransferFunction, ss2tf
 

--- a/control/tests/type_conversion_test.py
+++ b/control/tests/type_conversion_test.py
@@ -59,7 +59,7 @@ type_dict = {
 rtype_list =           ['ss',  'tf', 'frd', 'lio', 'ios', 'arr', 'flt']
 conversion_table = [
     # op        left     ss     tf    frd    lio    ios    arr    flt
-    ('add',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'xos', 'ss',  'ss' ]),
+    ('add',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'ios', 'ss',  'ss' ]),
     ('add',     'tf',  ['tf',  'tf',  'xrd', 'tf',  'xos', 'tf',  'tf' ]),
     ('add',     'frd', ['xrd', 'xrd', 'frd', 'xrd', 'E',   'xrd', 'xrd']),
     ('add',     'lio', ['lio', 'lio', 'xrd', 'lio', 'ios', 'lio', 'lio']),
@@ -68,7 +68,7 @@ conversion_table = [
     ('add',     'flt', ['ss',  'tf',  'xrd', 'lio', 'ios', 'arr', 'flt']),
     
     # op        left     ss     tf    frd    lio    ios    arr    flt
-    ('sub',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'xos', 'ss',  'ss' ]),
+    ('sub',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'ios', 'ss',  'ss' ]),
     ('sub',     'tf',  ['tf',  'tf',  'xrd', 'tf',  'xos', 'tf',  'tf' ]),
     ('sub',     'frd', ['xrd', 'xrd', 'frd', 'xrd', 'E',   'xrd', 'xrd']),
     ('sub',     'lio', ['lio', 'lio', 'xrd', 'lio', 'ios', 'lio', 'lio']),
@@ -77,7 +77,7 @@ conversion_table = [
     ('sub',     'flt', ['ss',  'tf',  'xrd', 'lio', 'ios', 'arr', 'flt']),
     
     # op        left     ss     tf    frd    lio    ios    arr    flt
-    ('mul',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'xos', 'ss',  'ss' ]),
+    ('mul',     'ss',  ['ss',  'ss',  'xrd', 'ss',  'ios', 'ss',  'ss' ]),
     ('mul',     'tf',  ['tf',  'tf',  'xrd', 'tf',  'xos', 'tf',  'tf' ]),
     ('mul',     'frd', ['xrd', 'xrd', 'frd', 'xrd', 'E',   'xrd', 'frd']),
     ('mul',     'lio', ['lio', 'lio', 'xrd', 'lio', 'ios', 'lio', 'lio']),

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -8,14 +8,11 @@ import pytest
 import operator
 
 import control as ct
-from control.statesp import StateSpace, _convert_to_statespace, rss
-from control.xferfcn import TransferFunction, _convert_to_transfer_function, \
-    ss2tf
-from control.lti import evalfr
+from control import StateSpace, TransferFunction, rss, ss2tf, evalfr
+from control import isctime, isdtime, sample_system, defaults
+from control.statesp import _convert_to_statespace
+from control.xferfcn import _convert_to_transfer_function
 from control.tests.conftest import slycotonly, nopython2, matrixfilter
-from control.lti import isctime, isdtime
-from control.dtime import sample_system
-from control.config import defaults
 
 
 class TestXferFcn:

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -80,6 +80,7 @@ from copy import copy
 
 from . import config
 from .lti import isctime, isdtime
+from .namedio import _NamedIOStateObject
 from .statesp import StateSpace, _convert_to_statespace, _mimo2simo, _mimo2siso
 from .xferfcn import TransferFunction
 
@@ -87,7 +88,7 @@ __all__ = ['forced_response', 'step_response', 'step_info',
            'initial_response', 'impulse_response', 'TimeResponseData']
 
 
-class TimeResponseData():
+class TimeResponseData(_NamedIOStateObject):
     """A class for returning time responses.
 
     This class maintains and manipulates the data corresponding to the

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -80,7 +80,6 @@ from copy import copy
 
 from . import config
 from .lti import isctime, isdtime
-from .namedio import _NamedIOStateObject
 from .statesp import StateSpace, _convert_to_statespace, _mimo2simo, _mimo2siso
 from .xferfcn import TransferFunction
 
@@ -88,7 +87,7 @@ __all__ = ['forced_response', 'step_response', 'step_info',
            'initial_response', 'impulse_response', 'TimeResponseData']
 
 
-class TimeResponseData(_NamedIOStateObject):
+class TimeResponseData:
     """A class for returning time responses.
 
     This class maintains and manipulates the data corresponding to the

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -243,7 +243,7 @@ class TransferFunction(LTI):
         if len(args) == 2:
             # no dt given in positional arguments
             if 'dt' in kwargs:
-                dt = kwargs['dt']
+                dt = kwargs.pop('dt')
             elif self._isstatic():
                 dt = None
             else:
@@ -253,6 +253,7 @@ class TransferFunction(LTI):
             if 'dt' in kwargs:
                 warn('received multiple dt arguments, '
                      'using positional arg dt=%s' % dt)
+                kwargs.pop('dt')
         elif len(args) == 1:
             # TODO: not sure this can ever happen since dt is always present
             try:

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -233,7 +233,7 @@ class TransferFunction(LTI):
                 if zeronum:
                     den[i][j] = ones(1)
 
-        LTI.__init__(self, inputs, outputs)
+        super().__init__(inputs, outputs)
         self.num = num
         self.den = den
 


### PR DESCRIPTION
This PR adds some new functionality for I/O systems that I used in a recent course on optimization-based control that I taught at Caltech:

* Modify the `ss()`, `rss()`, and `drss()` functions to return `LinearIOSystem` objects (instead of `StateSpace` objects).  This makes it easier to create LTI state space systems that can be combined with other I/O systems without having to add a conversation step.  Since `LinearIOSystem` objects are also `StateSpace` objects, no functionality is lost.  (This change is implemented through the introduction of a internal `NamedIOSystem` class, to avoid import cycles.)

* Added a new function `create_statefbk_iosystem()` that creates an I/O system for implementing a linear state feedback controller of the form u = ud - Kp(x - xd).  The function returns an I/O system that takes xd, ud, and x as inputs and generates u as an output.  The `integral_action` keyword can be used to define a set of outputs y = C x for which integral feedback is also included: u = ud - Kp(x - xd) - Ki(C x - C xd).

* The `lqr` and `dlqr` commands now accept an `integral_action` keyword that allows outputs to be specified for implementing integral action.  The resulting gain matrix has the form K = [Kp, Ki].  (This is useful for combining with the `integral_action` functionality in `create_statefbk_iosystem()`).
