### PR TITLE
Keyword argument checking

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -73,6 +73,9 @@ def set_defaults(module, **keywords):
     if not isinstance(module, str):
         raise ValueError("module must be a string")
     for key, val in keywords.items():
+        keyname = module + '.' + key
+        if keyname not in defaults and f"deprecated.{keyname}" not in defaults:
+            raise TypeError(f"unrecognized keyword: {key}")
         defaults[module + '.' + key] = val
 
 
@@ -289,6 +292,6 @@ def use_legacy_defaults(version):
         set_defaults('control', squeeze_time_response=True)
 
         # switched mirror_style of nyquist from '-' to '--'
-        set_defaults('nyqist', mirror_style='-')
+        set_defaults('nyquist', mirror_style='-')
 
     return (major, minor, patch)

--- a/control/frdata.py
+++ b/control/frdata.py
@@ -150,7 +150,11 @@ class FrequencyResponseData(LTI):
 
         """
         # TODO: discrete-time FRD systems?
-        smooth = kwargs.get('smooth', False)
+        smooth = kwargs.pop('smooth', False)
+
+        # Make sure there were no extraneous keywords
+        if kwargs:
+            raise TypeError("unrecognized keywords: ", str(kwargs))
 
         if len(args) == 2:
             if not isinstance(args[0], FRD) and isinstance(args[0], LTI):

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -221,12 +221,10 @@ def bode_plot(syslist, omega=None,
         # Get the current figure
 
         if 'sisotool' in kwargs:
-            fig = kwargs['fig']
+            fig = kwargs.pop('fig')
             ax_mag = fig.axes[0]
             ax_phase = fig.axes[2]
-            sisotool = kwargs['sisotool']
-            del kwargs['fig']
-            del kwargs['sisotool']
+            sisotool = kwargs.pop('sisotool')
         else:
             fig = plt.gcf()
             ax_mag = None

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -560,7 +560,7 @@ class InputOutputSystem(_NamedIOStateSystem):
 
         # Create the state space system
         linsys = LinearIOSystem(
-            StateSpace(A, B, C, D, self.dt, remove_useless=False),
+            StateSpace(A, B, C, D, self.dt, remove_useless_states=False),
             name=name, **kwargs)
 
         # Set the names the system, inputs, outputs, and states
@@ -660,7 +660,7 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
             states=linsys.nstates, params={}, dt=linsys.dt, name=name)
 
         # Initalize additional state space variables
-        StateSpace.__init__(self, linsys, remove_useless=False)
+        StateSpace.__init__(self, linsys, remove_useless_states=False)
 
         # Process input, output, state lists, if given
         # Make sure they match the size of the linear system
@@ -1551,7 +1551,7 @@ class LinearICSystem(InterconnectedSystem, LinearIOSystem):
                io_sys.nstates != ss_sys.nstates:
                 raise ValueError("System dimensions for first and second "
                                  "arguments must match.")
-            StateSpace.__init__(self, ss_sys, remove_useless=False)
+            StateSpace.__init__(self, ss_sys, remove_useless_states=False)
 
         else:
             raise TypeError("Second argument must be a state space system.")

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -1656,13 +1656,13 @@ def input_output_response(
             raise ValueError("ivp_method specified more than once")
         solve_ivp_kwargs['method'] = kwargs.pop('solve_ivp_method')
 
+    # Make sure there were no extraneous keywords
+    if kwargs:
+        raise TypeError("unrecognized keywords: ", str(kwargs))
+
     # Set the default method to 'RK45'
     if solve_ivp_kwargs.get('method', None) is None:
         solve_ivp_kwargs['method'] = 'RK45'
-
-    # Make sure all input arguments got parsed
-    if kwargs:
-        raise TypeError("unknown parameters %s" % kwargs)
 
     # Sanity checking on the input
     if not isinstance(sys, InputOutputSystem):

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2238,7 +2238,15 @@ def ss(*args, **kwargs):
     >>> sys2 = ss(sys_tf)
 
     """
-    sys = _ss(*args, keywords=kwargs)
+    # Extract the keyword arguments needed for StateSpace (via _ss)
+    ss_kwlist = ('dt', 'remove_useless_states')
+    ss_kwargs = {}
+    for kw in ss_kwlist:
+        if kw in kwargs:
+            ss_kwargs[kw] = kwargs.pop(kw)
+
+    # Create the statespace system and then convert to I/O system
+    sys = _ss(*args, keywords=ss_kwargs)
     return LinearIOSystem(sys, **kwargs)
 
 

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -1829,7 +1829,7 @@ def input_output_response(
 
 def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
               iu=None, iy=None, ix=None, idx=None, dx0=None,
-              return_y=False, return_result=False, **kw):
+              return_y=False, return_result=False):
     """Find the equilibrium point for an input/output system.
 
     Returns the value of an equilibrium point given the initial state and
@@ -1933,7 +1933,7 @@ def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
             # Take u0 as fixed and minimize over x
             # TODO: update to allow discrete time systems
             def ode_rhs(z): return sys._rhs(t, z, u0)
-            result = root(ode_rhs, x0, **kw)
+            result = root(ode_rhs, x0)
             z = (result.x, u0, sys._out(t, result.x, u0))
         else:
             # Take y0 as fixed and minimize over x and u
@@ -1944,7 +1944,7 @@ def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
                 return np.concatenate(
                     (sys._rhs(t, x, u), sys._out(t, x, u) - y0), axis=0)
             z0 = np.concatenate((x0, u0), axis=0)   # Put variables together
-            result = root(rootfun, z0, **kw)        # Find the eq point
+            result = root(rootfun, z0)              # Find the eq point
             x, u = np.split(result.x, [nstates])    # Split result back in two
             z = (x, u, sys._out(t, x, u))
 
@@ -2056,7 +2056,7 @@ def find_eqpt(sys, x0, u0=[], y0=None, t=0, params={},
         z0 = np.concatenate((x[state_vars], u[input_vars]), axis=0)
 
         # Finally, call the root finding function
-        result = root(rootfun, z0, **kw)
+        result = root(rootfun, z0)
 
         # Extract out the results and insert into x and u
         x[state_vars] = result.x[:nstate_vars]
@@ -2135,7 +2135,7 @@ def _parse_signal_parameter(value, name, kwargs, end=False):
 
     if end and kwargs:
         raise TypeError("unrecognized keywords: ", str(kwargs))
-    
+
     return value
 
 

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -148,7 +148,7 @@ class InputOutputSystem(_NamedIOStateSystem):
         # timebase
         self.dt = kwargs.pop('dt', config.defaults['control.default_dt'])
 
-        # Make sure there were no extraneous keyworks
+        # Make sure there were no extraneous keywords
         if kwargs:
             raise TypeError("unrecognized keywords: ", str(kwargs))
 
@@ -790,9 +790,9 @@ class NonlinearIOSystem(InputOutputSystem):
             params=params, dt=dt, name=name
         )
 
-        # Make sure all input arguments got parsed
+        # Make sure there were no extraneous keywords
         if kwargs:
-            raise TypeError("unknown parameters %s" % kwargs)
+            raise TypeError("unrecognized keywords: ", str(kwargs))
 
         # Check to make sure arguments are consistent
         if updfcn is None:
@@ -2134,7 +2134,8 @@ def _parse_signal_parameter(value, name, kwargs, end=False):
         value = kwargs.pop(name)
 
     if end and kwargs:
-        raise TypeError("unknown parameters %s" % kwargs)
+        raise TypeError("unrecognized keywords: ", str(kwargs))
+    
     return value
 
 

--- a/control/optimal.py
+++ b/control/optimal.py
@@ -154,7 +154,7 @@ class OptimalControlProblem():
         self.minimize_kwargs.update(kwargs.pop(
             'minimize_kwargs', config.defaults['optimal.minimize_kwargs']))
 
-        # Make sure all input arguments got parsed
+        # Make sure there were no extraneous keywords
         if kwargs:
             raise TypeError("unrecognized keyword(s): ", str(kwargs))
 

--- a/control/pzmap.py
+++ b/control/pzmap.py
@@ -91,7 +91,11 @@ def pzmap(sys, plot=None, grid=None, title='Pole Zero Map', **kwargs):
         import warnings
         warnings.warn("'Plot' keyword is deprecated in pzmap; use 'plot'",
                       FutureWarning)
-        plot = kwargs['Plot']
+        plot = kwargs.pop('Plot')
+
+    # Make sure there were no extraneous keywords
+    if kwargs:
+        raise TypeError("unrecognized keywords: ", str(kwargs))
 
     # Get parameter values
     plot = config._get_param('pzmap', 'plot', plot, True)

--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -168,6 +168,10 @@ def root_locus(sys, kvect=None, xlim=None, ylim=None,
     # Check for sisotool mode
     sisotool = False if 'sisotool' not in kwargs else True
 
+    # Make sure there were no extraneous keywords
+    if not sisotool and kwargs:
+        raise TypeError("unrecognized keywords: ", str(kwargs))
+
     # Create the Plot
     if plot:
         if sisotool:

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -261,7 +261,7 @@ def place_varga(A, B, p, dtime=False, alpha=None):
 
 
 # contributed by Sawyer B. Fuller <minster@uw.edu>
-def lqe(*args, **keywords):
+def lqe(*args, method=None):
     """lqe(A, G, C, QN, RN, [, NN])
 
     Linear quadratic estimator design (Kalman filter) for continuous-time
@@ -356,17 +356,14 @@ def lqe(*args, **keywords):
     # Process the arguments and figure out what inputs we received
     #
 
-    # Get the method to use (if specified as a keyword)
-    method = keywords.get('method', None)
+    # If we were passed a discrete time system as the first arg, use dlqe()
+    if isinstance(args[0], LTI) and isdtime(args[0], strict=True):
+        # Call dlqe
+        return dlqe(*args, method=method)
 
     # Get the system description
     if (len(args) < 3):
         raise ControlArgument("not enough input arguments")
-
-    # If we were passed a discrete time system as the first arg, use dlqe()
-    if isinstance(args[0], LTI) and isdtime(args[0], strict=True):
-        # Call dlqe
-        return dlqe(*args, **keywords)
 
     # If we were passed a state space  system, use that to get system matrices
     if isinstance(args[0], StateSpace):
@@ -409,7 +406,7 @@ def lqe(*args, **keywords):
 
 
 # contributed by Sawyer B. Fuller <minster@uw.edu>
-def dlqe(*args, **keywords):
+def dlqe(*args, method=None):
     """dlqe(A, G, C, QN, RN, [, N])
 
     Linear quadratic estimator design (Kalman filter) for discrete-time
@@ -479,9 +476,6 @@ def dlqe(*args, **keywords):
     #
     # Process the arguments and figure out what inputs we received
     #
-
-    # Get the method to use (if specified as a keyword)
-    method = keywords.get('method', None)
 
     # Get the system description
     if (len(args) < 3):

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1776,7 +1776,12 @@ def _ss(*args, keywords=None, **kwargs):
     """Internal function to create StateSpace system"""
     if len(args) == 4 or len(args) == 5:
         return StateSpace(*args, keywords=keywords, **kwargs)
+
     elif len(args) == 1:
+        # Make sure there were no extraneous keywords
+        if kwargs:
+            raise TypeError("unrecognized keywords: ", str(kwargs))
+
         from .xferfcn import TransferFunction
         sys = args[0]
         if isinstance(sys, StateSpace):

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -340,6 +340,10 @@ class StateSpace(LTI, _NamedIOStateSystem):
         self.dt = dt
         self.nstates = A.shape[1]
 
+        # Make sure there were no extraneous keywords
+        if keywords:
+            raise TypeError("unrecognized keywords: ", str(keywords))
+
         if 0 == self.nstates:
             # static gain
             # matrix's default "empty" shape is 1x0

--- a/control/tests/config_test.py
+++ b/control/tests/config_test.py
@@ -23,10 +23,10 @@ class TestConfig:
     sys = ct.tf([10], [1, 2, 1])
 
     def test_set_defaults(self):
-        ct.config.set_defaults('config', test1=1, test2=2, test3=None)
-        assert ct.config.defaults['config.test1'] == 1
-        assert ct.config.defaults['config.test2'] == 2
-        assert ct.config.defaults['config.test3'] is None
+        ct.config.set_defaults('freqplot', dB=1, deg=2, Hz=None)
+        assert ct.config.defaults['freqplot.dB'] == 1
+        assert ct.config.defaults['freqplot.deg'] == 2
+        assert ct.config.defaults['freqplot.Hz'] is None
 
     @mplcleanup
     def test_get_param(self):

--- a/control/tests/frd_test.py
+++ b/control/tests/frd_test.py
@@ -472,3 +472,9 @@ Freq [rad/s]  Response
       10.000         0.2        +4j
      100.000         0.1        +6j"""
         assert str(sysm) == refm
+
+    def test_unrecognized_keyword(self):
+        h = TransferFunction([1], [1, 2, 2])
+        omega = np.logspace(-1, 2, 10)
+        with pytest.raises(TypeError, match="unrecognized keyword"):
+            frd = FRD(h, omega, unknown=None)

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -188,19 +188,19 @@ def test_interconnect_exceptions():
 
     # Unrecognized arguments
     # LinearIOSystem
-    with pytest.raises(TypeError, match="unknown parameter"):
+    with pytest.raises(TypeError, match="unrecognized keyword"):
         P = ct.LinearIOSystem(ct.rss(2, 1, 1), output_name='y')
 
     # Interconnect
-    with pytest.raises(TypeError, match="unknown parameter"):
+    with pytest.raises(TypeError, match="unrecognized keyword"):
         T = ct.interconnect((P, C, sumblk), input_name='r', output='y')
 
     # Interconnected system
-    with pytest.raises(TypeError, match="unknown parameter"):
+    with pytest.raises(TypeError, match="unrecognized keyword"):
         T = ct.InterconnectedSystem((P, C, sumblk), input_name='r', output='y')
 
     # NonlinearIOSytem
-    with pytest.raises(TypeError, match="unknown parameter"):
+    with pytest.raises(TypeError, match="unrecognized keyword"):
         nlios =  ct.NonlinearIOSystem(
             None, lambda t, x, u, params: u*u, input_count=1, output_count=1)
 
@@ -208,7 +208,7 @@ def test_interconnect_exceptions():
     with pytest.raises(TypeError, match="input specification is required"):
         sumblk = ct.summing_junction()
 
-    with pytest.raises(TypeError, match="unknown parameter"):
+    with pytest.raises(TypeError, match="unrecognized keyword"):
         sumblk = ct.summing_junction(input_count=2, output_count=2)
 
 

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1580,7 +1580,8 @@ def test_interconnect_unused_input():
                           outputs=['u'],
                           name='k')
 
-    with pytest.warns(UserWarning, match=r"Unused input\(s\) in InterconnectedSystem"):
+    with pytest.warns(
+            UserWarning, match=r"Unused input\(s\) in InterconnectedSystem"):
         h = ct.interconnect([g,s,k],
                             inputs=['r'],
                             outputs=['y'])
@@ -1611,13 +1612,19 @@ def test_interconnect_unused_input():
 
 
     # warn if explicity ignored input in fact used
-    with pytest.warns(UserWarning, match=r"Input\(s\) specified as ignored is \(are\) used:") as record:
+    with pytest.warns(
+            UserWarning,
+            match=r"Input\(s\) specified as ignored is \(are\) used:") \
+            as record:
         h = ct.interconnect([g,s,k],
                             inputs=['r'],
                             outputs=['y'],
                             ignore_inputs=['u','n'])
 
-    with pytest.warns(UserWarning, match=r"Input\(s\) specified as ignored is \(are\) used:") as record:
+    with pytest.warns(
+            UserWarning,
+            match=r"Input\(s\) specified as ignored is \(are\) used:") \
+            as record:
         h = ct.interconnect([g,s,k],
                             inputs=['r'],
                             outputs=['y'],

--- a/control/tests/kwargs_test.py
+++ b/control/tests/kwargs_test.py
@@ -1,0 +1,168 @@
+# kwargs_test.py - test for uncrecognized keywords
+# RMM, 20 Mar 2022
+#
+# Allowing unrecognized keywords to be passed to a function without
+# generating and error message can generate annoying bugs, since you
+# sometimes think you are telling the function to do something and actually
+# you have a misspelling or other error and your input is being ignored.
+#
+# This unit test looks through all functions in the package for any that
+# allow kwargs as part of the function signature and makes sure that there
+# is a unit test that checks for unrecognized keywords.
+
+import inspect
+import pytest
+import warnings
+
+import control
+import control.flatsys
+
+# List of all of the test modules where kwarg unit tests are defined
+import control.tests.flatsys_test as flatsys_test
+import control.tests.frd_test as frd_test
+import control.tests.interconnect_test as interconnect_test
+import control.tests.statefbk_test as statefbk_test
+import control.tests.trdata_test as trdata_test
+
+
+@pytest.mark.parametrize("module, prefix", [
+    (control, ""), (control.flatsys, "flatsys.")
+])
+def test_kwarg_search(module, prefix):
+    # Look through every object in the package
+    for name, obj in inspect.getmembers(module):
+        # Skip anything that is outside of this module
+        if inspect.getmodule(obj) is not None and \
+           not inspect.getmodule(obj).__name__.startswith('control'):
+            # Skip anything that isn't part of the control package
+            continue
+        
+        # Look for functions with keyword arguments
+        if inspect.isfunction(obj):
+            # Get the signature for the function
+            sig = inspect.signature(obj)
+
+            # See if there is a variable keyword argument
+            for argname, par in sig.parameters.items():
+                if par.kind == inspect.Parameter.VAR_KEYWORD:
+                    # Make sure there is a unit test defined
+                    assert prefix + name in kwarg_unittest
+
+                    # Make sure there is a unit test
+                    if not hasattr(kwarg_unittest[prefix + name], '__call__'):
+                        warnings.warn("No unit test defined for '%s'"
+                                      % prefix + name)
+
+        # Look for classes and then check member functions
+        if inspect.isclass(obj):
+            test_kwarg_search(obj, prefix + obj.__name__ + '.')
+
+
+# Create a SISO system for use in parameterized tests
+sys = control.ss([[-1, 1], [0, -1]], [[0], [1]], [[1, 0]], 0, dt=None)
+
+
+# Parameterized tests for looking for unrecognized keyword errors
+@pytest.mark.parametrize("function, args, kwargs", [
+    [control.dlqr, (sys, [[1, 0], [0, 1]], [[1]]), {}],
+    [control.drss, (2, 1, 1), {}],
+    [control.input_output_response, (sys, [0, 1, 2], [1, 1, 1]), {}],
+    [control.lqr, (sys, [[1, 0], [0, 1]], [[1]]), {}],
+    [control.pzmap, (sys,), {}],
+    [control.rlocus, (control.tf([1], [1, 1]), ), {}],
+    [control.root_locus, (control.tf([1], [1, 1]), ), {}],
+    [control.rss, (2, 1, 1), {}],
+    [control.ss, (0, 0, 0, 0), {'dt': 1}],
+    [control.ss2io, (sys,), {}],
+    [control.summing_junction, (2,), {}],
+    [control.tf, ([1], [1, 1]), {}],
+    [control.tf2io, (control.tf([1], [1, 1]),), {}],
+    [control.InputOutputSystem, (1, 1, 1), {}],
+    [control.StateSpace, ([[-1, 0], [0, -1]], [[1], [1]], [[1, 1]], 0), {}],
+    [control.TransferFunction, ([1], [1, 1]), {}],
+])
+def test_unrecognized_kwargs(function, args, kwargs):
+    # Call the function normally and make sure it works
+    function(*args, **kwargs)
+
+    # Now add an unrecognized keyword and make sure there is an error
+    with pytest.raises(TypeError, match="unrecognized keyword"):
+        function(*args, **kwargs, unknown=None)
+
+
+# Parameterized tests for looking for keyword errors handled by matplotlib
+@pytest.mark.parametrize("function, args, kwargs", [
+    [control.bode, (sys, ), {}],
+    [control.bode_plot, (sys, ), {}],
+    [control.gangof4, (sys, sys), {}],
+    [control.gangof4_plot, (sys, sys), {}],
+    [control.nyquist, (sys, ), {}],
+    [control.nyquist_plot, (sys, ), {}],
+])
+def test_matplotlib_kwargs(function, args, kwargs):
+    # Call the function normally and make sure it works
+    function(*args, **kwargs)
+
+    # Now add an unrecognized keyword and make sure there is an error
+    with pytest.raises(AttributeError, match="has no property"):
+        function(*args, **kwargs, unknown=None)
+    
+
+#
+# List of all unit tests that check for unrecognized keywords
+#
+# Every function that accepts variable keyword arguments (**kwargs) should
+# have an entry in this table, to make sure that nothing is missing.  This
+# will also force people who add new functions to put in an appropriate unit
+# test.
+#
+
+kwarg_unittest = {
+    'bode': test_matplotlib_kwargs,
+    'bode_plot': test_matplotlib_kwargs,
+    'describing_function_plot': None,
+    'dlqr': statefbk_test.TestStatefbk.test_lqr_errors,
+    'drss': test_unrecognized_kwargs,
+    'find_eqpt': None,
+    'gangof4': test_matplotlib_kwargs,
+    'gangof4_plot': test_matplotlib_kwargs,
+    'input_output_response': test_unrecognized_kwargs,
+    'interconnect': interconnect_test.test_interconnect_exceptions,
+    'linearize': None,
+    'lqr': statefbk_test.TestStatefbk.test_lqr_errors,
+    'nyquist': test_matplotlib_kwargs,
+    'nyquist_plot': test_matplotlib_kwargs,
+    'pzmap': None,
+    'rlocus': test_unrecognized_kwargs,
+    'root_locus': test_unrecognized_kwargs,
+    'rss': test_unrecognized_kwargs,
+    'set_defaults': None,
+    'singular_values_plot': None,
+    'ss': test_unrecognized_kwargs,
+    'ss2io': test_unrecognized_kwargs,
+    'ss2tf': test_unrecognized_kwargs,
+    'summing_junction': interconnect_test.test_interconnect_exceptions,
+    'tf': test_unrecognized_kwargs,
+    'tf2io' : test_unrecognized_kwargs,
+    'flatsys.point_to_point':
+        flatsys_test.TestFlatSys.test_point_to_point_errors,
+    'FrequencyResponseData.__init__':
+        frd_test.TestFRD.test_unrecognized_keyword,
+    'InputOutputSystem.__init__': None,
+    'InputOutputSystem.linearize': None,
+    'InterconnectedSystem.__init__':
+        interconnect_test.test_interconnect_exceptions,
+    'InterconnectedSystem.linearize': None,
+    'LinearICSystem.linearize': None,
+    'LinearIOSystem.__init__':
+        interconnect_test.test_interconnect_exceptions,
+    'LinearIOSystem.linearize': None,
+    'NonlinearIOSystem.__init__':
+        interconnect_test.test_interconnect_exceptions,
+    'NonlinearIOSystem.linearize': None,
+    'StateSpace.__init__': None,
+    'TimeResponseData.__call__': trdata_test.test_response_copy,
+    'TransferFunction.__init__': None,
+    'flatsys.FlatSystem.linearize': None,
+    'flatsys.LinearFlatSystem.linearize': None,
+}

--- a/control/tests/kwargs_test.py
+++ b/control/tests/kwargs_test.py
@@ -58,54 +58,58 @@ def test_kwarg_search(module, prefix):
             test_kwarg_search(obj, prefix + obj.__name__ + '.')
 
 
-# Create a SISO system for use in parameterized tests
-sys = control.ss([[-1, 1], [0, -1]], [[0], [1]], [[1, 0]], 0, dt=None)
+def test_unrecognized_kwargs():
+    # Create a SISO system for use in parameterized tests
+    sys = control.ss([[-1, 1], [0, -1]], [[0], [1]], [[1, 0]], 0, dt=None)
+
+    table = [
+        [control.dlqr, (sys, [[1, 0], [0, 1]], [[1]]), {}],
+        [control.drss, (2, 1, 1), {}],
+        [control.input_output_response, (sys, [0, 1, 2], [1, 1, 1]), {}],
+        [control.lqr, (sys, [[1, 0], [0, 1]], [[1]]), {}],
+        [control.pzmap, (sys,), {}],
+        [control.rlocus, (control.tf([1], [1, 1]), ), {}],
+        [control.root_locus, (control.tf([1], [1, 1]), ), {}],
+        [control.rss, (2, 1, 1), {}],
+        [control.ss, (0, 0, 0, 0), {'dt': 1}],
+        [control.ss2io, (sys,), {}],
+        [control.summing_junction, (2,), {}],
+        [control.tf, ([1], [1, 1]), {}],
+        [control.tf2io, (control.tf([1], [1, 1]),), {}],
+        [control.InputOutputSystem, (1, 1, 1), {}],
+        [control.StateSpace, ([[-1, 0], [0, -1]], [[1], [1]], [[1, 1]], 0), {}],
+        [control.TransferFunction, ([1], [1, 1]), {}],
+    ]
+
+    for function, args, kwargs in table:
+        # Call the function normally and make sure it works
+        function(*args, **kwargs)
+
+        # Now add an unrecognized keyword and make sure there is an error
+        with pytest.raises(TypeError, match="unrecognized keyword"):
+            function(*args, **kwargs, unknown=None)
 
 
-# Parameterized tests for looking for unrecognized keyword errors
-@pytest.mark.parametrize("function, args, kwargs", [
-    [control.dlqr, (sys, [[1, 0], [0, 1]], [[1]]), {}],
-    [control.drss, (2, 1, 1), {}],
-    [control.input_output_response, (sys, [0, 1, 2], [1, 1, 1]), {}],
-    [control.lqr, (sys, [[1, 0], [0, 1]], [[1]]), {}],
-    [control.pzmap, (sys,), {}],
-    [control.rlocus, (control.tf([1], [1, 1]), ), {}],
-    [control.root_locus, (control.tf([1], [1, 1]), ), {}],
-    [control.rss, (2, 1, 1), {}],
-    [control.ss, (0, 0, 0, 0), {'dt': 1}],
-    [control.ss2io, (sys,), {}],
-    [control.summing_junction, (2,), {}],
-    [control.tf, ([1], [1, 1]), {}],
-    [control.tf2io, (control.tf([1], [1, 1]),), {}],
-    [control.InputOutputSystem, (1, 1, 1), {}],
-    [control.StateSpace, ([[-1, 0], [0, -1]], [[1], [1]], [[1, 1]], 0), {}],
-    [control.TransferFunction, ([1], [1, 1]), {}],
-])
-def test_unrecognized_kwargs(function, args, kwargs):
-    # Call the function normally and make sure it works
-    function(*args, **kwargs)
+def test_matplotlib_kwargs():
+    # Create a SISO system for use in parameterized tests
+    sys = control.ss([[-1, 1], [0, -1]], [[0], [1]], [[1, 0]], 0, dt=None)
 
-    # Now add an unrecognized keyword and make sure there is an error
-    with pytest.raises(TypeError, match="unrecognized keyword"):
-        function(*args, **kwargs, unknown=None)
+    table = [
+        [control.bode, (sys, ), {}],
+        [control.bode_plot, (sys, ), {}],
+        [control.gangof4, (sys, sys), {}],
+        [control.gangof4_plot, (sys, sys), {}],
+        [control.nyquist, (sys, ), {}],
+        [control.nyquist_plot, (sys, ), {}],
+    ]
 
+    for function, args, kwargs in table:
+        # Call the function normally and make sure it works
+        function(*args, **kwargs)
 
-# Parameterized tests for looking for keyword errors handled by matplotlib
-@pytest.mark.parametrize("function, args, kwargs", [
-    [control.bode, (sys, ), {}],
-    [control.bode_plot, (sys, ), {}],
-    [control.gangof4, (sys, sys), {}],
-    [control.gangof4_plot, (sys, sys), {}],
-    [control.nyquist, (sys, ), {}],
-    [control.nyquist_plot, (sys, ), {}],
-])
-def test_matplotlib_kwargs(function, args, kwargs):
-    # Call the function normally and make sure it works
-    function(*args, **kwargs)
-
-    # Now add an unrecognized keyword and make sure there is an error
-    with pytest.raises(AttributeError, match="has no property"):
-        function(*args, **kwargs, unknown=None)
+        # Now add an unrecognized keyword and make sure there is an error
+        with pytest.raises(AttributeError, match="has no property"):
+            function(*args, **kwargs, unknown=None)
     
 
 #

--- a/control/tests/trdata_test.py
+++ b/control/tests/trdata_test.py
@@ -208,7 +208,7 @@ def test_response_copy():
     assert response.input_labels == ['u']
 
     # Unknown keyword
-    with pytest.raises(ValueError, match="Unknown parameter(s)*"):
+    with pytest.raises(TypeError, match="unrecognized keywords"):
         response_bad_kw = response_mimo(input=0)
 
 

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -480,9 +480,9 @@ class TimeResponseData:
             response.state_labels = _process_labels(
                 state_labels, "state", response.nstates)
 
-        # Make sure no unknown keywords were passed
-        if len(kwargs) != 0:
-            raise ValueError("Unknown parameter(s) %s" % kwargs)
+        # Make sure there were no extraneous keywords
+        if kwargs:
+            raise TypeError("unrecognized keywords: ", str(kwargs))
 
         return response
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -265,6 +265,10 @@ class TransferFunction(LTI):
                     dt = config.defaults['control.default_dt']
         self.dt = dt
 
+        # Make sure there were no extraneous keywords
+        if kwargs:
+            raise TypeError("unrecognized keywords: ", str(kwargs))
+
     #
     # Class attributes
     #
@@ -1297,7 +1301,7 @@ def _add_siso(num1, den1, num2, den2):
     return num, den
 
 
-def _convert_to_transfer_function(sys, **kw):
+def _convert_to_transfer_function(sys, inputs=1, outputs=1):
     """Convert a system to transfer function form (if needed).
 
     If sys is already a transfer function, then it is returned.  If sys is a
@@ -1324,13 +1328,9 @@ def _convert_to_transfer_function(sys, **kw):
     from .statesp import StateSpace
 
     if isinstance(sys, TransferFunction):
-        if len(kw):
-            raise TypeError("If sys is a TransferFunction, " +
-                            "_convertToTransferFunction cannot take keywords.")
-
         return sys
-    elif isinstance(sys, StateSpace):
 
+    elif isinstance(sys, StateSpace):
         if 0 == sys.nstates:
             # Slycot doesn't like static SS->TF conversion, so handle
             # it first.  Can't join this with the no-Slycot branch,
@@ -1341,14 +1341,9 @@ def _convert_to_transfer_function(sys, **kw):
                    for i in range(sys.noutputs)]
         else:
             try:
-                from slycot import tb04ad
-                if len(kw):
-                    raise TypeError(
-                        "If sys is a StateSpace, " +
-                        "_convertToTransferFunction cannot take keywords.")
-
                 # Use Slycot to make the transformation
                 # Make sure to convert system matrices to numpy arrays
+                from slycot import tb04ad
                 tfout = tb04ad(
                     sys.nstates, sys.ninputs, sys.noutputs, array(sys.A),
                     array(sys.B), array(sys.C), array(sys.D), tol1=0.0)
@@ -1381,15 +1376,6 @@ def _convert_to_transfer_function(sys, **kw):
         return TransferFunction(num, den, sys.dt)
 
     elif isinstance(sys, (int, float, complex, np.number)):
-        if "inputs" in kw:
-            inputs = kw["inputs"]
-        else:
-            inputs = 1
-        if "outputs" in kw:
-            outputs = kw["outputs"]
-        else:
-            outputs = 1
-
         num = [[[sys] for j in range(inputs)] for i in range(outputs)]
         den = [[[1] for j in range(inputs)] for i in range(outputs)]
 
@@ -1498,6 +1484,10 @@ def tf(*args, **kwargs):
     if len(args) == 2 or len(args) == 3:
         return TransferFunction(*args, **kwargs)
     elif len(args) == 1:
+        # Make sure there were no extraneous keywords
+        if kwargs:
+            raise TypeError("unrecognized keywords: ", str(kwargs))
+
         # Look for special cases defining differential/delay operator
         if args[0] == 's':
             return TransferFunction.s
@@ -1525,8 +1515,8 @@ def ss2tf(*args, **kwargs):
     The function accepts either 1 or 4 parameters:
 
     ``ss2tf(sys)``
-        Convert a linear system from state space into transfer function form. Always creates a
-        new system.
+        Convert a linear system from state space into transfer function
+        form. Always creates a new system.
 
     ``ss2tf(A, B, C, D)``
         Create a transfer function system from the matrices of its state and

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1574,7 +1574,11 @@ def ss2tf(*args, **kwargs):
         # Assume we were given the A, B, C, D matrix and (optional) dt
         return _convert_to_transfer_function(StateSpace(*args, **kwargs))
 
-    elif len(args) == 1:
+    # Make sure there were no extraneous keywords
+    if kwargs:
+        raise TypeError("unrecognized keywords: ", str(kwargs))
+
+    if len(args) == 1:
         sys = args[0]
         if isinstance(sys, StateSpace):
             return _convert_to_transfer_function(sys)


### PR DESCRIPTION
This PR implements checks for unrecognized keywords in all functions that accept variable keywords (addressing #528).  This is accomplished using a the `kwargs_test` unit test, which inspects the module, finds all functions with variable keyword arguments, and then makes sure there is a unit test that confirms that sending an unknown keyword generates an error.  