### PR TITLE
Improvements to Nichols chart plotting

### DIFF
--- a/control/nichols.py
+++ b/control/nichols.py
@@ -153,6 +153,19 @@ def nichols_grid(cl_mags=None, cl_phases=None, line_style='dotted', ax=None,
         Axes to add grid to.  If ``None``, use ``plt.gca()``.
     label_cl_phases: bool, optional
         If True, closed-loop phase lines will be labelled.
+
+    Returns
+    -------
+    cl_mag_lines: list of `matplotlib.line.Line2D`
+      The constant closed-loop gain contours
+    cl_phase_lines: list of `matplotlib.line.Line2D`
+      The constant closed-loop phase contours
+    cl_mag_labels: list of `matplotlib.text.Text`
+      mcontour labels; each entry corresponds to the respective entry
+      in ``cl_mag_lines``
+    cl_phase_labels: list of `matplotlib.text.Text`
+      ncontour labels; each entry corresponds to the respective entry
+      in ``cl_phase_lines``
     """
     if ax is None:
         ax = plt.gca()
@@ -163,8 +176,8 @@ def nichols_grid(cl_mags=None, cl_phases=None, line_style='dotted', ax=None,
     ol_mag_min = -40.0
     ol_mag_max = default_ol_mag_max = 50.0
 
-    # Find bounds of the current dataset, if there is one.
     if ax.has_data():
+        # Find extent of intersection the current dataset or view
         ol_phase_min, ol_mag_min, ol_phase_max, ol_mag_max = _inner_extents(ax)
 
     # M-circle magnitudes.
@@ -184,20 +197,22 @@ def nichols_grid(cl_mags=None, cl_phases=None, line_style='dotted', ax=None,
                                      ol_mag_min + cl_mag_step, cl_mag_step)
         cl_mags = np.concatenate((extended_cl_mags, key_cl_mags))
 
-    phase_offset_min = 360.0*np.ceil(ol_phase_min/360.0)
-    phase_offset_max = 360.0*np.ceil(ol_phase_max/360.0) + 360.0
+    # a minimum 360deg extent containing the phases
+    phase_round_max = 360.0*np.ceil(ol_phase_max/360.0)
+    phase_round_min = min(phase_round_max-360,
+                          360.0*np.floor(ol_phase_min/360.0))
 
     # N-circle phases (should be in the range -360 to 0)
     if cl_phases is None:
         # aim for 9 lines, but always show (-360+eps, -180, -eps)
         # smallest spacing is 45, biggest is 180
-        phase_span = phase_offset_max - phase_offset_min
+        phase_span = phase_round_max - phase_round_min
         spacing = np.clip(round(phase_span / 8 / 45) * 45, 45, 180)
         key_cl_phases = np.array([-0.25, -359.75])
         other_cl_phases = np.arange(-spacing, -360.0, -spacing)
         cl_phases = np.unique(np.concatenate((key_cl_phases, other_cl_phases)))
-    else:
-        assert ((-360.0 < np.min(cl_phases)) and (np.max(cl_phases) < 0.0))
+    elif not ((-360 < np.min(cl_phases)) and (np.max(cl_phases) < 0.0)):
+        raise ValueError('cl_phases must between -360 and 0, exclusive')
 
     # Find the M-contours
     m = m_circles(cl_mags, phase_min=np.min(cl_phases),
@@ -216,21 +231,29 @@ def nichols_grid(cl_mags=None, cl_phases=None, line_style='dotted', ax=None,
     # over the range -360 < phase < 0. Given the range
     # the base chart is computed over, the phase offset should be 0
     # for -360 < ol_phase_min < 0.
-    phase_offsets = np.arange(phase_offset_min, phase_offset_max, 360.0)
+    phase_offsets = 360 + np.arange(phase_round_min, phase_round_max, 360.0)
+
+    cl_mag_lines = []
+    cl_phase_lines = []
+    cl_mag_labels = []
+    cl_phase_labels = []
 
     for phase_offset in phase_offsets:
         # Draw M and N contours
-        ax.plot(m_phase + phase_offset, m_mag, color='lightgray',
-                 linestyle=line_style, zorder=0)
-        ax.plot(n_phase + phase_offset, n_mag, color='lightgray',
-                 linestyle=line_style, zorder=0)
+        cl_mag_lines.extend(
+            ax.plot(m_phase + phase_offset, m_mag, color='lightgray',
+                    linestyle=line_style, zorder=0))
+        cl_phase_lines.extend(
+            ax.plot(n_phase + phase_offset, n_mag, color='lightgray',
+                    linestyle=line_style, zorder=0))
 
         # Add magnitude labels
         for x, y, m in zip(m_phase[:][-1] + phase_offset, m_mag[:][-1],
                            cl_mags):
             align = 'right' if m < 0.0 else 'left'
-            ax.text(x, y, str(m) + ' dB', size='small', ha=align,
-                     color='gray', clip_on=True)
+            cl_mag_labels.append(
+                ax.text(x, y, str(m) + ' dB', size='small', ha=align,
+                        color='gray', clip_on=True))
 
         # phase labels
         if label_cl_phases:
@@ -243,19 +266,22 @@ def nichols_grid(cl_mags=None, cl_phases=None, line_style='dotted', ax=None,
                     align = 'center'
                 else:
                     align = 'left'
-                ax.text(x, y, f'{round(p)}\N{DEGREE SIGN}',
-                        size='small',
-                        ha=align,
-                        va='bottom',
-                        color='gray',
-                        clip_on=True)
+                cl_phase_labels.append(
+                    ax.text(x, y, f'{round(p)}\N{DEGREE SIGN}',
+                            size='small',
+                            ha=align,
+                            va='bottom',
+                            color='gray',
+                            clip_on=True))
 
 
     # Fit axes to generated chart
-    ax.axis([phase_offset_min - 360.0,
-             phase_offset_max - 360.0,
+    ax.axis([phase_round_min,
+             phase_round_max,
              np.min(np.concatenate([cl_mags,[ol_mag_min]])),
              np.max([ol_mag_max, default_ol_mag_max])])
+
+    return cl_mag_lines, cl_phase_lines, cl_mag_labels, cl_phase_labels
 
 #
 # Utility functions

--- a/control/tests/nichols_test.py
+++ b/control/tests/nichols_test.py
@@ -3,9 +3,11 @@
 RMM, 31 Mar 2011
 """
 
+import matplotlib.pyplot as plt
+
 import pytest
 
-from control import StateSpace, nichols_plot, nichols
+from control import StateSpace, nichols_plot, nichols, nichols_grid, pade, tf
 
 
 @pytest.fixture()
@@ -26,3 +28,73 @@ def test_nichols(tsys, mplcleanup):
 def test_nichols_alias(tsys, mplcleanup):
     """Test the control.nichols alias and the grid=False parameter"""
     nichols(tsys, grid=False)
+
+
+class TestNicholsGrid:
+    def test_ax(self):
+        # check grid is plotted into gca, or specified axis
+        fig, axs = plt.subplots(2,2)
+        plt.sca(axs[0,1])
+
+        cl_mag_lines = nichols_grid()[1]
+        assert cl_mag_lines[0].axes is axs[0, 1]
+
+        cl_mag_lines = nichols_grid(ax=axs[1,1])[1]
+        assert cl_mag_lines[0].axes is axs[1, 1]
+        # nichols_grid didn't change what the "current axes" are
+        assert plt.gca() is axs[0, 1]
+
+
+    def test_cl_phase_label_control(self):
+        # test label_cl_phases argument
+        plt.clf()
+        cl_mag_lines, cl_phase_lines, cl_mag_labels, cl_phase_labels \
+            = nichols_grid()
+        assert len(cl_phase_labels) > 0
+
+        plt.clf()
+        cl_mag_lines, cl_phase_lines, cl_mag_labels, cl_phase_labels \
+            = nichols_grid(label_cl_phases=False)
+        assert len(cl_phase_labels) == 0
+
+
+    def test_labels_clipped(self):
+        # regression test: check that contour labels are clipped
+        plt.clf()
+        mcontours, ncontours, mlabels, nlabels = nichols_grid()
+        assert all(ml.get_clip_on() for ml in mlabels)
+        assert all(nl.get_clip_on() for nl in nlabels)
+
+
+    def test_minimal_phase(self):
+        # regression test: phase extent is minimal
+        g = tf([1],[1,1]) * tf([1],[1/1, 2*0.1/1, 1])
+        plt.clf()
+        nichols(g)
+        ax = plt.gca()
+        assert ax.get_xlim()[1] <= 0
+
+
+    def test_fixed_view(self):
+        # respect xlim, ylim set by user
+        g = (tf([1],[1/1, 2*0.01/1, 1])
+             * tf([1],[1/100**2, 2*0.001/100, 1])
+             * tf(*pade(0.01, 5)))
+
+        # normally a broad axis
+        plt.clf()
+        m, p = nichols(g)
+
+        assert(plt.xlim()[0] == -1440)
+        assert(plt.ylim()[0] <= -240)
+
+        plt.clf()
+        nichols(g, grid=False)
+
+        # zoom in
+        plt.axis([-360,0,-40,50])
+
+        # nichols_grid doesn't expand limits
+        nichols_grid()
+        assert(plt.xlim()[0] == -360)
+        assert(plt.ylim()[1] >= -40)

--- a/control/tests/nichols_test.py
+++ b/control/tests/nichols_test.py
@@ -30,6 +30,7 @@ def test_nichols_alias(tsys, mplcleanup):
     nichols(tsys, grid=False)
 
 
+@pytest.mark.usefixtures("mplcleanup")
 class TestNicholsGrid:
     def test_ax(self):
         # check grid is plotted into gca, or specified axis
@@ -47,12 +48,10 @@ class TestNicholsGrid:
 
     def test_cl_phase_label_control(self):
         # test label_cl_phases argument
-        plt.clf()
         cl_mag_lines, cl_phase_lines, cl_mag_labels, cl_phase_labels \
             = nichols_grid()
         assert len(cl_phase_labels) > 0
 
-        plt.clf()
         cl_mag_lines, cl_phase_lines, cl_mag_labels, cl_phase_labels \
             = nichols_grid(label_cl_phases=False)
         assert len(cl_phase_labels) == 0
@@ -60,7 +59,6 @@ class TestNicholsGrid:
 
     def test_labels_clipped(self):
         # regression test: check that contour labels are clipped
-        plt.clf()
         mcontours, ncontours, mlabels, nlabels = nichols_grid()
         assert all(ml.get_clip_on() for ml in mlabels)
         assert all(nl.get_clip_on() for nl in nlabels)
@@ -69,7 +67,6 @@ class TestNicholsGrid:
     def test_minimal_phase(self):
         # regression test: phase extent is minimal
         g = tf([1],[1,1]) * tf([1],[1/1, 2*0.1/1, 1])
-        plt.clf()
         nichols(g)
         ax = plt.gca()
         assert ax.get_xlim()[1] <= 0
@@ -82,13 +79,11 @@ class TestNicholsGrid:
              * tf(*pade(0.01, 5)))
 
         # normally a broad axis
-        plt.clf()
         nichols(g)
 
         assert(plt.xlim()[0] == -1440)
         assert(plt.ylim()[0] <= -240)
 
-        plt.clf()
         nichols(g, grid=False)
 
         # zoom in

--- a/control/tests/nichols_test.py
+++ b/control/tests/nichols_test.py
@@ -83,7 +83,7 @@ class TestNicholsGrid:
 
         # normally a broad axis
         plt.clf()
-        m, p = nichols(g)
+        nichols(g)
 
         assert(plt.xlim()[0] == -1440)
         assert(plt.ylim()[0] <= -240)


### PR DESCRIPTION
These are relatively minor updates to the Nichols chart (AKA grid) plotting.

It's far from ideal; further possible improvements:
   - more tightly fitting the chart to the view (or data) xlim and ylim (the "extent"); the pain here is figuring out which contours to plot, and where to place the labels
     - depending on the limits, some contours will end up with a two visible segments
   - recreating the axis on zoom and pan events
     - this might not be *too* difficult; Axes [support `'xlim_changed'` and `'ylim_changed'`](https://matplotlib.org/stable/api/axes_api.html#the-axes-class) events
   - a deluxe version of this would be too add (secondary?) axes, and show the closed-loop gain and phase in the "data value" text (the "x= <num>, y = <num>" on the Matplotlib toolbar)
   - I wonder if we could use a custom `ContourSet`s, and plug into however that labelling is done?

Here are some before-and-after pictures (left is before) of a few example systems.

The new code gives a better result in almost all respects.  One visible problem is that the closed-loop phase label for "0°" clashes with the "-40dB" (and similar) closed-loop gain label.  The gains become crowded when the gain span is large (final figure), but that is the same in both versions.

I haven't added tests; I'll see how much time I have to do that.  Easyish tests:
   - check for "tight" phase limits (see first example below)
   - check that the axes child text elements are have clip_on (I'd have to not check title  & tick labels, presume this is possible)
   - check for existence of phase labels, contingent on label_cl_phases flag
   - test both branches of the `if` in `_inner_extents`, and in fact test the behaviour in general by setting xlim & ylim before calling nichols_grid.
Please suggest other tests.

![example1](https://user-images.githubusercontent.com/110974/163677566-a9570b79-b107-42bb-9036-a1e07312818c.png)
![example2](https://user-images.githubusercontent.com/110974/163677571-4f689842-ed6f-4725-ba49-06344d6571c0.png)
![example3](https://user-images.githubusercontent.com/110974/163677572-f66c4c56-76a2-46dd-bddb-a2d8ce67dc2e.png)
![example4](https://user-images.githubusercontent.com/110974/163677574-9d7a8128-a412-4f7d-a7f1-7a4ee1416f48.png)

## Details (commit message)

Clip closed-loop contour labels.

Add labels for constant closed-loop phase contours.

Use smaller of data or view extents when deciding on how big, in
phase, a chart to create.

Use more uniformly spaced closed-loop phase contours, and use more
widely-spaced contours when phase extent is large.

Add optional `ax` argument, for axes to add grid to.