### PR TITLE
ENH: add `linform` to compute linear system L-infinity norm

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -55,6 +55,7 @@ from numpy.random import rand, randn
 from numpy.linalg import solve, eigvals, matrix_rank
 from numpy.linalg.linalg import LinAlgError
 import scipy as sp
+import scipy.linalg
 from scipy.signal import cont2discrete
 from scipy.signal import StateSpace as signalStateSpace
 from warnings import warn
@@ -63,7 +64,12 @@ from .namedio import _NamedIOStateSystem, _process_signal_list
 from . import config
 from copy import deepcopy
 
-__all__ = ['StateSpace', 'tf2ss', 'ssdata']
+try:
+    from slycot import ab13dd
+except ImportError:
+    ab13dd = None
+
+__all__ = ['StateSpace', 'tf2ss', 'ssdata', 'linfnorm']
 
 # Define module default parameter values
 _statesp_defaults = {
@@ -1888,3 +1894,61 @@ def ssdata(sys):
     """
     ss = _convert_to_statespace(sys)
     return ss.A, ss.B, ss.C, ss.D
+
+
+def linfnorm(sys, tol=1e-10):
+    """L-infinity norm of a linear system
+
+    Parameters
+    ----------
+    sys : LTI (StateSpace or TransferFunction)
+      system to evalute L-infinity norm of
+    tol : real scalar
+      tolerance on norm estimate
+
+    Returns
+    -------
+    gpeak : non-negative scalar
+      L-infinity norm
+    fpeak : non-negative scalar
+      Frequency, in rad/s, at which gpeak occurs
+
+    For stable systems, the L-infinity and H-infinity norms are equal;
+    for unstable systems, the H-infinity norm is infinite, while the
+    L-infinity norm is finite if the system has no poles on the
+    imaginary axis.
+
+    See also
+    --------
+    slycot.ab13dd : the Slycot routine linfnorm that does the calculation
+    """
+
+    if ab13dd is None:
+        raise ControlSlycot("Can't find slycot module 'ab13dd'")
+
+    a, b, c, d = ssdata(_convert_to_statespace(sys))
+    e = np.eye(a.shape[0])
+
+    n = a.shape[0]
+    m = b.shape[1]
+    p = c.shape[0]
+
+    if n == 0:
+        # ab13dd doesn't accept empty A, B, C, D;
+        # static gain case is easy enough to compute
+        gpeak = scipy.linalg.svdvals(d)[0]
+        # max svd is constant with freq; arbitrarily choose 0 as peak
+        fpeak = 0
+        return gpeak, fpeak
+
+    dico = 'C' if sys.isctime() else 'D'
+    jobe = 'I'
+    equil = 'S'
+    jobd = 'Z' if all(0 == d.flat) else 'D'
+
+    gpeak, fpeak = ab13dd(dico, jobe, equil, jobd, n, m, p, a, e, b, c, d, tol)
+
+    if dico=='D':
+        fpeak /= sys.dt
+
+    return gpeak, fpeak

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -19,12 +19,14 @@ from control.config import defaults
 from control.dtime import sample_system
 from control.lti import evalfr
 from control.statesp import StateSpace, _convert_to_statespace, tf2ss, \
-    _statesp_defaults, _rss_generate
+    _statesp_defaults, _rss_generate, linfnorm
 from control.iosys import ss, rss, drss
 from control.tests.conftest import ismatarrayout, slycotonly
 from control.xferfcn import TransferFunction, ss2tf
 
+
 from .conftest import editsdefaults
+
 
 class TestStateSpace:
     """Tests for the StateSpace class."""
@@ -1097,3 +1099,52 @@ def test_latex_repr_testsize(editsdefaults):
 
     gstatic = ss([], [], [], 1)
     assert gstatic._repr_latex_() is None
+
+
+class TestLinfnorm:
+    # these are simple tests; we assume ab13dd is correct
+    # python-control specific behaviour is:
+    #   - checking for continuous- and discrete-time
+    #   - scaling fpeak for discrete-time
+    #   - handling static gains
+
+    # the underdamped gpeak and fpeak are found from
+    #   gpeak = 1/(2*zeta*(1-zeta**2)**0.5)
+    #   fpeak = wn*(1-2*zeta**2)**0.5
+    @pytest.fixture(params=[
+        ('static', ct.tf, ([1.23],[1]), 1.23, 0),
+        ('underdamped', ct.tf, ([100],[1, 2*0.5*10, 100]), 1.1547005, 7.0710678),
+        ])
+    def ct_siso(self, request):
+        name, systype, sysargs, refgpeak, reffpeak = request.param
+        return systype(*sysargs), refgpeak, reffpeak
+
+    @pytest.fixture(params=[
+        ('underdamped', ct.tf, ([100],[1, 2*0.5*10, 100]), 1e-4, 1.1547005, 7.0710678),
+        ])
+    def dt_siso(self, request):
+        name, systype, sysargs, dt, refgpeak, reffpeak = request.param
+        return ct.c2d(systype(*sysargs), dt), refgpeak, reffpeak
+
+    @slycotonly
+    def test_linfnorm_ct_siso(self, ct_siso):
+        sys, refgpeak, reffpeak = ct_siso
+        gpeak, fpeak = linfnorm(sys)
+        np.testing.assert_allclose(gpeak, refgpeak)
+        np.testing.assert_allclose(fpeak, reffpeak)
+
+    @slycotonly
+    def test_linfnorm_dt_siso(self, dt_siso):
+        sys, refgpeak, reffpeak = dt_siso
+        gpeak, fpeak = linfnorm(sys)
+        # c2d pole-mapping has round-off
+        np.testing.assert_allclose(gpeak, refgpeak)
+        np.testing.assert_allclose(fpeak, reffpeak)
+
+    @slycotonly
+    def test_linfnorm_ct_mimo(self, ct_siso):
+        siso, refgpeak, reffpeak = ct_siso
+        sys = ct.append(siso, siso)
+        gpeak, fpeak = linfnorm(sys)
+        np.testing.assert_allclose(gpeak, refgpeak)
+        np.testing.assert_allclose(fpeak, reffpeak)


### PR DESCRIPTION
linfnorm requires Slycot routine ab13dd, which does the actual work.

Added tests for SISO and MIMO continuous- and discrete-time.  MIMO
reference values are generated by `linfnorm` itself, but results have
been reviewed graphically for correctness.

The MIMO tests rely, unfortunately, on circular logic: the very function being tested has been used to generate test data.  I could scour the various textbooks I have for independent examples, but I'm more-or-less assuming that SLICOT's `AB13DD` is correct, and the tests are to make sure no gross errors have occurred in wrapping.  I've tried to cover the various possible cases of gpeak finite (but non-zero) and infinite, and fpeak 0, finite and non-zero, and infinite.  I just realized I haven't checked for gpeak = 0; I'll add that (system would have to be non-minimal, or be a static gain of 0; I'll try the former first).

Below are the MIMO test cases for review; everything looks OK to me.  The left-hand figures are continuous-time, the right-hand discrete time.

While doing this rather hacky test-generation, I found that `StateSpace`'s `repr` is not `eval`-able; this is due, in turn, to `numpy.ndarray`'s `repr` not being `eval`-able.  I don't know why that is, but I monkey-patched `StateSpace.__repr__` to address this.  This new `repr` *is* `eval`-able, and I think looks a little better too (look in `linfnorm_mimo_testcases.py` for examples).

![gdamped](https://user-images.githubusercontent.com/110974/164982137-7dc3fd70-3692-4b21-a25e-4d889c9b0c02.png)
![ghigh](https://user-images.githubusercontent.com/110974/164982147-9d10105f-4a79-4807-bd1b-c9d8fe84ab41.png)
![gint](https://user-images.githubusercontent.com/110974/164982149-91db67ba-464b-46ba-899a-e6fb390918cc.png)
![gstatic](https://user-images.githubusercontent.com/110974/164982153-69e88d57-1945-4cf9-8a4c-87a92f83c2c6.png)
![gun](https://user-images.githubusercontent.com/110974/164982155-52f46816-5451-44df-b54a-a6c45eb3f7ca.png)
![gunder](https://user-images.githubusercontent.com/110974/164982158-5b183234-2dae-43b7-8cf9-439dd519256e.png)


