### PR TITLE
update python-package-conda workflow to use conda instead of conda-forge

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -38,13 +38,12 @@ jobs:
         pip install coveralls
 
         # Install python-control dependencies
-        # use conda-forge until https://github.com/numpy/numpy/issues/20233 is resolved
-        conda install -c conda-forge numpy matplotlib scipy
+        conda install numpy matplotlib scipy
         if [[ '${{matrix.slycot}}' == 'conda' ]]; then
           conda install -c conda-forge slycot
         fi
         if [[ '${{matrix.pandas}}' == 'conda' ]]; then
-          conda install -c conda-forge pandas
+          conda install pandas
         fi
 
     - name: Test with pytest


### PR DESCRIPTION
This fixes issue #735 by using conda to install `scipy` and dependencies instead of conda-forge.