### PR TITLE
fix README.rst for twine

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ operations for analysis and design of feedback control systems.
 
 
 Have a go now!
-======
+==============
 Try out the examples in the examples folder using the binder service.
 
 .. image:: https://mybinder.org/badge_logo.svg


### PR DESCRIPTION
Twine generated an error because of the formatting of README.rst, which prevented me from doing a release.  Fixed here.