### PR TITLE
CI: switch slycot and cvxopt installation order

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -50,14 +50,14 @@ jobs:
     - name: Install optional dependencies
       shell: bash -l {0}
       run: |
+        if [[ '${{matrix.cvxopt}}' == 'conda' ]]; then
+          mamba install cvxopt
+        fi
         if [[ '${{matrix.slycot}}' == 'conda' ]]; then
           mamba install slycot
         fi
         if [[ '${{matrix.pandas}}' == 'conda' ]]; then
           mamba install pandas
-        fi
-        if [[ '${{matrix.cvxopt}}' == 'conda' ]]; then
-          mamba install cvxopt
         fi
 
     - name: Test with pytest


### PR DESCRIPTION
This PR attempts to fix issue #761 by switching the order of installation of CVXOPT and Slycot.  In testing so far, the `python-package-conda.yml` tests have functioned without random failures.
