### PR TITLE
fix to insure that when a StateSpace and a LinearIOSystem are combined, the result is a LinearIOSystem

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -149,6 +149,7 @@ class InputOutputSystem(NamedIOSystem):
 
         # default parameters
         self.params = params.copy()
+        self._current_params = self.params.copy()
 
     def __mul__(sys2, sys1):
         """Multiply two input/output systems (series interconnection)"""
@@ -804,7 +805,7 @@ class NonlinearIOSystem(InputOutputSystem):
             f"Output: {self.outfcn}"
 
     # Return the value of a static nonlinear system
-    def __call__(sys, u, params=None, squeeze=None):
+    def __call__(sys, u, params={}, squeeze=None):
         """Evaluate a (static) nonlinearity at a given input value
 
         If a nonlinear I/O system has no internal state, then evaluating the
@@ -830,12 +831,8 @@ class NonlinearIOSystem(InputOutputSystem):
                 "function evaluation is only supported for static "
                 "input/output systems")
 
-        # If we received any parameters, update them before calling _out()
-        if params is not None:
-            sys._update_params(params)
-
         # Evaluate the function on the argument
-        out = sys._out(0, np.array((0,)), np.asarray(u))
+        out = sys._out(0, np.array((0,)), np.asarray(u), params)
         _, out = _process_time_response(
             None, out, issiso=sys.issiso(), squeeze=squeeze)
         return out

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -680,16 +680,16 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
             warn("Parameters passed to LinearIOSystems are ignored.")
 
     def _rhs(self, t, x, u, params={}):
-        # Convert input to column vector and then change output to 1D array
-        xdot = self.A @ np.reshape(x, (-1, 1)) \
+        # Convert input to column vector in case A, B are numpy matrix
+        output = self.A @ np.reshape(x, (-1, 1)) \
                + self.B @ np.reshape(u, (-1, 1))
-        return np.array(xdot).reshape((-1,))
+        return np.array(output).reshape((-1,)) # change output to 1D array
 
     def _out(self, t, x, u, params={}):
-        # Convert input to column vector and then change output to 1D array
+        # Convert input to column vector in case A, B are numpy matrix
         y = self.C @ np.reshape(x, (-1, 1)) \
             + self.D @ np.reshape(u, (-1, 1))
-        return np.array(y).reshape((-1,))
+        return np.array(y).reshape((-1,)) # change output to 1D array
 
     def __repr__(self):
         # Need to define so that I/O system gets used instead of StateSpace

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -679,17 +679,9 @@ class LinearIOSystem(InputOutputSystem, StateSpace):
         if params and warning:
             warn("Parameters passed to LinearIOSystems are ignored.")
 
-    def _rhs(self, t, x, u, params={}):
-        # Convert input to column vector in case A, B are numpy matrix
-        output = self.A @ np.reshape(x, (-1, 1)) \
-               + self.B @ np.reshape(u, (-1, 1))
-        return np.array(output).reshape((-1,)) # change output to 1D array
-
-    def _out(self, t, x, u, params={}):
-        # Convert input to column vector in case A, B are numpy matrix
-        y = self.C @ np.reshape(x, (-1, 1)) \
-            + self.D @ np.reshape(u, (-1, 1))
-        return np.array(y).reshape((-1,)) # change output to 1D array
+    # inherit methods as necessary
+    _rhs = StateSpace._rhs
+    _out = StateSpace._out
 
     def __repr__(self):
         # Need to define so that I/O system gets used instead of StateSpace

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -346,9 +346,8 @@ class StateSpace(LTI):
             defaults = args[0] if len(args) == 1 else \
                 {'inputs': D.shape[1], 'outputs': D.shape[0],
                  'states': A.shape[0]}
-            static = (A.size == 0)
             name, inputs, outputs, states, dt = _process_namedio_keywords(
-                kwargs, defaults, static=static, end=True)
+                kwargs, defaults, static=self._isstatic(), end=True)
 
             # Initialize LTI (NamedIOSystem) object
             super().__init__(

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -386,7 +386,7 @@ class StateSpace(LTI):
         # Check for states that don't do anything, and remove them
         if remove_useless_states:
             self._remove_useless_states()
-        # params for compatibility with LinearICSystems
+        # params for compatibility with LinearIOSystems
         self.params = {} 
         self._current_params = self.params.copy() 
 

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -66,6 +66,10 @@ class TestIOSys:
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y, atol=0.002, rtol=0.)
 
+        # Make sure that a combination of a LinearIOSystem and a StateSpace 
+        # system results in a LinearIOSystem
+        assert isinstance(linsys*iosys, ios.LinearIOSystem) 
+
     def test_tf2io(self, tsys):
         # Create a transfer function from the state space system
         linsys = tsys.siso_linsys

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -41,6 +41,9 @@ class TestIOSys:
             [[-1, 1], [0, -2]], [[0, 1], [1, 0]],
             [[1, 0], [0, 1]], np.zeros((2, 2)))
 
+        # Create a static gain linear system
+        T.staticgain = ct.StateSpace(0, 0, 0, 1)
+
         # Create simulation parameters
         T.T = np.linspace(0, 10, 100)
         T.U = np.sin(T.T)
@@ -69,6 +72,12 @@ class TestIOSys:
         # Make sure that a combination of a LinearIOSystem and a StateSpace 
         # system results in a LinearIOSystem
         assert isinstance(linsys*iosys, ios.LinearIOSystem) 
+
+        # Make sure that a static linear system has dt=None 
+        # and otherwise dt is as specified
+        assert ios.LinearIOSystem(tsys.staticgain).dt is None
+        assert ios.LinearIOSystem(tsys.staticgain, dt=.1).dt == .1
+
 
     def test_tf2io(self, tsys):
         # Create a transfer function from the state space system


### PR DESCRIPTION
Previously, when a `StateSpace` and a `LinearIOSystem` were combined, the result was not a `LinearICSystem` because `StateSpace` systems did not have `_rhs` and `_out` methods that could be used to re-linearize the system. This has been fixed. 