### PR TITLE
Fix interconnect type conversion bug for StateSpace systems

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -376,16 +376,17 @@ class InputOutputSystem(NamedIOSystem):
         right hand side of the dynamical system. If the system is continuous,
         returns the time derivative
 
-            dx/dt = f(t, x, u)
+            dx/dt = f(t, x, u, params)
 
         where `f` is the system's (possibly nonlinear) dynamics function.
         If the system is discrete-time, returns the next value of `x`:
 
-            x[t+dt] = f(t, x[t], u[t])
+            x[t+dt] = f(t, x[t], u[t], params)
 
-        Where `t` is a scalar.
+        where `t` is a scalar.
 
-        The inputs `x` and `u` must be of the correct length.
+        The inputs `x` and `u` must be of the correct length.  The `params`
+        argument is an optional dictionary of parameter values.
 
         Parameters
         ----------
@@ -395,6 +396,8 @@ class InputOutputSystem(NamedIOSystem):
             current state
         u : array_like
             input
+        params : dict (optional)
+            system parameter values
 
         Returns
         -------
@@ -421,7 +424,7 @@ class InputOutputSystem(NamedIOSystem):
         Given time `t`, input `u` and state `x`, returns the output of the
         system:
 
-            y = g(t, x, u)
+            y = g(t, x, u[, params])
 
         The inputs `x` and `u` must be of the correct length.
 
@@ -433,6 +436,8 @@ class InputOutputSystem(NamedIOSystem):
             current state
         u : array_like
             input
+        params : dict (optional)
+            system parameter values
 
         Returns
         -------

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -894,6 +894,12 @@ class InterconnectedSystem(InputOutputSystem):
 
         # Go through the system list and keep track of counts, offsets
         for sysidx, sys in enumerate(syslist):
+            # If we were passed a SS or TF system, convert to LinearIOSystem
+            if isinstance(sys, (StateSpace, TransferFunction)) and \
+               not isinstance(sys, LinearIOSystem):
+                sys = LinearIOSystem(sys)
+                syslist[sysidx] = sys
+
             # Make sure time bases are consistent
             dt = common_timebase(dt, sys.dt)
 
@@ -1781,7 +1787,7 @@ def input_output_response(
 
     # Update the parameter values
     sys._update_params(params)
-    
+
     #
     # Define a function to evaluate the input at an arbitrary time
     #

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -357,7 +357,7 @@ class InputOutputSystem(NamedIOSystem):
         if warning:
             warn("Parameters passed to InputOutputSystem ignored.")
 
-    def _rhs(self, t, x, u, params={}):
+    def _rhs(self, t, x, u):
         """Evaluate right hand side of a differential or difference equation.
 
         Private function used to compute the right hand side of an
@@ -369,7 +369,7 @@ class InputOutputSystem(NamedIOSystem):
         NotImplemented("Evaluation not implemented for system of type ",
                        type(self))
 
-    def dynamics(self, t, x, u):
+    def dynamics(self, t, x, u, params={}):
         """Compute the dynamics of a differential or difference equation.
 
         Given time `t`, input `u` and state `x`, returns the value of the
@@ -400,9 +400,10 @@ class InputOutputSystem(NamedIOSystem):
         -------
         dx/dt or x[t+dt] : ndarray
         """
+        self._update_params(params)
         return self._rhs(t, x, u)
 
-    def _out(self, t, x, u, params={}):
+    def _out(self, t, x, u):
         """Evaluate the output of a system at a given state, input, and time
 
         Private function used to compute the output of of an input/output
@@ -414,7 +415,7 @@ class InputOutputSystem(NamedIOSystem):
         # If no output function was defined in subclass, return state
         return x
 
-    def output(self, t, x, u):
+    def output(self, t, x, u, params={}):
         """Compute the output of the system
 
         Given time `t`, input `u` and state `x`, returns the output of the
@@ -437,6 +438,7 @@ class InputOutputSystem(NamedIOSystem):
         -------
         y : ndarray
         """
+        self._update_params(params)
         return self._out(t, x, u)
 
     def feedback(self, other=1, sign=-1, params={}):
@@ -2248,7 +2250,7 @@ def ss(*args, **kwargs):
         Convert a linear system into space system form. Always creates a
         new system, even if sys is already a state space system.
 
-    ``ss(updfcn, outfucn)``
+    ``ss(updfcn, outfcn)``
         Create a nonlinear input/output system with update function ``updfcn``
         and output function ``outfcn``.  See :class:`NonlinearIOSystem` for
         more information.

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -376,12 +376,12 @@ class InputOutputSystem(NamedIOSystem):
         right hand side of the dynamical system. If the system is continuous,
         returns the time derivative
 
-            dx/dt = f(t, x, u, params)
+            dx/dt = f(t, x, u[, params])
 
         where `f` is the system's (possibly nonlinear) dynamics function.
         If the system is discrete-time, returns the next value of `x`:
 
-            x[t+dt] = f(t, x[t], u[t], params)
+            x[t+dt] = f(t, x[t], u[t][, params])
 
         where `t` is a scalar.
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1389,7 +1389,7 @@ class StateSpace(LTI):
         """
         return self._dcgain(warn_infinite)
 
-    def dynamics(self, t, x, u=None):
+    def dynamics(self, t, x, u=None, params=None):
         """Compute the dynamics of the system
 
         Given input `u` and state `x`, returns the dynamics of the state-space
@@ -1423,6 +1423,9 @@ class StateSpace(LTI):
         dx/dt or x[t+dt] : ndarray
 
         """
+        if params is not None:
+            warn("params keyword ignored for StateSpace object")
+
         x = np.reshape(x, (-1, 1))  # force to a column in case matrix
         if np.size(x) != self.nstates:
             raise ValueError("len(x) must be equal to number of states")
@@ -1435,7 +1438,7 @@ class StateSpace(LTI):
             return (self.A @ x).reshape((-1,)) \
                 + (self.B @ u).reshape((-1,))  # return as row vector
 
-    def output(self, t, x, u=None):
+    def output(self, t, x, u=None, params=None):
         """Compute the output of the system
 
         Given input `u` and state `x`, returns the output `y` of the
@@ -1465,6 +1468,9 @@ class StateSpace(LTI):
         -------
         y : ndarray
         """
+        if params is not None:
+            warn("params keyword ignored for StateSpace object")
+
         x = np.reshape(x, (-1, 1))  # force to a column in case matrix
         if np.size(x) != self.nstates:
             raise ValueError("len(x) must be equal to number of states")

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -1158,3 +1158,15 @@ class TestLinfnorm:
         gpeak, fpeak = linfnorm(sys)
         np.testing.assert_allclose(gpeak, refgpeak)
         np.testing.assert_allclose(fpeak, reffpeak)
+
+
+# Make sure that using params for StateSpace objects generates a warning
+def test_params_warning():
+    sys = StateSpace(-1, 1, 1, 0)
+
+    with pytest.warns(UserWarning, match="params keyword ignored"):
+        sys.dynamics(0, [0], [0], {'k': 5})
+
+    with pytest.warns(UserWarning, match="params keyword ignored"):
+        sys.output(0, [0], [0], {'k': 5})
+

--- a/control/tests/type_conversion_test.py
+++ b/control/tests/type_conversion_test.py
@@ -19,7 +19,9 @@ def sys_dict():
     sdict['frd'] = ct.frd([10+0j, 9 + 1j, 8 + 2j, 7 + 3j], [1, 2, 3, 4])
     sdict['lio'] = ct.LinearIOSystem(ct.ss([[-1]], [[5]], [[5]], [[0]]))
     sdict['ios'] = ct.NonlinearIOSystem(
-        sdict['lio']._rhs, sdict['lio']._out, inputs=1, outputs=1, states=1)
+        lambda t, x, u, params: sdict['lio']._rhs(t, x, u),
+        lambda t, x, u, params: sdict['lio']._out(t, x, u),
+        inputs=1, outputs=1, states=1)
     sdict['arr'] = np.array([[2.0]])
     sdict['flt'] = 3.
     return sdict
@@ -226,4 +228,12 @@ def test_interconnect(
             result = ct.interconnect(syslist, connections, inplist, outlist)
     else:
             result = ct.interconnect(syslist, connections, inplist, outlist)
+
+            # Make sure the type is correct
             assert isinstance(result, type_dict[expected])
+
+            # Make sure we can evaluate the dynamics
+            np.testing.assert_equal(
+                result.dynamics(
+                    0, np.zeros(result.nstates), np.zeros(result.ninputs)),
+                np.zeros(result.nstates))


### PR DESCRIPTION
This PR fixes a problem that was identified in PR #785, where interconnecting a `LinearIOSystem` with a `StateSpace` system via the `interconnect` function did not work correctly.  In particular, if you created a mixed system of this type you would get back an `InterconnectedSystem` that would generate an error is you tried to simulate it or evaluate the dynamics.  This was fixed by adding a few lines of code to `interconnect()` that convert `StateSpace` and `TransferFunction` objects to `LinearIOSystems`, mimicking what is done with operator overloading.

In addition, there was a bug where the `param` keyword was not allowed in the `dynamics` and `output` functions.  This is now fixed and tested with a unit test.