### PR TITLE
fix _isstatic() to use nstates==0

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -326,7 +326,7 @@ class StateSpace(LTI):
             D = np.zeros((C.shape[0], B.shape[1]))
         D = _ssmatrix(D)
 
-        # Matrices definining the linear system
+        # Matrices defining the linear system
         self.A = A
         self.B = B
         self.C = C
@@ -346,9 +346,8 @@ class StateSpace(LTI):
             defaults = args[0] if len(args) == 1 else \
                 {'inputs': D.shape[1], 'outputs': D.shape[0],
                  'states': A.shape[0]}
-            static = (A.size == 0)
             name, inputs, outputs, states, dt = _process_namedio_keywords(
-                kwargs, defaults, static=static, end=True)
+                kwargs, defaults, static=(A.size == 0), end=True)
 
             # Initialize LTI (NamedIOSystem) object
             super().__init__(
@@ -1477,11 +1476,6 @@ class StateSpace(LTI):
                 raise ValueError("len(u) must be equal to number of inputs")
             return (self.C @ x).reshape((-1,)) \
                 + (self.D @ u).reshape((-1,))  # return as row vector
-
-    def _isstatic(self):
-        """True if and only if the system has no dynamics, that is,
-        if A and B are zero. """
-        return not np.any(self.A) and not np.any(self.B)
 
 
 # TODO: add discrete time check

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -41,6 +41,9 @@ class TestIOSys:
             [[-1, 1], [0, -2]], [[0, 1], [1, 0]],
             [[1, 0], [0, 1]], np.zeros((2, 2)))
 
+        # Create a static gain linear system
+        T.staticgain = ct.StateSpace([], [], [], 1)
+
         # Create simulation parameters
         T.T = np.linspace(0, 10, 100)
         T.U = np.sin(T.T)
@@ -51,7 +54,7 @@ class TestIOSys:
     def test_linear_iosys(self, tsys):
         # Create an input/output system from the linear system
         linsys = tsys.siso_linsys
-        iosys = ios.LinearIOSystem(linsys)
+        iosys = ios.LinearIOSystem(linsys).copy()
 
         # Make sure that the right hand side matches linear system
         for x, u in (([0, 0], 0), ([1, 0], 0), ([0, 1], 0), ([0, 0], 1)):
@@ -65,6 +68,11 @@ class TestIOSys:
         ios_t, ios_y = ios.input_output_response(iosys, T, U, X0)
         np.testing.assert_array_almost_equal(lti_t, ios_t)
         np.testing.assert_allclose(lti_y, ios_y, atol=0.002, rtol=0.)
+
+        # Make sure that a static linear system has dt=None
+        # and otherwise dt is as specified
+        assert ios.LinearIOSystem(tsys.staticgain).dt is None
+        assert ios.LinearIOSystem(tsys.staticgain, dt=.1).dt == .1
 
     def test_tf2io(self, tsys):
         # Create a transfer function from the state space system


### PR DESCRIPTION
This PR fixes the issues identified in PR #785 regarding the way that `StateSpace._isstatic` was defining a static system.  New version requires `nstates == 0`.