### PR TITLE
check for and fix mutable keyword defaults

### DIFF
--- a/control/flatsys/flatsys.py
+++ b/control/flatsys/flatsys.py
@@ -142,7 +142,7 @@ class FlatSystem(NonlinearIOSystem):
                  forward, reverse,              # flat system
                  updfcn=None, outfcn=None,      # I/O system
                  inputs=None, outputs=None,
-                 states=None, params={}, dt=None, name=None):
+                 states=None, params=None, dt=None, name=None):
         """Create a differentially flat I/O system.
 
         The FlatIOSystem constructor is used to create an input/output system
@@ -171,7 +171,7 @@ class FlatSystem(NonlinearIOSystem):
             + f"Forward: {self.forward}\n" \
             + f"Reverse: {self.reverse}"
 
-    def forward(self, x, u, params={}):
+    def forward(self, x, u, params=None):
 
         """Compute the flat flag given the states and input.
 
@@ -200,7 +200,7 @@ class FlatSystem(NonlinearIOSystem):
         """
         raise NotImplementedError("internal error; forward method not defined")
 
-    def reverse(self, zflag, params={}):
+    def reverse(self, zflag, params=None):
         """Compute the states and input given the flat flag.
 
         Parameters
@@ -224,18 +224,18 @@ class FlatSystem(NonlinearIOSystem):
         """
         raise NotImplementedError("internal error; reverse method not defined")
 
-    def _flat_updfcn(self, t, x, u, params={}):
+    def _flat_updfcn(self, t, x, u, params=None):
         # TODO: implement state space update using flat coordinates
         raise NotImplementedError("update function for flat system not given")
 
-    def _flat_outfcn(self, t, x, u, params={}):
+    def _flat_outfcn(self, t, x, u, params=None):
         # Return the flat output
         zflag = self.forward(x, u, params)
         return np.array([zflag[i][0] for i in range(len(zflag))])
 
 
 # Utility function to compute flag matrix given a basis
-def _basis_flag_matrix(sys, basis, flag, t, params={}):
+def _basis_flag_matrix(sys, basis, flag, t):
     """Compute the matrix of basis functions and their derivatives
 
     This function computes the matrix ``M`` that is used to solve for the

--- a/control/flatsys/linflat.py
+++ b/control/flatsys/linflat.py
@@ -142,11 +142,11 @@ class LinearFlatSystem(FlatSystem, LinearIOSystem):
         return np.reshape(x, self.nstates), np.reshape(u, self.ninputs)
 
     # Update function
-    def _rhs(self, t, x, u, params={}):
+    def _rhs(self, t, x, u):
         # Use LinearIOSystem._rhs instead of default (MRO) NonlinearIOSystem
         return LinearIOSystem._rhs(self, t, x, u)
 
     # output function
-    def _out(self, t, x, u, params={}):
+    def _out(self, t, x, u):
         # Use LinearIOSystem._out instead of default (MRO) NonlinearIOSystem
         return LinearIOSystem._out(self, t, x, u)

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -1584,7 +1584,7 @@ class LinearICSystem(InterconnectedSystem, LinearIOSystem):
 def input_output_response(
         sys, T, U=0., X0=0, params=None,
         transpose=False, return_x=False, squeeze=None,
-        solve_ivp_kwargs={}, t_eval='T', **kwargs):
+        solve_ivp_kwargs=None, t_eval='T', **kwargs):
     """Compute the output response of a system to a given input.
 
     Simulate a dynamical system with a given input and return its output
@@ -1650,7 +1650,7 @@ def input_output_response(
     solve_ivp_method : str, optional
         Set the method used by :func:`scipy.integrate.solve_ivp`.  Defaults
         to 'RK45'.
-    solve_ivp_kwargs : str, optional
+    solve_ivp_kwargs : dict, optional
         Pass additional keywords to :func:`scipy.integrate.solve_ivp`.
 
     Raises
@@ -1676,6 +1676,7 @@ def input_output_response(
     #
 
     # Figure out the method to be used
+    solve_ivp_kwargs = solve_ivp_kwargs.copy() if solve_ivp_kwargs else {}
     if kwargs.get('solve_ivp_method', None):
         if kwargs.get('method', None):
             raise ValueError("ivp_method specified more than once")


### PR DESCRIPTION
This PR adds a check for keyword arguments in all functions that are initialized to mutables and fixes a few errors that were found.  Setting keyword defaults to mutables is still allowed by listing the function in a table.  This should help introduction of errors if a mutable is used as a default keyword in future updates.
