### PR TITLE
Fixes for bugs found by pylint

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -366,8 +366,8 @@ class InputOutputSystem(NamedIOSystem):
         you may want to use :meth:`dynamics`.
 
         """
-        NotImplemented("Evaluation not implemented for system of type ",
-                       type(self))
+        raise NotImplementedError("Evaluation not implemented for system of type ",
+                                  type(self))
 
     def dynamics(self, t, x, u, params=None):
         """Compute the dynamics of a differential or difference equation.

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -476,7 +476,7 @@ def markov(Y, U, m=None, transpose=False):
 
     # Make sure there is enough data to compute parameters
     if m > n:
-        warn.warning("Not enough data for requested number of parameters")
+        warnings.warn("Not enough data for requested number of parameters")
 
     #
     # Original algorithm (with mapping to standard order)

--- a/control/optimal.py
+++ b/control/optimal.py
@@ -20,8 +20,6 @@ from . import config
 from .exception import ControlNotImplemented
 from .timeresp import TimeResponseData
 
-__all__ = ['find_optimal_input']
-
 # Define module default parameter values
 _optimal_defaults = {
     'optimal.minimize_method': None,

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -59,6 +59,8 @@ import scipy.linalg
 from scipy.signal import cont2discrete
 from scipy.signal import StateSpace as signalStateSpace
 from warnings import warn
+
+from .exception import ControlSlycot
 from .frdata import FrequencyResponseData
 from .lti import LTI, _process_frequency_response
 from .namedio import common_timebase, isdtime

--- a/control/tests/optimal_test.py
+++ b/control/tests/optimal_test.py
@@ -381,17 +381,8 @@ def test_optimal_logging(capsys):
 @pytest.mark.parametrize("fun, args, exception, match", [
     [opt.quadratic_cost, (np.zeros((2, 3)), np.eye(2)), ValueError,
      "Q matrix is the wrong shape"],
-    [opt.quadratic_cost, (np.eye(2), 1), ValueError,
+    [opt.quadratic_cost, (np.eye(2), np.eye(2, 3)), ValueError,
      "R matrix is the wrong shape"],
-])
-def test_constraint_constructor_errors(fun, args, exception, match):
-    """Test various error conditions for constraint constructors"""
-    sys = ct.ss2io(ct.rss(2, 2, 2))
-    with pytest.raises(exception, match=match):
-        fun(sys, *args)
-
-
-@pytest.mark.parametrize("fun, args, exception, match", [
     [opt.input_poly_constraint, (np.zeros((2, 3)), [0, 0]), ValueError,
      "polytope matrix must match number of inputs"],
     [opt.output_poly_constraint, (np.zeros((2, 3)), [0, 0]), ValueError,


### PR DESCRIPTION
I found these with [pylint](https://pylint.pycqa.org).

See also rory/pylint for two pylint-specific commits if you want to run this yourself; I used `pylint -E control` to run pylint, with `-E` disabling all but the most serious of warnings.

On rory/pylint, pylint still reports all of these as errors; some are false positives (e.g.,  "invalid-unary-operand-type"), and others are stylistic (e.g., "self as first argument"), but I haven't investigated every single one.

We could consider incorporating pylint, but we'd obviously have to do more work configuring it.

```
pylint -E control
************* Module control.iosys
control/iosys.py:153:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:203:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:222:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:260:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:279:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:317:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:336:4: E0213: Method should have "self" as first argument (no-self-argument)
control/iosys.py:809:4: E0213: Method should have "self" as first argument (no-self-argument)
************* Module control.mateqn
control/mateqn.py:182:51: E1130: bad operand type for unary -: NoneType (invalid-unary-operand-type)
control/mateqn.py:185:31: E1130: bad operand type for unary -: NoneType (invalid-unary-operand-type)
************* Module control.sisotool
control/sisotool.py:305:22: E1130: bad operand type for unary -: NoneType (invalid-unary-operand-type)
control/sisotool.py:305:22: E1130: bad operand type for unary -: NoneType (invalid-unary-operand-type)
************* Module control.passivity
control/passivity.py:150:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:150:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:150:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:152:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:152:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:152:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:154:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:154:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/passivity.py:154:24: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
************* Module control.descfcn
control/descfcn.py:388:58: E1130: bad operand type for unary -: NoneType (invalid-unary-operand-type)
************* Module control.statefbk
control/statefbk.py:768:27: E1130: bad operand type for unary -: NoneType (invalid-unary-operand-type)
************* Module control.freqplot
control/freqplot.py:1043:27: E1130: bad operand type for unary -: MaskedArray (invalid-unary-operand-type)
control/freqplot.py:1046:20: E1130: bad operand type for unary -: MaskedArray (invalid-unary-operand-type)
************* Module control.lti
control/lti.py:119:16: E1101: Instance of 'LTI' has no 'poles' member; maybe 'pole'? (no-member)
control/lti.py:188:19: E1101: Instance of 'LTI' has no '__call__' member (no-member)
control/lti.py:198:19: E1102: self is not callable (not-callable)
control/lti.py:217:15: E1101: Instance of 'LTI' has no 'poles' member; maybe 'pole'? (no-member)
control/lti.py:222:15: E1101: Instance of 'LTI' has no 'zeros' member; maybe 'zero'? (no-member)
************* Module control.optimal
control/optimal.py:307:40: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:324:49: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:329:39: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:428:50: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:430:37: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:441:46: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:443:33: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:513:50: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:515:37: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:526:46: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/optimal.py:528:33: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
************* Module control.exception
control/exception.py:94:12: E0401: Unable to import 'cvxopt' (import-error)
************* Module control.tests.matlab_test
control/tests/matlab_test.py:366:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/matlab_test.py:367:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/matlab_test.py:368:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
************* Module control.tests.xferfcn_test
control/tests/xferfcn_test.py:448:39: E1101: Instance of 'TransferFunction' has no 'evalfr' member (no-member)
************* Module control.tests.iosys_test
control/tests/iosys_test.py:533:52: E1130: bad operand type for unary -: tuple (invalid-unary-operand-type)
control/tests/iosys_test.py:1796:35: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
************* Module control.tests.optimal_test
control/tests/optimal_test.py:174:8: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/optimal_test.py:619:12: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/optimal_test.py:620:12: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/optimal_test.py:621:11: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
************* Module control.tests.matlab2_test
control/tests/matlab2_test.py:142:16: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/matlab2_test.py:172:16: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/matlab2_test.py:267:8: E1101: Instance of 'TestControlMatlab' has no 'assertRaises' member (no-member)
control/tests/matlab2_test.py:272:8: E1101: Instance of 'TestControlMatlab' has no 'assertRaises' member (no-member)
control/tests/matlab2_test.py:325:8: E1101: Instance of 'TestControlMatlab' has no 'assertRaises' member (no-member)
control/tests/matlab2_test.py:325:38: E1123: Unexpected keyword argument 'x0' in function call (unexpected-keyword-arg)
control/tests/matlab2_test.py:330:8: E1101: Instance of 'TestControlMatlab' has no 'assertRaises' member (no-member)
control/tests/matlab2_test.py:330:37: E1123: Unexpected keyword argument 'x0' in function call (unexpected-keyword-arg)
control/tests/matlab2_test.py:333:8: E1101: Instance of 'TestControlMatlab' has no 'assertRaises' member (no-member)
control/tests/matlab2_test.py:333:38: E1123: Unexpected keyword argument 'x0' in function call (unexpected-keyword-arg)
control/tests/matlab2_test.py:335:8: E1101: Instance of 'TestControlMatlab' has no 'assertRaises' member (no-member)
control/tests/matlab2_test.py:335:38: E1123: Unexpected keyword argument 'x0' in function call (unexpected-keyword-arg)
************* Module control.tests.robust_test
control/tests/robust_test.py:86:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:88:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:105:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:122:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:143:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:149:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:173:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:174:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:175:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:176:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:288:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:289:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:290:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
control/tests/robust_test.py:291:31: E1130: bad operand type for unary -: list (invalid-unary-operand-type)
************* Module control.tests.timeresp_test
control/tests/timeresp_test.py:355:38: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:355:48: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:356:38: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:356:51: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:421:36: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/timeresp_test.py:521:45: E1126: Sequence index is not an int, slice, or instance with __index__ (invalid-sequence-index)
control/tests/timeresp_test.py:923:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:924:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:924:36: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:926:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:926:33: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:976:15: E1101: Instance of 'tuple' has no 'ndim' member (no-member)
control/tests/timeresp_test.py:977:15: E1101: Instance of 'tuple' has no 'ndim' member (no-member)
control/tests/timeresp_test.py:978:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:978:26: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1022:23: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1024:23: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1035:23: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1037:23: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1047:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1057:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1076:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1093:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1098:19: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1142:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1167:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1168:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1169:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1174:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1175:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
control/tests/timeresp_test.py:1176:15: E1101: Instance of 'tuple' has no 'shape' member (no-member)
************* Module control.tests.input_element_int_test
control/tests/input_element_int_test.py:66:40: E1101: Instance of 'finfo' has no 'epsneg' member (no-member)
************* Module control.flatsys.flatsys
control/flatsys/flatsys.py:174:4: E0202: An attribute defined in control.flatsys.flatsys line 163 hides this method (method-hidden)
control/flatsys/flatsys.py:203:4: E0202: An attribute defined in control.flatsys.flatsys line 164 hides this method (method-hidden)
```

