### PR TITLE
Support Python 3.11 and drop Python 3.7

### DIFF
--- a/.github/workflows/control-slycot-src.yml
+++ b/.github/workflows/control-slycot-src.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         path: python-control
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
     - name: Install Python dependencies and test tools
       run: pip install -v -e './python-control[test]'
 

--- a/.github/workflows/control-slycot-src.yml
+++ b/.github/workflows/control-slycot-src.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
     - name: Install Python dependencies and test tools
-      run: pip install -v -e './python-control[test]'
+      run: pip install -v './python-control[test]'
 
     - name: Checkout Slycot
       uses: actions/checkout@v3

--- a/.github/workflows/control-slycot-src.yml
+++ b/.github/workflows/control-slycot-src.yml
@@ -13,6 +13,8 @@ jobs:
         path: python-control
     - name: Set up Python
       uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - name: Install Python dependencies and test tools
       run: pip install -v './python-control[test]'
 

--- a/.github/workflows/install_examples.yml
+++ b/.github/workflows/install_examples.yml
@@ -3,7 +3,7 @@ name: Setup, Examples, Notebooks
 on: [push, pull_request]
 
 jobs:
-  build-linux:
+  install-examples:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.11']
         slycot: ["", "conda"]
         pandas: [""]
         cvxopt: ["", "conda"]

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -17,14 +17,14 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.11']
         slycot: ["", "conda"]
         pandas: [""]
         cvxopt: ["", "conda"]
         mplbackend: [""]
         array-and-matrix: [0]
         include:
-          - python-version: '3.10'
+          - python-version: '3.11'
             slycot: conda
             pandas: conda
             cvxopt: conda

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -3,7 +3,7 @@ name: Conda-based pytest
 on: [push, pull_request]
 
 jobs:
-  test-linux:
+  test-linux-conda:
     name: >
       Py${{ matrix.python-version }};
       ${{ matrix.slycot || 'no' }} Slycot;
@@ -75,7 +75,7 @@ jobs:
 
   coveralls:
     name: coveralls completion
-    needs: test-linux
+    needs: test-linux-conda
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -29,7 +28,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "scipy>=1.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
- Add Python 3.11 classifier to Python metadata
- Bump the testing to Python 3.11
- Bump some GitHub actions, avoids deprecation warnings