### PR TITLE
docstring improvements

### DIFF
--- a/control/dtime.py
+++ b/control/dtime.py
@@ -84,6 +84,14 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
     copy_names : bool, Optional
         If True, copy the names of the input signals, output
         signals, and states to the sampled system.
+
+    Returns
+    -------
+    sysd : linsys
+        Discrete time system, with sampling rate Ts
+
+    Other Parameters
+    ----------------
     inputs : int, list of str or None, optional
         Description of the system inputs.  If not specified, the origional
         system inputs are used.  See :class:`InputOutputSystem` for more
@@ -93,11 +101,6 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
     states : int, list of str, or None, optional
         Description of the system states.  Same format as `inputs`. Only
         available if the system is :class:`StateSpace`.
-
-    Returns
-    -------
-    sysd : linsys
-        Discrete time system, with sampling rate Ts
 
     Notes
     -----

--- a/control/dtime.py
+++ b/control/dtime.py
@@ -84,14 +84,6 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
     copy_names : bool, Optional
         If True, copy the names of the input signals, output
         signals, and states to the sampled system.
-
-    Returns
-    -------
-    sysd : linsys
-        Discrete time system, with sampling rate Ts
-
-    Additional Parameters
-    ---------------------
     inputs : int, list of str or None, optional
         Description of the system inputs.  If not specified, the origional
         system inputs are used.  See :class:`NamedIOSystem` for more
@@ -101,6 +93,11 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
     states : int, list of str, or None, optional
         Description of the system states.  Same format as `inputs`. Only
         available if the system is :class:`StateSpace`.
+
+    Returns
+    -------
+    sysd : linsys
+        Discrete time system, with sampling rate Ts
 
     Notes
     -----

--- a/control/dtime.py
+++ b/control/dtime.py
@@ -86,7 +86,7 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
         signals, and states to the sampled system.
     inputs : int, list of str or None, optional
         Description of the system inputs.  If not specified, the origional
-        system inputs are used.  See :class:`NamedIOSystem` for more
+        system inputs are used.  See :class:`InputOutputSystem` for more
         information.
     outputs : int, list of str or None, optional
         Description of the system outputs.  Same format as `inputs`.

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2203,15 +2203,6 @@ def linearize(sys, xeq, ueq=None, t=0, params=None, **kw):
     copy_names : bool, Optional
         If True, Copy the names of the input signals, output signals, and
         states to the linearized system.
-
-    Returns
-    -------
-    ss_sys : LinearIOSystem
-        The linearization of the system, as a :class:`~control.LinearIOSystem`
-        object (which is also a :class:`~control.StateSpace` object.
-
-    Additional Parameters
-    ---------------------
     inputs : int, list of str or None, optional
         Description of the system inputs.  If not specified, the origional
         system inputs are used.  See :class:`NamedIOSystem` for more
@@ -2220,6 +2211,12 @@ def linearize(sys, xeq, ueq=None, t=0, params=None, **kw):
         Description of the system outputs.  Same format as `inputs`.
     states : int, list of str, or None, optional
         Description of the system states.  Same format as `inputs`.
+
+    Returns
+    -------
+    ss_sys : LinearIOSystem
+        The linearization of the system, as a :class:`~control.LinearIOSystem`
+        object (which is also a :class:`~control.StateSpace` object.
 
     """
     if not isinstance(sys, InputOutputSystem):
@@ -2716,8 +2713,8 @@ def interconnect(syslist, connections=None, inplist=None, outlist=None,
     :func:`~control.summing_block` function and the ability to automatically
     interconnect signals with the same names:
 
-    >>> P = control.tf2io(control.tf(1, [1, 0]), inputs='u', outputs='y')
-    >>> C = control.tf2io(control.tf(10, [1, 1]), inputs='e', outputs='u')
+    >>> P = control.tf(1, [1, 0], inputs='u', outputs='y')
+    >>> C = control.tf(10, [1, 1], inputs='e', outputs='u')
     >>> sumblk = control.summing_junction(inputs=['r', '-y'], output='e')
     >>> T = control.interconnect([P, C, sumblk], inputs='r', outputs='y')
 

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2205,7 +2205,7 @@ def linearize(sys, xeq, ueq=None, t=0, params=None, **kw):
         states to the linearized system.
     inputs : int, list of str or None, optional
         Description of the system inputs.  If not specified, the origional
-        system inputs are used.  See :class:`NamedIOSystem` for more
+        system inputs are used.  See :class:`InputOutputSystem` for more
         information.
     outputs : int, list of str or None, optional
         Description of the system outputs.  Same format as `inputs`.

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2428,7 +2428,10 @@ def rss(states=1, outputs=1, inputs=1, strictly_proper=False, **kwargs):
 
 
 def drss(*args, **kwargs):
-    """Create a stable, discrete-time, random state space system
+    """
+    drss([states, outputs, inputs, strictly_proper])
+
+    Create a stable, discrete-time, random state space system
 
     Create a stable *discrete time* random state space object.  This
     function calls :func:`rss` using either the `dt` keyword provided by
@@ -2466,7 +2469,7 @@ ss2io.__doc__ = LinearIOSystem.__init__.__doc__
 
 # Convert a transfer function into an input/output system (wrapper)
 def tf2io(*args, **kwargs):
-    """tf2io(sys)
+    """tf2io(sys[, ...])
 
     Convert a transfer function into an I/O system
 

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2203,6 +2203,15 @@ def linearize(sys, xeq, ueq=None, t=0, params=None, **kw):
     copy_names : bool, Optional
         If True, Copy the names of the input signals, output signals, and
         states to the linearized system.
+
+    Returns
+    -------
+    ss_sys : LinearIOSystem
+        The linearization of the system, as a :class:`~control.LinearIOSystem`
+        object (which is also a :class:`~control.StateSpace` object.
+
+    Other Parameters
+    ----------------
     inputs : int, list of str or None, optional
         Description of the system inputs.  If not specified, the origional
         system inputs are used.  See :class:`InputOutputSystem` for more
@@ -2211,13 +2220,6 @@ def linearize(sys, xeq, ueq=None, t=0, params=None, **kw):
         Description of the system outputs.  Same format as `inputs`.
     states : int, list of str, or None, optional
         Description of the system states.  Same format as `inputs`.
-
-    Returns
-    -------
-    ss_sys : LinearIOSystem
-        The linearization of the system, as a :class:`~control.LinearIOSystem`
-        object (which is also a :class:`~control.StateSpace` object.
-
     """
     if not isinstance(sys, InputOutputSystem):
         raise TypeError("Can only linearize InputOutputSystem types")

--- a/control/mateqn.py
+++ b/control/mateqn.py
@@ -88,7 +88,9 @@ __all__ = ['lyap', 'dlyap', 'dare', 'care']
 
 
 def lyap(A, Q, C=None, E=None, method=None):
-    """X = lyap(A, Q) solves the continuous-time Lyapunov equation
+    """Solves the continuous-time Lyapunov equation
+
+    X = lyap(A, Q) solves
 
         :math:`A X + X A^T + Q = 0`
 
@@ -217,7 +219,9 @@ def lyap(A, Q, C=None, E=None, method=None):
 
 
 def dlyap(A, Q, C=None, E=None, method=None):
-    """dlyap(A, Q) solves the discrete-time Lyapunov equation
+    """Solves the discrete-time Lyapunov equation
+
+    X = dlyap(A, Q) solves
 
         :math:`A X A^T - X + Q = 0`
 
@@ -348,8 +352,9 @@ def dlyap(A, Q, C=None, E=None, method=None):
 
 def care(A, B, Q, R=None, S=None, E=None, stabilizing=True, method=None,
          A_s="A", B_s="B", Q_s="Q", R_s="R", S_s="S", E_s="E"):
-    """X, L, G = care(A, B, Q, R=None) solves the continuous-time
-    algebraic Riccati equation
+    """Solves the continuous-time algebraic Riccati equation
+
+    X, L, G = care(A, B, Q, R=None) solves
 
         :math:`A^T X + X A - X B R^{-1} B^T X + Q = 0`
 
@@ -505,8 +510,10 @@ def care(A, B, Q, R=None, S=None, E=None, stabilizing=True, method=None,
 
 def dare(A, B, Q, R, S=None, E=None, stabilizing=True, method=None,
          A_s="A", B_s="B", Q_s="Q", R_s="R", S_s="S", E_s="E"):
-    """X, L, G = dare(A, B, Q, R) solves the discrete-time algebraic Riccati
+    """Solves the discrete-time algebraic Riccati
     equation
+
+    X, L, G = dare(A, B, Q, R) solves
 
         :math:`A^T X A - X - A^T X B (B^T X B + R)^{-1} B^T X A + Q = 0`
 

--- a/control/matlab/__init__.py
+++ b/control/matlab/__init__.py
@@ -84,7 +84,7 @@ from ..margins import margin
 from ..rlocus import rlocus
 from ..dtime import c2d
 from ..sisotool import sisotool
-from ..stochsys import *
+from ..stochsys import lqe, dlqe
 
 # Functions that are renamed in MATLAB
 pole, zero = poles, zeros

--- a/control/matlab/__init__.py
+++ b/control/matlab/__init__.py
@@ -84,6 +84,7 @@ from ..margins import margin
 from ..rlocus import rlocus
 from ..dtime import c2d
 from ..sisotool import sisotool
+from ..stochsys import *
 
 # Functions that are renamed in MATLAB
 pole, zero = poles, zeros

--- a/control/matlab/timeresp.py
+++ b/control/matlab/timeresp.py
@@ -7,8 +7,7 @@ Note that the return arguments are different than in the standard control packag
 __all__ = ['step', 'stepinfo', 'impulse', 'initial', 'lsim']
 
 def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
-    '''
-    Step response of a linear system
+    '''Step response of a linear system
 
     If the system has multiple inputs or outputs (MIMO), one input has
     to be selected for the simulation.  Optionally, one output may be
@@ -20,19 +19,14 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
     ----------
     sys: StateSpace, or TransferFunction
         LTI system to simulate
-
     T: array-like or number, optional
         Time vector, or simulation time duration if a number (time vector is
         autocomputed if not given)
-
     X0: array-like or number, optional
         Initial condition (default = 0)
-
         Numbers are converted to constant arrays with the correct shape.
-
     input: int
         Index of the input that will be used in this simulation.
-
     output: int
         If given, index of the output that is returned by this simulation.
 
@@ -40,13 +34,10 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
     -------
     yout: array
         Response of the system
-
     T: array
         Time values of the output
-
     xout: array (if selected)
         Individual response of each x variable
-
 
 
     See Also
@@ -67,8 +58,7 @@ def step(sys, T=None, X0=0., input=0, output=None, return_x=False):
 
 def stepinfo(sysdata, T=None, yfinal=None, SettlingTimeThreshold=0.02,
              RiseTimeLimits=(0.1, 0.9)):
-    """
-    Step response characteristics (Rise time, Settling Time, Peak and others).
+    """Step response characteristics (Rise time, Settling Time, Peak and others)
 
     Parameters
     ----------
@@ -137,8 +127,7 @@ def stepinfo(sysdata, T=None, yfinal=None, SettlingTimeThreshold=0.02,
     return S
 
 def impulse(sys, T=None, X0=0., input=0, output=None, return_x=False):
-    '''
-    Impulse response of a linear system
+    '''Impulse response of a linear system
 
     If the system has multiple inputs or outputs (MIMO), one input has
     to be selected for the simulation.  Optionally, one output may be
@@ -150,19 +139,15 @@ def impulse(sys, T=None, X0=0., input=0, output=None, return_x=False):
     ----------
     sys: StateSpace, TransferFunction
         LTI system to simulate
-
     T: array-like or number, optional
         Time vector, or simulation time duration if a number (time vector is
         autocomputed if not given)
-
     X0: array-like or number, optional
         Initial condition (default = 0)
 
         Numbers are converted to constant arrays with the correct shape.
-
     input: int
         Index of the input that will be used in this simulation.
-
     output: int
         Index of the output that will be used in this simulation.
 
@@ -170,10 +155,8 @@ def impulse(sys, T=None, X0=0., input=0, output=None, return_x=False):
     -------
     yout: array
         Response of the system
-
     T: array
         Time values of the output
-
     xout: array (if selected)
         Individual response of each x variable
 
@@ -193,8 +176,7 @@ def impulse(sys, T=None, X0=0., input=0, output=None, return_x=False):
     return (out[1], out[0], out[2]) if return_x else (out[1], out[0])
 
 def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
-    '''
-    Initial condition response of a linear system
+    '''Initial condition response of a linear system
 
     If the system has multiple outputs (?IMO), optionally, one output
     may be selected. If no selection is made for the output, all
@@ -204,20 +186,16 @@ def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
     ----------
     sys: StateSpace, or TransferFunction
         LTI system to simulate
-
     T: array-like or number, optional
         Time vector, or simulation time duration if a number (time vector is
         autocomputed if not given)
-
     X0: array-like object or number, optional
         Initial condition (default = 0)
 
         Numbers are converted to constant arrays with the correct shape.
-
     input: int
         This input is ignored, but present for compatibility with step
         and impulse.
-
     output: int
         If given, index of the output that is returned by this simulation.
 
@@ -225,10 +203,8 @@ def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
     -------
     yout: array
         Response of the system
-
     T: array
         Time values of the output
-
     xout: array (if selected)
         Individual response of each x variable
 
@@ -250,8 +226,7 @@ def initial(sys, T=None, X0=0., input=None, output=None, return_x=False):
 
 
 def lsim(sys, U=0., T=None, X0=0.):
-    '''
-    Simulate the output of a linear system.
+    '''Simulate the output of a linear system
 
     As a convenience for parameters `U`, `X0`:
     Numbers (scalars) are converted to constant arrays with the correct shape.
@@ -261,16 +236,13 @@ def lsim(sys, U=0., T=None, X0=0.):
     ----------
     sys: LTI (StateSpace, or TransferFunction)
         LTI system to simulate
-
     U: array-like or number, optional
         Input array giving input at each time `T` (default = 0).
 
         If `U` is ``None`` or ``0``, a special algorithm is used. This special
         algorithm is faster than the general algorithm, which is used otherwise.
-
     T: array-like, optional for discrete LTI `sys`
         Time steps at which the input is defined; values must be evenly spaced.
-
     X0: array-like or number, optional
         Initial condition (default = 0).
 

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -178,8 +178,7 @@ ngrid.__doc__ = nichols_grid.__doc__
 
 
 def dcgain(*args):
-    '''
-    Compute the gain of the system in steady state.
+    '''Compute the gain of the system in steady state
 
     The function takes either 1, 2, 3, or 4 parameters:
 

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -209,10 +209,6 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
 
     C_f = Kp + Ki/s + Kd*s/(tau*s + 1).
 
-    If `plant` is a discrete-time system, then the proportional, integral, and
-    derivative terms are given instead by Kp, Ki*dt/2*(z+1)/(z-1), and
-    Kd/dt*(z-1)/z, respectively.
-
     ::
 
           ------> C_ff ------    d
@@ -223,6 +219,10 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
               |             |                 |
               |             ----- C_b <-------|
               ---------------------------------
+
+    If `plant` is a discrete-time system, then the proportional, integral, and
+    derivative terms are given instead by Kp, Ki*dt/2*(z+1)/(z-1), and
+    Kd/dt*(z-1)/z, respectively.
 
     It is also possible to move the derivative term into the feedback path
     `C_b` using `derivative_in_feedback_path=True`. This may be desired to

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1338,6 +1338,14 @@ class StateSpace(LTI):
         copy_names : bool, Optional
             If True, copy the names of the input signals, output
             signals, and states to the sampled system.
+
+        Returns
+        -------
+        sysd : StateSpace
+            Discrete-time system, with sampling rate Ts
+
+        Other Parameters
+        ----------------
         inputs : int, list of str or None, optional
             Description of the system inputs.  If not specified, the origional
             system inputs are used.  See :class:`InputOutputSystem` for more
@@ -1346,11 +1354,6 @@ class StateSpace(LTI):
             Description of the system outputs.  Same format as `inputs`.
         states : int, list of str, or None, optional
             Description of the system states.  Same format as `inputs`.
-
-        Returns
-        -------
-        sysd : StateSpace
-            Discrete-time system, with sampling rate Ts
 
         Notes
         -----

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -807,7 +807,7 @@ class StateSpace(LTI):
             "StateSpace.__rdiv__ is not implemented yet.")
 
     def __call__(self, x, squeeze=None, warn_infinite=True):
-        """Evaluate system's transfer function at complex frequency.
+        """Evaluate system's frequency response at complex frequencies.
 
         Returns the complex frequency response `sys(x)` where `x` is `s` for
         continuous-time systems and `z` for discrete-time systems.

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1338,14 +1338,6 @@ class StateSpace(LTI):
         copy_names : bool, Optional
             If True, copy the names of the input signals, output
             signals, and states to the sampled system.
-
-        Returns
-        -------
-        sysd : StateSpace
-            Discrete-time system, with sampling rate Ts
-
-        Additional Parameters
-        ---------------------
         inputs : int, list of str or None, optional
             Description of the system inputs.  If not specified, the origional
             system inputs are used.  See :class:`InputOutputSystem` for more
@@ -1354,6 +1346,11 @@ class StateSpace(LTI):
             Description of the system outputs.  Same format as `inputs`.
         states : int, list of str, or None, optional
             Description of the system states.  Same format as `inputs`.
+
+        Returns
+        -------
+        sysd : StateSpace
+            Discrete-time system, with sampling rate Ts
 
         Notes
         -----
@@ -1520,6 +1517,7 @@ class StateSpace(LTI):
 
 
 # TODO: add discrete time check
+# TODO: copy signal names
 def _convert_to_statespace(sys):
     """Convert a system to state space form (if needed).
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1130,20 +1130,17 @@ class TransferFunction(LTI):
         copy_names : bool, Optional
             If True, copy the names of the input signals, output
             signals, and states to the sampled system.
+        inputs : int, list of str or None, optional
+            Description of the system inputs.  If not specified, the origional
+            system inputs are used.  See :class:`InputOutputSystem` for more
+            information.
+        outputs : int, list of str or None, optional
+            Description of the system outputs.  Same format as `inputs`.
 
         Returns
         -------
         sysd : TransferFunction system
             Discrete-time system, with sample period Ts
-
-        Additional Parameters
-        ---------------------
-        inputs : int, list of str or None, optional
-            Description of the system inputs.  If not specified, the origional
-            system inputs are used.  See :class:`NamedIOSystem` for more
-            information.
-        outputs : int, list of str or None, optional
-            Description of the system outputs.  Same format as `inputs`.
 
         Notes
         -----

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1130,17 +1130,20 @@ class TransferFunction(LTI):
         copy_names : bool, Optional
             If True, copy the names of the input signals, output
             signals, and states to the sampled system.
+
+        Returns
+        -------
+        sysd : TransferFunction system
+            Discrete-time system, with sample period Ts
+
+        Other Parameters
+        ----------------
         inputs : int, list of str or None, optional
             Description of the system inputs.  If not specified, the origional
             system inputs are used.  See :class:`InputOutputSystem` for more
             information.
         outputs : int, list of str or None, optional
             Description of the system outputs.  Same format as `inputs`.
-
-        Returns
-        -------
-        sysd : TransferFunction system
-            Discrete-time system, with sample period Ts
 
         Notes
         -----
@@ -1582,7 +1585,7 @@ def tf(*args, **kwargs):
     else:
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
 
-
+# TODO: copy signal names
 def ss2tf(*args, **kwargs):
     """ss2tf(sys)
 

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -31,10 +31,10 @@ System interconnections
     append
     connect
     feedback
+    interconnect
     negate
     parallel
     series
-    interconnect
 
 
 Frequency domain plotting
@@ -80,8 +80,6 @@ Control system analysis
     dcgain
     describing_function
     frequency_response
-    TransferFunction.__call__
-    StateSpace.__call__
     get_input_ff_index
     get_output_fb_index
     ispassive
@@ -93,6 +91,8 @@ Control system analysis
     pzmap
     root_locus
     sisotool
+    StateSpace.__call__
+    TransferFunction.__call__
 
 
 
@@ -102,10 +102,10 @@ Matrix computations
    :toctree: generated/
 
     care
-    dare
-    lyap
-    dlyap
     ctrb
+    dare
+    dlyap
+    lyap
     obsv
     gram
 
@@ -116,10 +116,10 @@ Control system synthesis
 
     acker
     create_statefbk_iosystem
+    dlqr
     h2syn
     hinfsyn
     lqr
-    dlqr
     mixsyn
     place
     rootlocus_pid_designer
@@ -157,8 +157,8 @@ Stochastic system support
 
     correlation
     create_estimator_iosystem
-    lqe
     dlqe
+    lqe
     white_noise
 
 .. _utility-and-conversions:

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -116,10 +116,10 @@ Control system synthesis
 
     acker
     create_statefbk_iosystem
-    dlqr
     h2syn
     hinfsyn
     lqr
+    dlqr
     mixsyn
     place
     rootlocus_pid_designer
@@ -157,8 +157,8 @@ Stochastic system support
 
     correlation
     create_estimator_iosystem
-    dlqe
     lqe
+    dlqe
     white_noise
 
 .. _utility-and-conversions:
@@ -194,3 +194,5 @@ Utility functions and conversions
     use_fbs_defaults
     use_matlab_defaults
     use_numpy_matrix
+
+

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -20,6 +20,8 @@ System creation
     frd
     rss
     drss
+    NonlinearIOSystem
+
 
 System interconnections
 =======================
@@ -32,9 +34,8 @@ System interconnections
     negate
     parallel
     series
+    interconnect
 
-See also the :ref:`iosys-module` module, which can be used to create and
-interconnect nonlinear input/output systems.
 
 Frequency domain plotting
 =========================
@@ -78,8 +79,9 @@ Control system analysis
 
     dcgain
     describing_function
-    evalfr
-    freqresp
+    frequency_response
+    TransferFunction.__call__
+    StateSpace.__call__
     get_input_ff_index
     get_output_fb_index
     ispassive
@@ -141,7 +143,6 @@ Nonlinear system support
 
     describing_function
     find_eqpt
-    interconnect
     linearize
     input_output_response
     ss2io

--- a/doc/matlab.rst
+++ b/doc/matlab.rst
@@ -86,6 +86,9 @@ Compensator design
    sisotool
    place
    lqr
+   dlqr
+   lqe
+   dlqe
 
 State-space (SS) models
 =======================


### PR DESCRIPTION
Improvements needed when looking at the html function reference
* add `NonlinearIOSystem` to system creation section, `interconnect` to interconnection section
* remove `evalfr` and `freqresp` (they still live in matlab module). Replace them with `__call__` methods and `frequency_response` respectively. The former ends up being a bit verbose, I'm open to other ideas for how to present this.  
* updates `lyap` and `care` descriptions to be consistent with other functions
* misc other formatting and consistency issues in various functions