### PR TITLE
import and document zpk utility functions imported from scipy

### DIFF
--- a/control/__init__.py
+++ b/control/__init__.py
@@ -44,6 +44,9 @@ The Python Control Systems Library :mod:`control` provides common functions
 for analyzing and designing feedback control systems.
 """
 
+# Import MATLAB-like functions that are defined in other packages
+from scipy.signal import zpk2ss, ss2zpk, tf2zpk, zpk2tf
+
 # Import functions from within the control system library
 # Note: the functions we use are specified as __all__ variables in the modules
 from .bdalg import *

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -193,3 +193,13 @@ Utility functions and conversions
     use_fbs_defaults
     use_matlab_defaults
     use_numpy_matrix
+
+Functions imported from other modules
+=====================================
+.. autosummary::
+
+   ~scipy.signal.ss2zpk
+   ~scipy.signal.tf2zpk
+   ~scipy.signal.zpk2ss
+   ~scipy.signal.zpk2tf
+


### PR DESCRIPTION
This PR is a stopgap solution to #749. It imports zpk functionality from scipy so anybody who needs it will at least be able to find it in the main function reference and can use it to create their own `tf` or `ss` systems. Eventually these should be re-implemented to actually create control system objects. 

If people think it would be better to, as @bnavigator suggested, avoid backward compatibility issues and only bring these names in once they actually create control system objects, I'd be happy to close this PR and leave this as a future project. 