### PR TITLE
fix gain handling in rlocus and sisotool

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -97,6 +97,9 @@ def reset_defaults():
     from .rlocus import _rlocus_defaults
     defaults.update(_rlocus_defaults)
 
+    from .sisotool import _sisotool_defaults
+    defaults.update(_sisotool_defaults)
+
     from .namedio import _namedio_defaults
     defaults.update(_namedio_defaults)
 

--- a/control/matlab/wrappers.py
+++ b/control/matlab/wrappers.py
@@ -117,7 +117,7 @@ def nyquist(*args, **kwargs):
 def _parse_freqplot_args(*args):
     """Parse arguments to frequency plot routines (bode, nyquist)"""
     syslist, plotstyle, omega, other = [], [], None, {}
-    i = 0;
+    i = 0
     while i < len(args):
         # Check to see if this is a system of some sort
         if issys(args[i]):

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -9,6 +9,7 @@ from .iosys import ss
 from .bdalg import append, connect
 from .iosys import tf2io, ss2io, summing_junction, interconnect
 from control.statesp import _convert_to_statespace, StateSpace
+import numpy as np
 import matplotlib.pyplot as plt
 import warnings
 
@@ -101,6 +102,9 @@ def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
         'margins': margins_bode
     }
 
+    # make sure kvect is an array
+    if kvect is not None and ~hasattr(kvect, '__len__'):
+        kvect = np.atleast_1d(kvect)
     # First time call to setup the bode and step response plots
     _SisotoolUpdate(sys, fig,
         1 if kvect is None else kvect[0], bode_plot_params)

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -37,8 +37,13 @@ def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
         the step response. This allows you to see the step responses of more
         complex systems, for example, systems with a feedforward path into the
         plant or in which the gain appears in the feedback path.
-    kvect : list or ndarray, optional
-        List of gains to use for plotting root locus
+    kvect : float or array_like, optional
+        List of gains to use for plotting root locus. If only one value is
+        provided, the set of gains in the root locus plot is calculated
+        automatically, and kvect is interpreted as if it was the value of
+        the gain associated with the first mouse click on the root locus
+        plot. This is useful if it is not possible to use interactive
+        plotting.
     xlim_rlocus : tuple or list, optional
         control of x-axis range, normally with tuple
         (see :doc:`matplotlib:api/axes_api`).

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -29,14 +29,19 @@ def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
     sys : LTI object
         Linear input/output systems. If sys is SISO, use the same
         system for the root locus and step response. If it is desired to
-        see a different step response than feedback(K*loop,1), sys can be
-        provided as a two-input, two-output system (e.g. by using
-        :func:`bdgalg.connect' or :func:`iosys.interconnect`). Sisotool
-        inserts the negative of the selected gain K between the first output
-        and first input and uses the second input and output for computing
-        the step response. This allows you to see the step responses of more
-        complex systems, for example, systems with a feedforward path into the
-        plant or in which the gain appears in the feedback path.
+        see a different step response than feedback(K*sys,1), such as a
+        disturbance response, sys can be provided as a two-input, two-output
+        system (e.g. by using :func:`bdgalg.connect' or
+        :func:`iosys.interconnect`). For two-input, two-output
+        system, sisotool inserts the negative of the selected gain K between
+        the first output and first input and uses the second input and output
+        for computing the step response. To see the disturbance response,
+        configure your plant to have as its second input the disturbance input.
+        To view the step response with a feedforward controller, give your
+        plant two identical inputs, and sum your feedback controller and your
+        feedforward controller and multiply them into your plant's second
+        input. It is also possible to accomodate a system with a gain in the
+        feedback.
     kvect : float or array_like, optional
         List of gains to use for plotting root locus. If only one value is
         provided, the set of gains in the root locus plot is calculated
@@ -115,7 +120,7 @@ def sisotool(sys, kvect=None, xlim_rlocus=None, ylim_rlocus=None,
         1 if kvect is None else kvect[0], bode_plot_params)
 
     # Setup the root-locus plot window
-    root_locus(sys, kvect=kvect, xlim=xlim_rlocus,
+    root_locus(sys[0,0], kvect=kvect, xlim=xlim_rlocus,
         ylim=ylim_rlocus, plotstr=plotstr_rlocus, grid=rlocus_grid,
         fig=fig, bode_plot_params=bode_plot_params, tvect=tvect, sisotool=True)
 

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -117,7 +117,7 @@ def sisotool(sys, initial_gain=None, xlim_rlocus=None, ylim_rlocus=None,
     if kvect is not None:
         warnings.warn("'kvect' keyword is deprecated in sisotool; "
                       "use 'initial_gain' instead", FutureWarning)
-        initial_gain = np.atleast1d(kvect)[0]
+        initial_gain = np.atleast_1d(kvect)[0]
     initial_gain = config._get_param('sisotool', 'initial_gain',
             initial_gain, _sisotool_defaults)
 

--- a/control/tests/rlocus_test.py
+++ b/control/tests/rlocus_test.py
@@ -54,6 +54,12 @@ class TestRootLocus:
         np.testing.assert_allclose(klist, k_out)
         self.check_cl_poles(sys, roots, klist)
 
+        # now check with plotting
+        roots, k_out = root_locus(sys, klist)
+        np.testing.assert_equal(len(roots), len(klist))
+        np.testing.assert_allclose(klist, k_out)
+        self.check_cl_poles(sys, roots, klist)
+
     def test_without_gains(self, sys):
         roots, kvect = root_locus(sys, plot=False)
         self.check_cl_poles(sys, roots, kvect)

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -136,6 +136,16 @@ class TestSisotool:
                            bode_plot_params=dict(), tvect=tvect)
         assert_array_almost_equal(tvect, ax_step.lines[0].get_data()[0])
 
+    @pytest.mark.skipif(plt.get_current_fig_manager().toolbar is None,
+                        reason="Requires the zoom toolbar")
+    def test_sisotool_kvect(self, tsys):
+        # test supply kvect
+        kvect = np.linspace(0, 1, 10)
+        # check if it can receive an array
+        sisotool(tsys, kvect=kvect)
+        # check if it can receive a singleton
+        sisotool(tsys, kvect=1)
+
 
     def test_sisotool_mimo(self,  sys222, sys221):
         # a 2x2 should not raise an error:

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -138,14 +138,11 @@ class TestSisotool:
 
     @pytest.mark.skipif(plt.get_current_fig_manager().toolbar is None,
                         reason="Requires the zoom toolbar")
-    def test_sisotool_kvect(self, tsys):
-        # test supply kvect
-        kvect = np.linspace(0, 1, 10)
-        # check if it can receive an array
-        sisotool(tsys, kvect=kvect)
-        # check if it can receive a singleton
-        sisotool(tsys, kvect=1)
-
+    def test_sisotool_initial_gain(self, tsys):
+        sisotool(tsys, initial_gain=1.2)
+        # kvect keyword should give deprecation warning
+        with pytest.warns(FutureWarning):
+            sisotool(tsys, kvect=1.2)
 
     def test_sisotool_mimo(self,  sys222, sys221):
         # a 2x2 should not raise an error:


### PR DESCRIPTION
current problem is that if you want to pass an initial gain to `sisotool` to plot as starting point gain in the various plots, an error is raised if it is not an array. so you have to do `sisotool(sys, kvect=(1.1, ))` which is awkward. With this fix, <s>you can do `sisotool(sys, kvect=1.1)`</s> update: changed function call to look like `sisotool(sys, initial_gain=1.1)`