### PR TITLE
Small fixes and tweaks

### DIFF
--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -251,7 +251,9 @@ jobs:
           pip install slycot-wheels/${{ matrix.packagekey }}/slycot*.whl
           pip show slycot
       - name: Test with pytest
-        run: pytest -v control/tests
+        run: JOBNAME="$JOBNAME" pytest control/tests
+        env:
+          JOBNAME: wheel ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
 
 
   test-conda:
@@ -318,6 +320,6 @@ jobs:
           mamba install -c ./slycot-conda-pkgs slycot
           conda list
       - name: Test with pytest
-        run: JOBNAME=$JOBNAME pytest control/tests
+        run: JOBNAME="$JOBNAME" pytest control/tests
         env:
-          JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
+          JOBNAME: conda ${{ matrix.packagekey }} ${{ matrix.blas_lib }}

--- a/control/descfcn.py
+++ b/control/descfcn.py
@@ -74,7 +74,7 @@ class DescribingFunctionNonlinearity():
 
 def describing_function(
         F, A, num_points=100, zero_check=True, try_method=True):
-    """Numerical compute the describing function of a nonlinear function
+    """Numerically compute the describing function of a nonlinear function
 
     The describing function of a nonlinearity is given by magnitude and phase
     of the first harmonic of the function when evaluated along a sinusoidal

--- a/control/tests/flatsys_test.py
+++ b/control/tests/flatsys_test.py
@@ -210,7 +210,8 @@ class TestFlatSys:
                 pytest.xfail("precision loss in some configurations")
 
             elif re.match("Iteration limit.*", traj_ocp.message) and \
-                 re.match("ubuntu-3.* Generic", os.getenv('JOBNAME', '')) and \
+                 re.match(
+                     "conda ubuntu-3.* Generic", os.getenv('JOBNAME', '')) and \
                  np.__version__ == '1.24.0':
                 pytest.xfail("gh820: iteration limit exceeded")
 

--- a/control/tests/flatsys_test.py
+++ b/control/tests/flatsys_test.py
@@ -210,7 +210,7 @@ class TestFlatSys:
                 pytest.xfail("precision loss in some configurations")
 
             elif re.match("Iteration limit.*", traj_ocp.message) and \
-                 re.match("ubuntu-3.* Generic", os.getenv('JOBNAME')) and \
+                 re.match("ubuntu-3.* Generic", os.getenv('JOBNAME', '')) and \
                  np.__version__ == '1.24.0':
                 pytest.xfail("gh820: iteration limit exceeded")
 

--- a/control/tests/optimal_test.py
+++ b/control/tests/optimal_test.py
@@ -626,7 +626,7 @@ def test_equality_constraints():
         ('collocation', 5, 'u0', 'endpoint'),
         ('collocation', 5, 'input', 'openloop'),# open loop sim fails
         ('collocation', 10, 'input', None),
-        ('collocation', 10, 'u0', None),        # from documenentation
+        ('collocation', 10, 'u0', None),        # from documentation
         ('collocation', 10, 'state', None),
         ('collocation', 20, 'state', None),
     ])
@@ -716,9 +716,11 @@ def test_optimal_doc(method, npts, initial_guess, fail):
 
         # Make sure we started and stopped at the right spot
         if fail == 'endpoint':
+            assert not np.allclose(result.states[:, -1], xf, rtol=1e-4)
             pytest.xfail("optimization does not converge to endpoint")
         else:
             np.testing.assert_almost_equal(result.states[:, 0], x0, decimal=4)
+            np.testing.assert_almost_equal(result.states[:, -1], xf, decimal=2)
 
             # Simulate the trajectory to make sure it looks OK
             resp = ct.input_output_response(

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -642,7 +642,7 @@ class TimeResponseData:
     # Convert to pandas
     def to_pandas(self):
         if not pandas_check():
-            ImportError('pandas not installed')
+            raise ImportError("pandas not installed")
         import pandas
 
         # Create a dict for setting up the data frame


### PR DESCRIPTION
This PR has some small fixes and tweaks in preparation for release of control-0.9.3.  Nothing major:

* Fixed a few small typos/grammar errors in docstrings and comments
* Fixed improper call to an exception in `timeresp.py` (missing raise statement)
* Added quotes + build type for JOBNAME in `os-blas-test-matrix.yml`
* Added more careful checking of xfail for a case in `optimal_test.py`
