### PR TITLE
Add gain scheduling to create_statefbk_iosystem()

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -536,6 +536,10 @@ class InputOutputSystem(NamedIOSystem):
         # functions.
         #
 
+        # If x0 and u0 are specified as lists, concatenate the elements
+        x0 = _concatenate_list_elements(x0, 'x0')
+        u0 = _concatenate_list_elements(u0, 'u0')
+
         # Figure out dimensions if they were not specified.
         nstates = _find_size(self.nstates, x0)
         ninputs = _find_size(self.ninputs, u0)
@@ -1758,14 +1762,7 @@ def input_output_response(
     ninputs = U.shape[0]
 
     # If we were passed a list of initial states, concatenate them
-    if isinstance(X0, (tuple, list)):
-        X0_list = []
-        for i, x0 in enumerate(X0):
-            x0 = np.array(x0).reshape(-1)       # convert everyting to 1D array
-            X0_list += x0.tolist()              # add elements to initial state
-
-        # Save the newly created input vector
-        X0 = np.array(X0_list)
+    X0 = _concatenate_list_elements(X0, 'X0')
 
     # If the initial state is too short, make it longer (NB: sys.nstates
     # could be None if nstates comes from size of initial condition)
@@ -2376,6 +2373,19 @@ def ss(*args, **kwargs):
 
     return sys
 
+
+# Utility function to allow lists states, inputs
+def _concatenate_list_elements(X, name='X'):
+    # If we were passed a list, concatenate the elements together
+    if isinstance(X, (tuple, list)):
+        X_list = []
+        for i, x in enumerate(X):
+            x = np.array(x).reshape(-1)         # convert everyting to 1D array
+            X_list += x.tolist()                # add elements to initial state
+        return np.array(X_list)
+
+    # Otherwise, do nothing
+    return X
 
 def rss(states=1, outputs=1, inputs=1, strictly_proper=False, **kwargs):
     """Create a stable random state space object.

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -679,7 +679,7 @@ def create_statefbk_iosystem(
         the system state x (or state estimate xhat, if an estimator is
         given). The indices can either be specified as integer offsets into
         the input vector or as strings matching the signal names of the
-        input vector.
+        input vector. The default is to use the desire state xd.
 
     gainsched_method : str, optional
         The method to use for gain scheduling.  Possible values are 'linear'
@@ -812,8 +812,8 @@ def create_statefbk_iosystem(
 
     # Process gainscheduling variables, if present
     if gainsched:
-        # Create a copy of the scheduling variable indices (default = empty)
-        gainsched_indices = [] if gainsched_indices is None \
+        # Create a copy of the scheduling variable indices (default = xd)
+        gainsched_indices = range(sys.nstates) if gainsched_indices is None \
             else list(gainsched_indices)
 
         # Make sure the scheduling variable indices are the right length

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -676,17 +676,17 @@ def create_statefbk_iosystem(
         If a gain scheduled controller is specified, specify the indices of
         the controller input to use for scheduling the gain. The input to
         the controller is the desired state xd, the desired input ud, and
-        either the system state x or the system output y (if an estimator is
+        the system state x (or state estimate xhat, if an estimator is
         given). The indices can either be specified as integer offsets into
         the input vector or as strings matching the signal names of the
         input vector.
 
     gainsched_method : str, optional
-        The method to use for gain scheduling.  Possible values include
-        `linear` (default), `nearest`, and `cubic`.  More information is
-        available in :func:`scipy.interpolate.griddata`. For points outside
-        of the convex hull of the scheduling points, the gain at the nearest
-        point is used.
+        The method to use for gain scheduling.  Possible values are 'linear'
+        (default), 'nearest', and 'cubic'.  More information is available in
+        :func:`scipy.interpolate.griddata`. For points outside of the convex
+        hull of the scheduling points, the gain at the nearest point is
+        used.
 
     type : 'linear' or 'nonlinear', optional
         Set the type of controller to create. The default for a linear gain
@@ -700,20 +700,21 @@ def create_statefbk_iosystem(
     -------
     ctrl : InputOutputSystem
         Input/output system representing the controller.  This system takes
-        as inputs the desired state xd, the desired input ud, and either the
-        system state x or the estimated state xhat.  It outputs the
-        controller action u according to the formula u = ud - K(x - xd).  If
-        the keyword `integral_action` is specified, then an additional set
-        of integrators is included in the control system (with the gain
-        matrix K having the integral gains appended after the state gains).
-        If a gain scheduled controller is specified, the gain (proportional
-        and integral) are evaluated using the scheduling variables specified
-        by ``gainsched_indices``.
+        as inputs the desired state ``xd``, the desired input ``ud``, and
+        either the system state ``x`` or the estimated state ``xhat``.  It
+        outputs the controller action u according to the formula :math:`u =
+        u_d - K(x - x_d)`.  If the keyword ``integral_action`` is specified,
+        then an additional set of integrators is included in the control
+        system (with the gain matrix ``K`` having the integral gains
+        appended after the state gains).  If a gain scheduled controller is
+        specified, the gain (proportional and integral) are evaluated using
+        the scheduling variables specified by ``gainsched_indices``.
 
     clsys : InputOutputSystem
         Input/output system representing the closed loop system.  This
-        systems takes as inputs the desired trajectory (xd, ud) and outputs
-        the system state x and the applied input u (vertically stacked).
+        systems takes as inputs the desired trajectory ``(xd, ud)`` and
+        outputs the system state ``x`` and the applied input ``u``
+        (vertically stacked).
 
     Other Parameters
     ----------------

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1187,7 +1187,7 @@ class TestIOSys:
             assert "copy of namedsys.x0" in same_name_series.state_index
 
     def test_named_signals_linearize_inconsistent(self, tsys):
-        """Mare sure that providing inputs or outputs not consistent with
+        """Make sure that providing inputs or outputs not consistent with
            updfcn or outfcn fail
         """
 
@@ -1231,6 +1231,17 @@ class TestIOSys:
                        ([0, 0], [0, 0, 0])]:
             with pytest.raises(ValueError):
                 sys2.linearize(x0, u0)
+
+    def test_linearize_concatenation(self, kincar):
+        # Create a simple nonlinear system to check (kinematic car)
+        iosys = kincar
+        linearized = iosys.linearize([0, np.array([0, 0])], [0, 0])
+        np.testing.assert_array_almost_equal(linearized.A, np.zeros((3,3)))
+        np.testing.assert_array_almost_equal(
+            linearized.B, [[1, 0], [0, 0], [0, 1]])
+        np.testing.assert_array_almost_equal(
+            linearized.C, [[1, 0, 0], [0, 1, 0]])
+        np.testing.assert_array_almost_equal(linearized.D, np.zeros((2,2)))
 
     def test_lineariosys_statespace(self, tsys):
         """Make sure that a LinearIOSystem is also a StateSpace object"""

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -308,8 +308,12 @@ and the control action will be given by
   u = u_\text{d} - K\text{p} (x - x_\text{d}) -
       K_\text{i} \int C (x - x_\text{d}) dt.
 
-(If an estimator is specified, :math:`\hat x` will be used in place of
-:math:`x`.)
+If `integral_action` is a function `h`, that function will be called
+with the signature `h(t, x, u, params)` to obtain the outputs that
+should be integrated.  The number of outputs that are to be integrated
+must match the number of additional columns in the `K` matrix.  If an
+estimator is specified, :math:`\hat x` will be used in place of
+:math:`x`.
 
 Finally, gain scheduling on the desired state, desired input, or
 system state can be implemented by setting the gain to a 2-tuple

--- a/doc/steering-gainsched.rst
+++ b/doc/steering-gainsched.rst
@@ -1,3 +1,5 @@
+.. _steering-gainsched.py:
+
 Gain scheduled control for vehicle steeering (I/O system)
 ---------------------------------------------------------
 


### PR DESCRIPTION
This PR adds functionality to the `create_statefbk_iosystem` function, allowing it to be used to set up a simple gain scheduled controller.  From the documentation:

> Gain scheduling on the desired state, desired input, or system state can be implemented by setting the gain to a 2-tuple consisting of a list of gains and a list of points at which the gains
were computed, as well as a description of the scheduling variables
```
  ctrl, clsys = ct.create_statefbk_iosystem(
      sys, ([g1, ..., gN], [p1, ..., pN]), gainsched_indices=[s1, ..., sq])
```
> The list of indices can either be integers indicating the offset into the controller input vector or a list of strings matching the names of the input signals.

Example:
```
    # Create a simple nonlinear system to check (kinematic car)
    def unicycle_update(t, x, u, params):
        return np.array([np.cos(x[2]) * u[0], np.sin(x[2]) * u[0], u[1]])

    def unicycle_output(t, x, u, params):
        return x

    unicycle = ct.NonlinearIOSystem(
        unicycle_update, unicycle_output, inputs = ['v', 'phi'], 
        outputs = ['x', 'y', 'theta'], states = ['x_', 'y_', 'theta_'])

    # Speeds and angles at which to compute the gains
    speeds = [1, 5, 10]
    angles = np.linspace(0, pi/2, 4)
    points = list(itertools.product(speeds, angles))

    # Gains for each speed (using LQR controller)
    Q = np.identity(unicycle.nstates)
    R = np.identity(unicycle.ninputs)
    gains = [np.array(ct.lqr(unicycle.linearize(
        [0, 0, angle], [speed, 0]), Q, R)[0]) for speed, angle in points]

    #
    # Schedule on desired speed and angle
    #

    # Create gain scheduled controller
    ctrl, clsys = ct.create_statefbk_iosystem(
        unicycle, (gains, points), gainsched_indices=['vd', 'theta'])
```
Includes unit tests and documentation.