### PR TITLE
update docs to use use numpydoc + linkcode

### DIFF
--- a/control/descfcn.py
+++ b/control/descfcn.py
@@ -236,8 +236,8 @@ def describing_function_plot(
         given by the first value of the tuple and frequency given by the
         second value.
 
-    Example
-    -------
+    Examples
+    --------
     >>> H_simple = ct.tf([8], [1, 2, 2, 1])
     >>> F_saturation = ct.descfcn.saturation_nonlinearity(1)
     >>> amp = np.linspace(1, 4, 10)

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -589,8 +589,8 @@ def nyquist_plot(
         if `return_contour` is Tue.  To obtain the Nyquist curve values,
         evaluate system(s) along contour.
 
-    Additional Parameters
-    ---------------------
+    Other Parameters
+    ----------------
     arrows : int or 1D/2D array of floats, optional
         Specify the number of arrows to plot on the Nyquist curve.  If an
         integer is passed. that number of equally spaced arrows will be

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2713,8 +2713,8 @@ def interconnect(syslist, connections=None, inplist=None, outlist=None,
         generated and if `True` then warnings are always generated.
 
 
-    Example
-    -------
+    Examples
+    --------
     >>> P = control.LinearIOSystem(
     >>>        control.rss(2, 2, 2, strictly_proper=True), name='P')
     >>> C = control.LinearIOSystem(control.rss(2, 2, 2), name='C')
@@ -2914,8 +2914,8 @@ def summing_junction(
         Linear input/output system object with no states and only a direct
         term that implements the summing junction.
 
-    Example
-    -------
+    Examples
+    --------
     >>> P = control.tf2io(ct.tf(1, [1, 0]), inputs='u', outputs='y')
     >>> C = control.tf2io(ct.tf(10, [1, 1]), inputs='e', outputs='u')
     >>> sumblk = control.summing_junction(inputs=['r', '-y'], output='e')

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -1618,6 +1618,10 @@ def input_output_response(
         number of states in the system, the initial condition will be padded
         with zeros.
 
+    t_eval : array-list, optional
+        List of times at which the time response should be computed.
+        Defaults to ``T``.
+
     return_x : bool, optional
         If True, return the state vector when assigning to a tuple (default =
         False).  See :func:`forced_response` for more details.

--- a/control/lti.py
+++ b/control/lti.py
@@ -304,8 +304,12 @@ def damp(sys, doprint=True):
     poles: array
         Pole locations
 
-    Algorithm
-    ---------
+    See Also
+    --------
+    pole
+
+    Notes
+    -----
     If the system is continuous,
         wn = abs(poles)
         Z  = -real(poles)/poles.
@@ -320,9 +324,6 @@ def damp(sys, doprint=True):
         wn = abs(s)
         Z = -real(s)/wn.
 
-    See Also
-    --------
-    pole
     """
     wn, damping, poles = sys.damp()
     if doprint:

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -285,7 +285,7 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
         Whether to create Sisotool interactive plot.
 
     Returns
-    ----------
+    -------
     closedloop : class:`StateSpace` system
         The closed-loop system using initial gains.
 

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -126,10 +126,6 @@ def place(A, B, p):
     --------
     place_varga, acker
 
-    Notes
-    -----
-    The return type for 2D arrays depends on the default class set for
-    state space operations.  See :func:`~control.use_numpy_matrix`.
     """
     from scipy.signal import place_poles
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,5 +20,5 @@ classes.pdf: classes.fig;	fig2dev -Lpdf $< $@
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-html pdf: Makefile $(FIGS)
+html pdf clean: Makefile $(FIGS)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
This PR updates documentation to use the numpydoc extension and also adds the linkcode extension.  Include numpydoc seems to mainly check for consistency with NumPy documentation format, so it found a few inconsistencies that were fixed.  The linkcode extension adds a link to the source code for each function to GitHub.