### PR TITLE
remove __commit__ from version test

### DIFF
--- a/control/__init__.py
+++ b/control/__init__.py
@@ -79,7 +79,7 @@ from .exception import *
 
 # Version information
 try:
-    from ._version import __version__, __commit__
+    from ._version import __version__
 except ImportError:
     __version__ = "dev"
 


### PR DESCRIPTION
When I did the release for v0.9.3, I got `control.__version__` as 'dev'.  It looks like this occurred because we try to import `__commit__` from `control/_version.py` but that information is not actually included there by setuptools_scm.

I'll re-release with this change in a bit.
