### PR TITLE
Add README to pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ name = "control"
 description = "Python Control Systems Library"
 authors = [{name = "Python Control Developers", email = "python-control-developers@lists.sourceforge.net"}]
 license = {text = "BSD-3-Clause"}
+readme = "README.rst"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
https://pypi.org/project/control/0.9.3.post1/ shows an empty page.

Compare https://test.pypi.org/project/control/0.9.3.post2/ with the PR applied.