### PR TITLE
allow .postn for readthedocsversion

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -202,7 +202,7 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     base_url = "https://github.com/python-control/python-control/blob/"
-    if 'dev' in control.__version__ or 'post' in control.__version__:
+    if 'dev' in control.__version__:
         return base_url + "main/control/%s%s" % (fn, linespec)
     else:
         return base_url + "%s/control/%s%s" % (


### PR DESCRIPTION
Readthedocs was resorting to using the main branch if it saw 'post' in the version string, but we should use the specific version instead (otherwise pointers to source code will stop working as we update the main branch).
