### PR TITLE
Fix Interconnect name clobbering

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2840,17 +2840,17 @@ def interconnect(syslist, connections=None, inplist=None, outlist=None,
         # Check for signal names without a system name
         if isinstance(signal, str) and len(signal.split('.')) == 1:
             # Get the signal name
-            name = signal[1:] if signal[0] == '-' else signal
+            signal_name = signal[1:] if signal[0] == '-' else signal
             sign = '-' if signal[0] == '-' else ""
 
             # Look for the signal name as a system input
             for sys in syslist:
-                if name in sys.input_index.keys():
-                    connection.append(sign + sys.name + "." + name)
+                if signal_name in sys.input_index.keys():
+                    connection.append(sign + sys.name + "." + signal_name)
 
             # Make sure we found the name
             if len(connection) == 0:
-                raise ValueError("could not find signal %s" % name)
+                raise ValueError("could not find signal %s" % signal_name)
             else:
                 new_inplist.append(connection)
         else:
@@ -2868,17 +2868,17 @@ def interconnect(syslist, connections=None, inplist=None, outlist=None,
         # Check for signal names without a system name
         if isinstance(signal, str) and len(signal.split('.')) == 1:
             # Get the signal name
-            name = signal[1:] if signal[0] == '-' else signal
+            signal_name = signal[1:] if signal[0] == '-' else signal
             sign = '-' if signal[0] == '-' else ""
 
             # Look for the signal name as a system output
             for sys in syslist:
-                if name in sys.output_index.keys():
-                    connection.append(sign + sys.name + "." + name)
+                if signal_name in sys.output_index.keys():
+                    connection.append(sign + sys.name + "." + signal_name)
 
             # Make sure we found the name
             if len(connection) == 0:
-                raise ValueError("could not find signal %s" % name)
+                raise ValueError("could not find signal %s" % signal_name)
             else:
                 new_outlist.append(connection)
         else:

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1619,6 +1619,27 @@ def secord_output(t, x, u, params={}):
     return np.array([x[0]])
 
 
+def test_interconnect_name():
+    g = ct.LinearIOSystem(ct.ss(-1,1,1,0),
+                          inputs=['u'],
+                          outputs=['y'],
+                          name='g')
+    k = ct.LinearIOSystem(ct.ss(0,10,2,0),
+                          inputs=['e'],
+                          outputs=['z'],
+                          name='k')
+    h = ct.interconnect([g,k],
+                            inputs=['u','e'],
+                            outputs=['y','z'])
+    assert re.match(r'sys\[\d+\]', h.name), f"Interconnect default name does not match 'sys[]' pattern, got '{h.name}'"
+
+    h = ct.interconnect([g,k],
+                            inputs=['u','e'],
+                            outputs=['y','z'],
+                            name='ic_system')
+    assert h.name == 'ic_system', f"Interconnect name excpected 'ic_system', got '{h.name}'"
+
+
 def test_interconnect_unused_input():
     # test that warnings about unused inputs are reported, or not,
     # as required


### PR DESCRIPTION
iosys interconnect implementation clobbers the name argument of the function.
Fix by renaming to a name that is only used locally