### PR TITLE
fix blank bode plot in rootlocus_pid_designer

### DIFF
--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -22,8 +22,8 @@ def sisotool(sys, initial_gain=None, xlim_rlocus=None, ylim_rlocus=None,
              plotstr_rlocus='C0', rlocus_grid=False, omega=None, dB=None,
              Hz=None, deg=None, omega_limits=None, omega_num=None,
              margins_bode=True, tvect=None, kvect=None):
-    """
-    Sisotool style collection of plots inspired by MATLAB's sisotool.
+    """Sisotool style collection of plots inspired by MATLAB's sisotool.
+
     The left two plots contain the bode magnitude and phase diagrams.
     The top right plot is a clickable root locus plot, clicking on the
     root locus will change the gain of the system. The bottom left plot
@@ -32,52 +32,52 @@ def sisotool(sys, initial_gain=None, xlim_rlocus=None, ylim_rlocus=None,
     Parameters
     ----------
     sys : LTI object
-        Linear input/output systems. If sys is SISO, use the same
-        system for the root locus and step response. If it is desired to
-        see a different step response than feedback(K*sys,1), such as a
-        disturbance response, sys can be provided as a two-input, two-output
-        system (e.g. by using :func:`bdgalg.connect' or
-        :func:`iosys.interconnect`). For two-input, two-output
-        system, sisotool inserts the negative of the selected gain K between
-        the first output and first input and uses the second input and output
-        for computing the step response. To see the disturbance response,
-        configure your plant to have as its second input the disturbance input.
-        To view the step response with a feedforward controller, give your
-        plant two identical inputs, and sum your feedback controller and your
-        feedforward controller and multiply them into your plant's second
-        input. It is also possible to accomodate a system with a gain in the
-        feedback.
+        Linear input/output systems. If sys is SISO, use the same system for
+        the root locus and step response. If it is desired to see a different
+        step response than feedback(K*sys,1), such as a disturbance response,
+        sys can be provided as a two-input, two-output system (e.g. by using
+        :func:`bdgalg.connect' or :func:`iosys.interconnect`). For two-input,
+        two-output system, sisotool inserts the negative of the selected gain
+        K between the first output and first input and uses the second input
+        and output for computing the step response. To see the disturbance
+        response, configure your plant to have as its second input the
+        disturbance input.  To view the step response with a feedforward
+        controller, give your plant two identical inputs, and sum your
+        feedback controller and your feedforward controller and multiply them
+        into your plant's second input. It is also possible to accomodate a
+        system with a gain in the feedback.
     initial_gain : float, optional
         Initial gain to use for plotting root locus. Defaults to 1
         (config.defaults['sisotool.initial_gain']).
     xlim_rlocus : tuple or list, optional
-        control of x-axis range, normally with tuple
+        Control of x-axis range, normally with tuple
         (see :doc:`matplotlib:api/axes_api`).
     ylim_rlocus : tuple or list, optional
         control of y-axis range
     plotstr_rlocus : :func:`matplotlib.pyplot.plot` format string, optional
-        plotting style for the root locus plot(color, linestyle, etc)
+        Plotting style for the root locus plot(color, linestyle, etc).
     rlocus_grid : boolean (default = False)
         If True plot s- or z-plane grid.
     omega : array_like
-        List of frequencies in rad/sec to be used for bode plot
+        List of frequencies in rad/sec to be used for bode plot.
     dB : boolean
-        If True, plot result in dB for the bode plot
+        If True, plot result in dB for the bode plot.
     Hz : boolean
-        If True, plot frequency in Hz for the bode plot (omega must be provided in rad/sec)
+        If True, plot frequency in Hz for the bode plot (omega must be
+        provided in rad/sec).
     deg : boolean
-        If True, plot phase in degrees for the bode plot (else radians)
+        If True, plot phase in degrees for the bode plot (else radians).
     omega_limits : array_like of two values
-        Limits of the to generate frequency vector.
-        If Hz=True the limits are in Hz otherwise in rad/s. Ignored if omega
-        is provided, and auto-generated if omitted.
+        Limits of the to generate frequency vector.  If Hz=True the limits
+        are in Hz otherwise in rad/s. Ignored if omega is provided, and
+        auto-generated if omitted.
     omega_num : int
         Number of samples to plot.  Defaults to
         config.defaults['freqplot.number_of_samples'].
     margins_bode : boolean
-        If True, plot gain and phase margin in the bode plot
+        If True, plot gain and phase margin in the bode plot.
     tvect : list or ndarray, optional
-        List of timesteps to use for closed loop step response
+        List of timesteps to use for closed loop step response.
 
     Examples
     --------
@@ -207,7 +207,7 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
                            plot=True):
     """Manual PID controller design based on root locus using Sisotool
 
-    Uses `Sisotool` to investigate the effect of adding or subtracting an
+    Uses `sisotool` to investigate the effect of adding or subtracting an
     amount `deltaK` to the proportional, integral, or derivative (PID) gains of
     a controller. One of the PID gains, `Kp`, `Ki`, or `Kd`, respectively, can
     be modified at a time. `Sisotool` plots the step response, frequency
@@ -275,18 +275,18 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
     Parameters
     ----------
     plant : :class:`LTI` (:class:`TransferFunction` or :class:`StateSpace` system)
-        The dynamical system to be controlled
+        The dynamical system to be controlled.
     gain : string (optional)
         Which gain to vary by `deltaK`. Must be one of `'P'`, `'I'`, or `'D'`
-        (proportional, integral, or derative)
+        (proportional, integral, or derative).
     sign : int (optional)
-        The sign of deltaK gain perturbation
+        The sign of deltaK gain perturbation.
     input : string (optional)
         The input used for the step response; must be `'r'` (reference) or
-        `'d'` (disturbance) (see figure above)
+        `'d'` (disturbance) (see figure above).
     Kp0, Ki0, Kd0 : float (optional)
         Initial values for proportional, integral, and derivative gains,
-        respectively
+        respectively.
     deltaK : float (optional)
         Perturbation value for gain specified by the `gain` keywoard.
     tau : float (optional)
@@ -306,6 +306,11 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
     -------
     closedloop : class:`StateSpace` system
         The closed-loop system using initial gains.
+
+    Notes
+    -----
+    When running using iPython or Jupyter, use `%matplotlib` to configure
+    the session for interactive support.
 
     """
 

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -213,8 +213,8 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
     be modified at a time. `Sisotool` plots the step response, frequency
     response, and root locus.
 
-    When first run, `deltaK` is set to 0; click on a branch of the root locus
-    plot to try a different value. Each click updates plots and prints
+    When first run, `deltaK` is set to 0.001; click on a branch of the root
+    locus plot to try a different value. Each click updates plots and prints
     the corresponding `deltaK`. To tune all three PID gains, repeatedly call
     `rootlocus_pid_designer`, and select a different `gain` each time (`'P'`,
     `'I'`, or `'D'`). Make sure to add the resulting `deltaK` to your chosen
@@ -352,6 +352,6 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
                             inplist=['input', input_signal],
                             outlist=['output', 'y'], check_unused=False)
     if plot:
-        sisotool(loop, kvect=(0.,))
+        sisotool(loop, initial_gain=0.001)
     cl = loop[1, 1] # closed loop transfer function with initial gains
     return StateSpace(cl.A, cl.B, cl.C, cl.D, cl.dt)

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -220,6 +220,15 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
     `'I'`, or `'D'`). Make sure to add the resulting `deltaK` to your chosen
     initial gain on the next iteration.
 
+    Note: Clicking on interactive plots feature is not currently compatible
+    with in-line plots in the Jupyter Notebook including online notebooks.
+    The alternative is to iteratively explore calling this function with
+    different initial argument values `Kp0`, `Ki0`, and `Kd0`. If you are
+    running the notebook on your local computer, it may be possible to spawn
+    separate interactive plots outside of the notebook with a command, e.g.
+    `%matplotlib qt`; when you are done, `%matplotlib inline` returns to
+    inline plots.
+
     Example: to examine the effect of varying `Kp` starting from an intial
     value of 10, use the arguments `gain='P', Kp0=10`. Suppose a `deltaK`
     value of 5 gives satisfactory performance. Then on the next iteration,
@@ -254,7 +263,7 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
     its second input rather than being added to `u`.
 
     Remark: It may be helpful to zoom in using the magnifying glass on the
-    plot. Just ake sure to deactivate magnification mode when you are done by
+    plot. Just make sure to deactivate magnification mode when you are done by
     clicking the magnifying glass. Otherwise you will not be able to be able
     to choose a gain on the root locus plot.
 
@@ -320,7 +329,7 @@ def rootlocus_pid_designer(plant, gain='P', sign=+1, input_signal='r',
         deriv = tf([1, -1], [dt, 0], dt)
 
     # add signal names by turning into iosystems
-    prop  = tf2io(prop,        inputs='e', outputs='prop_e')
+    prop  = tf2io(prop,        )
     integ = tf2io(integ,       inputs='e', outputs='int_e')
     if derivative_in_feedback_path:
         deriv = tf2io(-deriv,  inputs='y', outputs='deriv')

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -182,22 +182,23 @@ class TestPidDesigner:
     @pytest.mark.parametrize('Kp0', (0,))
     @pytest.mark.parametrize('Ki0', (1.,))
     @pytest.mark.parametrize('Kd0', (0.1,))
+    @pytest.mark.parametrize('deltaK', (1.,))
     @pytest.mark.parametrize('tau', (0.01,))
     @pytest.mark.parametrize('C_ff', (0, 1,))
     @pytest.mark.parametrize('derivative_in_feedback_path', (True, False,))
     @pytest.mark.parametrize("kwargs", [{'plot':False},])
-    def test_pid_designer_1(self, plant, gain, sign, input_signal, Kp0, Ki0, Kd0, tau, C_ff,
+    def test_pid_designer_1(self, plant, gain, sign, input_signal, Kp0, Ki0, Kd0, deltaK, tau, C_ff,
             derivative_in_feedback_path, kwargs):
-        rootlocus_pid_designer(plant, gain, sign, input_signal, Kp0, Ki0, Kd0, tau, C_ff,
+        rootlocus_pid_designer(plant, gain, sign, input_signal, Kp0, Ki0, Kd0, deltaK, tau, C_ff,
             derivative_in_feedback_path, **kwargs)
 
     # test creation of sisotool plot
     # input from reference or disturbance
-    @pytest.mark.skip("Bode plot is incorrect; generates spurious warnings")
     @pytest.mark.parametrize('plant', ('syscont', 'syscont221'), indirect=True)
     @pytest.mark.parametrize("kwargs", [
         {'input_signal':'r', 'Kp0':0.01, 'derivative_in_feedback_path':True},
-        {'input_signal':'d', 'Kp0':0.01, 'derivative_in_feedback_path':True},])
+        {'input_signal':'d', 'Kp0':0.01, 'derivative_in_feedback_path':True},
+        {'input_signal':'r', 'Kd0':0.01, 'derivative_in_feedback_path':True}])
     def test_pid_designer_2(self, plant, kwargs):
         rootlocus_pid_designer(plant, **kwargs)
 


### PR DESCRIPTION
Starts with a small gain rather than zero to insure that the frequency response plots appear. Addresses #686 