### PR TITLE
make _convert_to_statespace properly pass signal and system names

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -170,9 +170,9 @@ class StateSpace(LTI):
 
     The StateSpace class is used to represent state-space realizations of
     linear time-invariant (LTI) systems:
-    
+
     .. math::
-    
+
           dx/dt &= A x + B u \\
               y &= C x + D u
 
@@ -1561,7 +1561,8 @@ def _convert_to_statespace(sys):
             return StateSpace(
                 ssout[1][:states, :states], ssout[2][:states, :sys.ninputs],
                 ssout[3][:sys.noutputs, :states], ssout[4], sys.dt,
-                inputs=sys.input_labels, outputs=sys.output_labels)
+                inputs=sys.input_labels, outputs=sys.output_labels,
+                name=sys.name)
         except ImportError:
             # No Slycot.  Scipy tf->ss can't handle MIMO, but static
             # MIMO is an easy special case we can check for here
@@ -1574,7 +1575,9 @@ def _convert_to_statespace(sys):
                 for i, j in itertools.product(range(sys.noutputs),
                                               range(sys.ninputs)):
                     D[i, j] = sys.num[i][j][0] / sys.den[i][j][0]
-                return StateSpace([], [], [], D, sys.dt)
+                return StateSpace([], [], [], D, sys.dt,
+                    inputs=sys.input_labels, outputs=sys.output_labels,
+                    name=sys.name)
             else:
                 if sys.ninputs != 1 or sys.noutputs != 1:
                     raise TypeError("No support for MIMO without slycot")
@@ -1586,7 +1589,7 @@ def _convert_to_statespace(sys):
                     sp.signal.tf2ss(squeeze(sys.num), squeeze(sys.den))
                 return StateSpace(
                     A, B, C, D, sys.dt, inputs=sys.input_labels,
-                    outputs=sys.output_labels)
+                    outputs=sys.output_labels, name=sys.name)
 
     elif isinstance(sys, FrequencyResponseData):
         raise TypeError("Can't convert FRD to StateSpace system.")

--- a/control/tests/namedio_test.py
+++ b/control/tests/namedio_test.py
@@ -241,11 +241,26 @@ def test_init_namedif():
 
 # Test state space conversion
 def test_convert_to_statespace():
-    # Set up the initial system
-    sys = ct.tf(ct.rss(2, 1, 1))
+    # Set up the initial systems
+    sys = ct.tf(ct.rss(2, 1, 1), inputs='u', outputs='y', name='sys')
+    sys_static = ct.tf(1, 2, inputs='u', outputs='y', name='sys_static')
+
+    # check that name, inputs, and outputs passed through
+    sys_new = ct.ss(sys)
+    assert sys_new.name == 'sys'
+    assert sys_new.input_labels == ['u']
+    assert sys_new.output_labels == ['y']
+    sys_new = ct.ss(sys_static)
+    assert sys_new.name == 'sys_static'
+    assert sys_new.input_labels == ['u']
+    assert sys_new.output_labels == ['y']
 
     # Make sure we can rename system name, inputs, outputs
     sys_new = ct.ss(sys, inputs='u', outputs='y', name='new')
+    assert sys_new.name == 'new'
+    assert sys_new.input_labels == ['u']
+    assert sys_new.output_labels == ['y']
+    sys_new = ct.ss(sys_static, inputs='u', outputs='y', name='new')
     assert sys_new.name == 'new'
     assert sys_new.input_labels == ['u']
     assert sys_new.output_labels == ['y']


### PR DESCRIPTION
update: this PR has been converted to a bugfix in `_convert_to_statespace` to insure it copies signal and system names correctly. Found the bug by using the test suite. 

Old PR description: 
On some <s>systems</s> computers , the process of converting `tf` systems into `LinearIOSystems` in the `interconnect` function loses signal names -- if the transfer function is static. For example, if a system is defined as `sys=tf(1, 2, inputs='a', outputs='b')`, an error is raised when that system is interconnected with others because `sys` gets copied but loses its signal names, something along the lines of `Signal 'a' not found`.

But this doesn't happen on my system on Python 3.9, 3.10, or 3.11. Maybe something peculiar to windows? 

This PR adds unit tests in an attempt to see if our test suite catches this bug. 