### PR TITLE
bandwidth feature 

### DIFF
--- a/control/lti.py
+++ b/control/lti.py
@@ -203,11 +203,6 @@ class LTI(NamedIOSystem):
             return zeroresp
 
     def bandwidth(self, dbdrop=-3):
-        """Return the bandwidth"""
-        raise NotImplementedError("bandwidth not implemented for %s objects" %
-                                  str(self.__class__))
-
-    def _bandwidth(self, dbdrop=-3):
         # check if system is SISO and dbdrop is a negative scalar
         if not self.issiso():
             raise TypeError("system should be a SISO system")

--- a/control/lti.py
+++ b/control/lti.py
@@ -209,8 +209,11 @@ class LTI(NamedIOSystem):
 
     def _bandwidth(self, dbdrop=-3):
         # check if system is SISO and dbdrop is a negative scalar
-        if (not self.issiso()) and (dbdrop >= 0):
-            raise ValueError("#TODO ")
+        if not self.issiso():
+            raise TypeError("system should be a SISO system")
+        
+        if not(np.isscalar(dbdrop)) or dbdrop >= 0:
+            raise ValueError("expecting dbdrop be a negative scalar in dB")
 
         # # # this will probabily fail if there is a resonant frequency larger than the bandwidth, the initial guess can be around that peak
         #   G1 = ct.tf(0.1, [1, 0.1])
@@ -560,7 +563,7 @@ def bandwidth(sys, dbdrop=-3):
 
     Example
     -------
-    >>> G = ct.tf([1], [1, 2])
+    >>> G = ct.tf([1], [1, 1])
     >>> ct.bandwidth(G)
     0.9976
 

--- a/control/lti.py
+++ b/control/lti.py
@@ -203,6 +203,31 @@ class LTI(NamedIOSystem):
             return zeroresp
 
     def bandwidth(self, dbdrop=-3):
+        """Evaluate the bandwidth of the LTI system for a given dB drop.
+
+        Evaluate the first frequency that the response magnitude is lower than
+        DC gain by dbdrop dB.
+
+        Parameters
+        ----------
+        dpdrop : float, optional
+            A strictly negative scalar in dB (default = -3) defines the
+            amount of gain drop for deciding bandwidth.
+
+        Returns
+        -------
+        bandwidth : ndarray
+            The first frequency (rad/time-unit) where the gain drops below
+            dbdrop of the dc gain of the system, or nan if the system has
+            infinite dc gain, inf if the gain does not drop for all frequency
+
+        Raises
+        ------
+        TypeError
+            if 'sys' is not an SISO LTI instance
+        ValueError
+            if 'dbdrop' is not a negative scalar
+        """
         # check if system is SISO and dbdrop is a negative scalar
         if not self.issiso():
             raise TypeError("system should be a SISO system")

--- a/control/matlab/__init__.py
+++ b/control/matlab/__init__.py
@@ -189,7 +189,7 @@ System gain and dynamics
 
 ==  ==========================  ============================================
 \*  :func:`dcgain`              steady-state (D.C.) gain
-\   lti/bandwidth               system bandwidth
+\*  :func:`bandwidth`           system bandwidth
 \   lti/norm                    h2 and Hinfinity norms of LTI models
 \*  :func:`pole`                system poles
 \*  :func:`zero`                system (transmission) zeros

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1424,10 +1424,6 @@ class StateSpace(LTI):
         """
         return self._dcgain(warn_infinite)
 
-    def bandwidth(self, dbdrop=-3):
-        """Return the bandwith"""
-        return self._bandwidth(dbdrop)
-
     def dynamics(self, t, x, u=None, params=None):
         """Compute the dynamics of the system
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1424,6 +1424,10 @@ class StateSpace(LTI):
         """
         return self._dcgain(warn_infinite)
 
+    def bandwidth(self, dbdrop=-3):
+        """Return the bandwith"""
+        return self._bandwidth(dbdrop)
+
     def dynamics(self, t, x, u=None, params=None):
         """Compute the dynamics of the system
 

--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -117,7 +117,18 @@ class TestLTI:
         np.testing.assert_allclose(sys2.bandwidth(), 0.101848388240241)
         np.testing.assert_allclose(bandwidth(sys2), 0.101848388240241)
 
-        # test if raise exception given other than SISO system
+        # test constant gain, bandwidth should be infinity
+        sysAP = tf(1,1)
+        np.testing.assert_allclose(bandwidth(sysAP), np.inf)
+
+        # test integrator, bandwidth should return np.nan
+        sysInt = tf(1, [1, 0])
+        np.testing.assert_allclose(bandwidth(sysInt), np.nan)
+
+        # test exception for system other than LTI
+        np.testing.assert_raises(TypeError, bandwidth, 1)
+
+        # test exception for system other than SISO system
         sysMIMO = tf([[[-1, 41], [1]], [[1, 2], [3, 4]]], 
                      [[[1, 10], [1, 20]], [[1, 30], [1, 40]]])
         np.testing.assert_raises(TypeError, bandwidth, sysMIMO)

--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -6,7 +6,7 @@ from .conftest import editsdefaults
 
 import control as ct
 from control import c2d, tf, ss, tf2ss, NonlinearIOSystem
-from control.lti import LTI, evalfr, damp, dcgain, zeros, poles
+from control.lti import LTI, evalfr, damp, dcgain, zeros, poles, bandwidth
 from control import common_timebase, isctime, isdtime, issiso, timebaseEqual
 from control.tests.conftest import slycotonly
 from control.exception import slycot_check
@@ -103,6 +103,27 @@ class TestLTI:
         sys = tf(84, [1, 2])
         np.testing.assert_allclose(sys.dcgain(), 42)
         np.testing.assert_allclose(dcgain(sys), 42)
+
+    def test_bandwidth(self):
+        # test a first-order system, compared with matlab
+        sys1 = tf(0.1, [1, 0.1])
+        np.testing.assert_allclose(sys1.bandwidth(), 0.099762834511098)
+        np.testing.assert_allclose(bandwidth(sys1), 0.099762834511098)
+
+        # test a second-order system, compared with matlab
+        wn2 = 1
+        zeta2 = 0.001
+        sys2 = sys1 * tf(wn2**2, [1, 2*zeta2*wn2, wn2**2])
+        np.testing.assert_allclose(sys2.bandwidth(), 0.101848388240241)
+        np.testing.assert_allclose(bandwidth(sys2), 0.101848388240241)
+
+        # test if raise exception given other than SISO system
+        sysMIMO = tf([[[-1, 41], [1]], [[1, 2], [3, 4]]], 
+                     [[[1, 10], [1, 20]], [[1, 30], [1, 40]]])
+        np.testing.assert_raises(TypeError, bandwidth, sysMIMO)
+
+        # test if raise exception if dbdrop is positive scalar
+        np.testing.assert_raises(ValueError, bandwidth, sys1, 3)
 
     @pytest.mark.parametrize("dt1, dt2, expected",
                              [(None, None, True),

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -74,6 +74,7 @@ _xferfcn_defaults = {
     'xferfcn.floating_point_format': '.4g'
 }
 
+
 def _float2str(value):
     _num_format = config.defaults.get('xferfcn.floating_point_format', ':.4g')
     return f"{value:{_num_format}}"
@@ -1246,7 +1247,7 @@ class TransferFunction(LTI):
 
         """
         return self._dcgain(warn_infinite)
-    
+
     def _isstatic(self):
         """returns True if and only if all of the numerator and denominator
         polynomials of the (possibly MIMO) transfer function are zeroth order,
@@ -1406,6 +1407,7 @@ def _tf_factorized_polynomial_to_string(roots, gain=1, var='s'):
         factors = [f"({factor})" for factor in factors]
 
     return multiplier + " ".join(factors)
+
 
 def _tf_string_to_latex(thestr, var='s'):
     """ make sure to superscript all digits in a polynomial string

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1246,6 +1246,10 @@ class TransferFunction(LTI):
 
         """
         return self._dcgain(warn_infinite)
+    
+    def bandwidth(self, dbdrop=-3):
+        """Return the bandwith"""
+        return self._bandwidth(dbdrop)
 
     def _isstatic(self):
         """returns True if and only if all of the numerator and denominator

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1247,10 +1247,6 @@ class TransferFunction(LTI):
         """
         return self._dcgain(warn_infinite)
     
-    def bandwidth(self, dbdrop=-3):
-        """Return the bandwith"""
-        return self._bandwidth(dbdrop)
-
     def _isstatic(self):
         """returns True if and only if all of the numerator and denominator
         polynomials of the (possibly MIMO) transfer function are zeroth order,


### PR DESCRIPTION
As discussed in #690, the bandwidth feature is added to the LTI class.

Implementation:
1. The range of possible frequency is extracted from `freqplot._default_frequency_range`. 
2. The index, $idx$, is identified, which corresponds to the first frequency dropped by a desired amount relative to the DC gain.
3. Bisection search (`scipy.optimize.root_scalar`) is used to solve for the bandwidth in the frequency bracket $[\omega[idx-1], \omega[idx]]$.

Notes:
1. The bandwidth of a system with infinite DC gain is set to be `np.nan`, which follows the convention of Matlab.
2. The above approach is chosen to solve the bandwidth instead of the `scipy.optimize.root` suggested in issue #690. The suggested approach requires an initial guess and might fail, e.g., a system with a resonant peak at a frequency higher than the bandwidth. 

Notes on git commits:
git commits are duplicated as I was having some issues to push. I pulled (suggested by git error hint), and it prompts `"merge made by the 'recursive' strategy.` Not sure whether this is a problem. 