### PR TITLE
warn if prewarp-frequency is not used

### DIFF
--- a/control/dtime.py
+++ b/control/dtime.py
@@ -72,22 +72,12 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
             otherwise. See :func:`scipy.signal.cont2discrete`.
     prewarp_frequency : float within [0, infinity)
         The frequency [rad/s] at which to match with the input continuous-
-        time system's magnitude and phase (only valid for method='bilinear')
-    name : string, optional
-        Set the name of the sampled system.  If not specified and
-        if `copy_names` is `False`, a generic name <sys[id]> is generated
-        with a unique integer id.  If `copy_names` is `True`, the new system
-        name is determined by adding the prefix and suffix strings in
-        config.defaults['namedio.sampled_system_name_prefix'] and
-        config.defaults['namedio.sampled_system_name_suffix'], with the
-        default being to add the suffix '$sampled'.
-    copy_names : bool, Optional
-        If True, copy the names of the input signals, output
-        signals, and states to the sampled system.
+        time system's magnitude and phase (only valid for method='bilinear',
+        'tustin', or 'gbt' with alpha=0.5)
 
     Returns
     -------
-    sysd : linsys
+    sysd : LTI of the same class (:class:`StateSpace` or :class:`TransferFunction`)
         Discrete time system, with sampling rate Ts
 
     Other Parameters
@@ -101,6 +91,17 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
     states : int, list of str, or None, optional
         Description of the system states.  Same format as `inputs`. Only
         available if the system is :class:`StateSpace`.
+    name : string, optional
+        Set the name of the sampled system.  If not specified and
+        if `copy_names` is `False`, a generic name <sys[id]> is generated
+        with a unique integer id.  If `copy_names` is `True`, the new system
+        name is determined by adding the prefix and suffix strings in
+        config.defaults['namedio.sampled_system_name_prefix'] and
+        config.defaults['namedio.sampled_system_name_suffix'], with the
+        default being to add the suffix '$sampled'.
+    copy_names : bool, Optional
+        If True, copy the names of the input signals, output
+        signals, and states to the sampled system.
 
     Notes
     -----
@@ -126,46 +127,4 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
         method=method, alpha=alpha, prewarp_frequency=prewarp_frequency,
         name=name, copy_names=copy_names, **kwargs)
 
-
-def c2d(sysc, Ts, method='zoh', prewarp_frequency=None):
-    """
-    Convert a continuous time system to discrete time by sampling
-
-    Parameters
-    ----------
-    sysc : LTI (:class:`StateSpace` or :class:`TransferFunction`)
-        Continuous time system to be converted
-    Ts : float > 0
-        Sampling period
-    method : string
-        Method to use for conversion, e.g. 'bilinear', 'zoh' (default)
-    prewarp_frequency : real within [0, infinity)
-        The frequency [rad/s] at which to match with the input continuous-
-        time system's magnitude and phase (only valid for method='bilinear')
-
-    Returns
-    -------
-    sysd : LTI of the same class
-        Discrete time system, with sampling rate Ts
-
-    Notes
-    -----
-    See :meth:`StateSpace.sample` or :meth:`TransferFunction.sample`` for
-    further details.
-
-    Examples
-    --------
-    >>> Gc = ct.tf([1], [1, 2, 1])
-    >>> Gc.isdtime()
-    False
-    >>> Gd = ct.sample_system(Gc, 1, method='bilinear')
-    >>> Gd.isdtime()
-    True
-
-    """
-
-    #  Call the sample_system() function to do the work
-    sysd = sample_system(sysc, Ts,
-        method=method, prewarp_frequency=prewarp_frequency)
-
-    return sysd
+c2d = sample_system

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -170,9 +170,9 @@ class StateSpace(LTI):
 
     The StateSpace class is used to represent state-space realizations of
     linear time-invariant (LTI) systems:
-    
+
     .. math::
-    
+
           dx/dt &= A x + B u \\
               y &= C x + D u
 
@@ -1368,10 +1368,13 @@ class StateSpace(LTI):
         """
         if not self.isctime():
             raise ValueError("System must be continuous time system")
-
-        if (method == 'bilinear' or (method == 'gbt' and alpha == 0.5)) and \
-                prewarp_frequency is not None:
-            Twarp = 2 * np.tan(prewarp_frequency * Ts/2)/prewarp_frequency
+        if prewarp_frequency is not None:
+            if method in ('bilinear', 'tustin') or \
+                    (method == 'gbt' and alpha == 0.5):
+                Twarp = 2*np.tan(prewarp_frequency*Ts/2)/prewarp_frequency
+            else:
+                warn('prewarp_frequency ignored: incompatible conversion')
+                Twarp = Ts
         else:
             Twarp = Ts
         sys = (self.A, self.B, self.C, self.D)

--- a/control/tests/kwargs_test.py
+++ b/control/tests/kwargs_test.py
@@ -190,6 +190,7 @@ kwarg_unittest = {
     'tf2io' : test_unrecognized_kwargs,
     'tf2ss' : test_unrecognized_kwargs,
     'sample_system' : test_unrecognized_kwargs,
+    'c2d' : test_unrecognized_kwargs,
     'zpk': test_unrecognized_kwargs,
     'flatsys.point_to_point':
         flatsys_test.TestFlatSys.test_point_to_point_errors,
@@ -210,7 +211,7 @@ kwarg_unittest = {
     'NonlinearIOSystem.__init__':
         interconnect_test.test_interconnect_exceptions,
     'StateSpace.__init__': test_unrecognized_kwargs,
-    'StateSpace.sample': test_unrecognized_kwargs, 
+    'StateSpace.sample': test_unrecognized_kwargs,
     'TimeResponseData.__call__': trdata_test.test_response_copy,
     'TransferFunction.__init__': test_unrecognized_kwargs,
     'TransferFunction.sample': test_unrecognized_kwargs,

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1134,7 +1134,7 @@ class TransferFunction(LTI):
             Method to use for sampling:
 
             * gbt: generalized bilinear transformation
-            * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
+            * bilinear or tustin: Tustin's approximation ("gbt" with alpha=0.5)
             * euler: Euler (or forward difference) method ("gbt" with alpha=0)
             * backward_diff: Backwards difference ("gbt" with alpha=1.0)
             * zoh: zero-order hold (default)
@@ -1192,9 +1192,13 @@ class TransferFunction(LTI):
         if method == "matched":
             return _c2d_matched(self, Ts)
         sys = (self.num[0][0], self.den[0][0])
-        if (method == 'bilinear' or (method == 'gbt' and alpha == 0.5)) and \
-                prewarp_frequency is not None:
-            Twarp = 2*np.tan(prewarp_frequency*Ts/2)/prewarp_frequency
+        if prewarp_frequency is not None:
+            if method in ('bilinear', 'tustin') or \
+                    (method == 'gbt' and alpha == 0.5):
+                Twarp = 2*np.tan(prewarp_frequency*Ts/2)/prewarp_frequency
+            else:
+                warn('prewarp_frequency ignored: incompatible conversion')
+                Twarp = Ts
         else:
             Twarp = Ts
         numd, dend, _ = cont2discrete(sys, Twarp, method, alpha)


### PR DESCRIPTION
This PR makes sure the prewarp-frequency kwarg is used in `sys.sample`. 
* now warns if a descretization type doesn't support it
* now c2d is an identical copy of sample_system instead of being a somewhat-compatible version of it
* more/better unit tests. 