### PR TITLE
Change name of converted LinearIOSystems

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -591,13 +591,8 @@ class InputOutputSystem(NamedIOSystem):
                 DeprecationWarning)
 
         if copy_names:
-            linsys._copy_names(self)
-            if name is None:
-                linsys.name = \
-                    config.defaults['namedio.linearized_system_name_prefix']+\
-                    linsys.name+\
-                    config.defaults['namedio.linearized_system_name_suffix']
-            else:
+            linsys._copy_names(self, prefix_suffix_name='linearized')
+            if name is not None:
                 linsys.name = name
 
         # re-init to include desired signal names if names were provided

--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2395,7 +2395,9 @@ def ss(*args, **kwargs):
                      "non-unique state space realization")
 
             # Create a state space system from an LTI system
-            sys = LinearIOSystem(_convert_to_statespace(sys), **kwargs)
+            sys = LinearIOSystem(
+                _convert_to_statespace(sys, use_prefix_suffix=True), **kwargs)
+
         else:
             raise TypeError("ss(sys): sys must be a StateSpace or "
                             "TransferFunction object.  It is %s." % type(sys))

--- a/control/namedio.py
+++ b/control/namedio.py
@@ -119,13 +119,11 @@ class NamedIOSystem(object):
         self.name = prefix + sys.name + suffix
 
         # Name the inputs, outputs, and states
-        self.ninputs, self.input_index = \
-            sys.ninputs, sys.input_index.copy()
-        self.noutputs, self.output_index = \
-            sys.noutputs, sys.output_index.copy()
-        if sys.nstates:         # only copy for state space systems
-            self.nstates, self.state_index = \
-                sys.nstates, sys.state_index.copy()
+        self.input_index = sys.input_index.copy()
+        self.output_index = sys.output_index.copy()
+        if self.nstates and sys.nstates:
+            # only copy state names for state space systems
+            self.state_index = sys.state_index.copy()
 
     def copy(self, name=None, use_prefix_suffix=True):
         """Make a copy of an input/output system

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1382,13 +1382,8 @@ class StateSpace(LTI):
         sysd = StateSpace(Ad, Bd, C, D, Ts)
         # copy over the system name, inputs, outputs, and states
         if copy_names:
-            sysd._copy_names(self)
-            if name is None:
-                sysd.name = \
-                    config.defaults['namedio.sampled_system_name_prefix'] +\
-                    sysd.name + \
-                    config.defaults['namedio.sampled_system_name_suffix']
-            else:
+            sysd._copy_names(self, prefix_suffix_name='sampled')
+            if name is not None:
                 sysd.name = name
         # pass desired signal names if names were provided
         return StateSpace(sysd, **kwargs)

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1572,9 +1572,7 @@ def _convert_to_statespace(sys, use_prefix_suffix=False):
                 for i, j in itertools.product(range(sys.noutputs),
                                               range(sys.ninputs)):
                     D[i, j] = sys.num[i][j][0] / sys.den[i][j][0]
-                return StateSpace([], [], [], D, sys.dt,
-                    inputs=sys.input_labels, outputs=sys.output_labels,
-                    name=sys.name)
+                newsys = StateSpace([], [], [], D, sys.dt)
             else:
                 if sys.ninputs != 1 or sys.noutputs != 1:
                     raise TypeError("No support for MIMO without slycot")

--- a/control/tests/namedio_test.py
+++ b/control/tests/namedio_test.py
@@ -169,6 +169,9 @@ def test_io_naming(fun, args, kwargs):
         assert sys_ss != sys_r
         assert sys_ss.input_labels == input_labels
         assert sys_ss.output_labels == output_labels
+        if not isinstance(sys_r, ct.StateSpace):
+            # System should get unique name
+            assert sys_ss.name != sys_r.name
 
         # Reassign system and signal names
         sys_ss = ct.ss(
@@ -247,11 +250,11 @@ def test_convert_to_statespace():
 
     # check that name, inputs, and outputs passed through
     sys_new = ct.ss(sys)
-    assert sys_new.name == 'sys'
+    assert sys_new.name == 'sys$converted'
     assert sys_new.input_labels == ['u']
     assert sys_new.output_labels == ['y']
     sys_new = ct.ss(sys_static)
-    assert sys_new.name == 'sys_static'
+    assert sys_new.name == 'sys_static$converted'
     assert sys_new.input_labels == ['u']
     assert sys_new.output_labels == ['y']
 

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -1262,6 +1262,12 @@ def test_copy_names(create, args, kwargs, convert):
     if cpy.nstates is not None and sys.nstates is not None:
         assert cpy.state_labels == sys.state_labels
 
+    # Make sure that names aren't the same if system changed type
+    if not isinstance(cpy, create):
+        assert cpy.name == sys.name + '$converted'
+    else:
+        assert cpy.name == sys.name
+
     # Relabel inputs and outputs
     cpy = convert(sys, inputs='myin', outputs='myout')
     assert cpy.input_labels == ['myin']

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1206,13 +1206,8 @@ class TransferFunction(LTI):
         sysd = TransferFunction(numd[0, :], dend, Ts)
         # copy over the system name, inputs, outputs, and states
         if copy_names:
-            sysd._copy_names(self)
-            if name is None:
-                sysd.name = \
-                    config.defaults['namedio.sampled_system_name_prefix'] +\
-                    sysd.name + \
-                    config.defaults['namedio.sampled_system_name_suffix']
-            else:
+            sysd._copy_names(self, prefix_suffix_name='sampled')
+            if name is not None:
                 sysd.name = name
         # pass desired signal names if names were provided
         return TransferFunction(sysd, name=name, **kwargs)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1433,7 +1433,8 @@ def _add_siso(num1, den1, num2, den2):
     return num, den
 
 
-def _convert_to_transfer_function(sys, inputs=1, outputs=1):
+def _convert_to_transfer_function(
+        sys, inputs=1, outputs=1, use_prefix_suffix=False):
     """Convert a system to transfer function form (if needed).
 
     If sys is already a transfer function, then it is returned.  If sys is a
@@ -1509,7 +1510,10 @@ def _convert_to_transfer_function(sys, inputs=1, outputs=1):
                 num = squeeze(num)  # Convert to 1D array
                 den = squeeze(den)  # Probably not needed
 
-        return TransferFunction(num, den, sys.dt)
+        newsys = TransferFunction(num, den, sys.dt)
+        if use_prefix_suffix:
+            newsys._copy_names(sys, prefix_suffix_name='converted')
+        return newsys
 
     elif isinstance(sys, (int, float, complex, np.number)):
         num = [[[sys] for j in range(inputs)] for i in range(outputs)]
@@ -1809,7 +1813,8 @@ def ss2tf(*args, **kwargs):
             if not kwargs.get('outputs'):
                 kwargs['outputs'] = sys.output_labels
             return TransferFunction(
-                _convert_to_transfer_function(sys), **kwargs)
+                _convert_to_transfer_function(sys, use_prefix_suffix=True),
+                **kwargs)
         else:
             raise TypeError(
                 "ss2tf(sys): sys must be a StateSpace object.  It is %s."


### PR DESCRIPTION
This PR implements that change suggested in PR #884 and issue #901 regarding changing the system name when a transfer function is converted to a state space system and vice versa.  Converted systems now have "$converted" appended to the system name.  This is only done when you do an explicit conversation via `ss` or `tf`.  Implicit conversions from a `TransferFunction` to a `StateSpace` object, for example as part of using `interconnect` use the original name.

In addition, prefix/suffix processing has been moved into the `NamedIOSystem` class, under `_copy_names` and `_name_or_default` methods.