### PR TITLE
fix up some warning messages due to converted systems

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -2405,7 +2405,10 @@ def ss(*args, **kwargs):
 
             # Create a state space system from an LTI system
             sys = LinearIOSystem(
-                _convert_to_statespace(sys, use_prefix_suffix=True), **kwargs)
+                _convert_to_statespace(
+                    sys,
+                    use_prefix_suffix=not sys._generic_name_check()),
+                **kwargs)
 
         else:
             raise TypeError("ss(sys): sys must be a StateSpace or "

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1914,8 +1914,11 @@ def tf2ss(*args, **kwargs):
         if not isinstance(sys, TransferFunction):
             raise TypeError("tf2ss(sys): sys must be a TransferFunction "
                             "object.")
-        return StateSpace(_convert_to_statespace(sys, use_prefix_suffix=True),
-                          **kwargs)
+        return StateSpace(
+            _convert_to_statespace(
+                sys,
+                use_prefix_suffix=not sys._generic_name_check()),
+            **kwargs)
     else:
         raise ValueError("Needs 1 or 2 arguments; received %i." % len(args))
 

--- a/control/tests/namedio_test.py
+++ b/control/tests/namedio_test.py
@@ -135,6 +135,8 @@ def test_io_naming(fun, args, kwargs):
         sys_r.set_states(state_labels)
         assert sys_r.state_labels == state_labels
 
+    sys_r.name = 'sys'          # make sure name is non-generic
+
     #
     # Set names using keywords and make sure they stick
     #

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -1254,7 +1254,7 @@ def test_zpk(zeros, poles, gain, args, kwargs):
 ])
 def test_copy_names(create, args, kwargs, convert):
     # Convert a system with no renaming
-    sys = create(*args, **kwargs)
+    sys = create(*args, **kwargs, name='sys')
     cpy = convert(sys)
 
     assert cpy.input_labels == sys.input_labels

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1813,7 +1813,8 @@ def ss2tf(*args, **kwargs):
             if not kwargs.get('outputs'):
                 kwargs['outputs'] = sys.output_labels
             return TransferFunction(
-                _convert_to_transfer_function(sys, use_prefix_suffix=True),
+                _convert_to_transfer_function(
+                    sys, use_prefix_suffix=not sys._generic_name_check()),
                 **kwargs)
         else:
             raise TypeError(


### PR DESCRIPTION
Small PR to fix up some issues where the functionality in #903 was causing some warning messages.  In particular, the following snipped was causing a warning (from `matlab_test.py`):
```
siso_tf2 = tf([1, 1], [1, 2, 3, 1])
siso_ss2 = ss(siso_tf2)
[gm, pm, gmc, pmc] = margin(siso_ss2 * siso_ss2 * 2)
```
The reason for the warning was that `siso_ss2` had the name 'sys[0]$converted' and when you create an interconnected system with duplicated non-generic names it gives you a warning (since things like change the parameters of one of the systems would affect the other.

To fix this, converted LinearIOSystems with "generic" names (sys[0]) do _not_ get '$converted' added to the end.  Instead they just get a new generic system name.

That change meant that some of the previous unit tests needed to use an explicitly named system, which is what the the changes in the unit tests are about.
