### PR TITLE
Some doc fixes

### DIFF
--- a/control/__init__.py
+++ b/control/__init__.py
@@ -55,7 +55,7 @@ The docstring examples assume that the following import commands::
 Available subpackages
 ---------------------
 
-The main control package includes the most commpon functions used in
+The main control package includes the most common functions used in
 analysis, design, and simulation of feedback control systems.  Several
 additional subpackages are available that provide more specialized
 functionality:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # -- Project information -----------------------------------------------------
 
 project = u'Python Control Systems Library'
-copyright = u'2022, python-control.org'
+copyright = u'2023, python-control.org'
 author = u'Python Control Developers'
 
 # Version information - read from the source code

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -16,8 +16,8 @@ LTI system representation
 
 Linear time invariant (LTI) systems are represented in python-control in
 state space, transfer function, or frequency response data (FRD) form.  Most
-functions in the toolbox will operate on any of these data types and
-functions for converting between compatible types is provided.
+functions in the toolbox will operate on any of these data types, and
+functions for converting between compatible types are provided.
 
 State space systems
 -------------------
@@ -152,7 +152,7 @@ in the next section).
 
 The :func:`forced_response` system is the most general and allows by
 the zero initial state response to be simulated as well as the
-response from a non-zero intial condition.
+response from a non-zero initial condition.
 
 In addition the :func:`input_output_response` function, which handles
 simulation of nonlinear systems and interconnected systems, can be

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -6,7 +6,7 @@ Examples
 ********
 
 The source code for the examples below are available in the `examples/`
-subdirecory of the source code distribution.  The can also be accessed online
+subdirectory of the source code distribution. They can also be accessed online
 via the [python-control GitHub repository](https://github.com/python-control/python-control/tree/master/examples).
 
 
@@ -38,7 +38,7 @@ Jupyter notebooks
 =================
 
 The examples below use `python-control` in a Jupyter notebook environment.
-These notebooks demonstrate the use of modeling, anaylsis, and design tools
+These notebooks demonstrate the use of modeling, analysis, and design tools
 using examples from textbooks
 (`FBS <https://fbswiki.org/wiki/index.php?title=FBS>`_,
 `OBC <https://fbswiki.org/wiki/index.php?title=OBC>`_), courses, and other

--- a/doc/flatsys.rst
+++ b/doc/flatsys.rst
@@ -39,7 +39,7 @@ Differentially flat systems are useful in situations where explicit
 trajectory generation is required. Since the behavior of a flat system
 is determined by the flat outputs, we can plan trajectories in output
 space, and then map these to appropriate inputs.  Suppose we wish to
-generate a feasible trajectory for the the nonlinear system
+generate a feasible trajectory for the nonlinear system
 
 .. math::
     \dot x = f(x, u), \qquad x(0) = x_0,\, x(T) = x_f.
@@ -181,7 +181,7 @@ solve an optimal control problem without a final state::
     traj = control.flatsys.solve_flat_ocp(
         sys, timepts, x0, u0, cost, basis=basis)
 
-The `cost` parameter is a function function with call signature
+The `cost` parameter is a function with call signature
 `cost(x, u)` and should return the (incremental) cost at the given
 state, and input.  It will be evaluated at each point in the `timepts`
 vector.  The `terminal_cost` parameter can be used to specify a cost
@@ -193,7 +193,7 @@ Example
 To illustrate how we can use a two degree-of-freedom design to improve the
 performance of the system, consider the problem of steering a car to change
 lanes on a road. We use the non-normalized form of the dynamics, which are
-derived *Feedback Systems* by Astrom and Murray, Example 3.11.
+derived in *Feedback Systems* by Astrom and Murray, Example 3.11.
 
 .. code-block:: python
 

--- a/doc/interconnect_tutorial.ipynb
+++ b/doc/interconnect_tutorial.ipynb
@@ -1,0 +1,1 @@
+../examples/interconnect_tutorial.ipynb

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -26,7 +26,7 @@ NumPy and MATLAB can be found `here
 <https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html>`_.
 
 In terms of the python-control package more specifically, here are
-some thing to keep in mind:
+some things to keep in mind:
 
 * You must include commas in vectors.  So [1 2 3] must be [1, 2, 3].
 * Functions that return multiple arguments use tuples.  
@@ -56,7 +56,7 @@ they are not already present.
 .. note::
    Mixing packages from conda-forge and the default conda channel
    can sometimes cause problems with dependencies, so it is usually best to
-   instally NumPy, SciPy, and Matplotlib from conda-forge as well.)
+   instally NumPy, SciPy, and Matplotlib from conda-forge as well.
 
 To install using pip::
 

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -251,7 +251,7 @@ will create a unity gain, negative feedback system::
 If a signal name appears in multiple outputs then that signal will be summed
 when it is interconnected.  Similarly, if a signal name appears in multiple
 inputs then all systems using that signal name will receive the same input.
-The :func:`~control.interconnect` function will generate an error if an signal
+The :func:`~control.interconnect` function will generate an error if a signal
 listed in ``inplist`` or ``outlist`` (corresponding to the inputs and outputs
 of the interconnected system) is not found, but inputs and outputs of
 individual systems that are not connected to other systems are left
@@ -404,7 +404,7 @@ The closed loop controller will include both the state feedback and
 the estimator.
 
 Integral action can be included using the `integral_action` keyword.
-The value of this keyword can either be an matrix (ndarray) or a
+The value of this keyword can either be a matrix (ndarray) or a
 function.  If a matrix :math:`C` is specified, the difference between
 the desired state and system state will be multiplied by this matrix
 and integrated.  The controller gain should then consist of a set of

--- a/doc/optimal.rst
+++ b/doc/optimal.rst
@@ -129,7 +129,7 @@ The result of this optimization gives us the estimated state for the
 previous :math:`N` steps in time, including the "current" time
 :math:`x[N]`.  The basic idea is thus to compute the state estimate that is
 most consistent with our model and penalize the noise and disturbances
-according to how likely the are (based on the given stochastic system 
+according to how likely they are (based on the given stochastic system 
 model for each).
 
 Given a solution to this fixed-horizon optimal estimation problem, we can
@@ -344,7 +344,7 @@ following code::
 
 We consider an optimal control problem that consists of "changing lanes" by
 moving from the point x = 0 m, y = -2 m, :math:`\theta` = 0 to the point x =
-100 m, y = 2 m, :math:`\theta` = 0) over a period of 10 seconds and with a
+100 m, y = 2 m, :math:`\theta` = 0) over a period of 10 seconds and
 with a starting and ending velocity of 10 m/s::
 
   x0 = np.array([0., -2., 0.]); u0 = np.array([10., 0.])
@@ -360,7 +360,7 @@ penalizes the state and input using quadratic cost functions::
   traj_cost = obc.quadratic_cost(vehicle, Q, R, x0=xf, u0=uf)
   term_cost = obc.quadratic_cost(vehicle, P, 0, x0=xf)
 
-We also constraint the maximum turning rate to 0.1 radians (about 6 degees)
+We also constrain the maximum turning rate to 0.1 radians (about 6 degrees)
 and constrain the velocity to be in the range of 9 m/s to 11 m/s::
 
   constraints = [ obc.input_range_constraint(vehicle, [8, -0.1], [12, 0.1]) ]
@@ -431,7 +431,7 @@ solutions do not seem close to optimal, here are a few things to try:
   good solutions with a small number of free variables (the example above
   uses 3 time points for 2 inputs, so a total of 6 optimization variables).
   Note that you can "resample" the optimal trajectory by running a
-  simulation of the sytem and using the `t_eval` keyword in
+  simulation of the system and using the `t_eval` keyword in
   `input_output_response` (as done above).
 
 * Use a smooth basis: as an alternative to parameterizing the optimal
@@ -445,14 +445,14 @@ solutions do not seem close to optimal, here are a few things to try:
   and `minimize_kwargs` keywords in :func:`~control.solve_ocp`, you can
   choose the SciPy optimization function that you use and set many
   parameters.  See :func:`scipy.optimize.minimize` for more information on
-  the optimzers that are available and the options and keywords that they
+  the optimizers that are available and the options and keywords that they
   accept.
 
 * Walk before you run: try setting up a simpler version of the optimization,
   remove constraints or simplifying the cost to get a simple version of the
   problem working and then add complexity.  Sometimes this can help you find
   the right set of options or identify situations in which you are being too
-  aggressive in what your are trying to get the system to do.
+  aggressive in what you are trying to get the system to do.
 
 See :ref:`steering-optimal` for some examples of different problem
 formulations.

--- a/doc/simulating_discrete_nonlinear.ipynb
+++ b/doc/simulating_discrete_nonlinear.ipynb
@@ -1,0 +1,1 @@
+../examples/simulating_discrete_nonlinear.ipynb

--- a/doc/steering-optimal.rst
+++ b/doc/steering-optimal.rst
@@ -1,6 +1,6 @@
 .. _steering-optimal:
 
-Optimal control for vehicle steeering (lane change)
+Optimal control for vehicle steering (lane change)
 ---------------------------------------------------
 
 Code


### PR DESCRIPTION
- Update sphinx doc year to 2023
- Fix some typos in sphinx doc
- Add symbolic links to two jupyter-notebooks examples

Remark:
make html was not completely successful.
I got an error related to use_numpy_matrix. 

"WARNING: autodoc: failed to import function 'use_numpy_matrix' from module 'control'; the following exception was raised:"

I guess sphinx uses an old version of control for autodoc? ==> doc/conf.py ==> git describe?
However, I was not able to find the reason. 