### PR TITLE
print a connection table for interconnected systems

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -539,7 +539,7 @@ def isctime(sys, strict=False):
         return sys.isctime(strict)
 
 
-# Utility function to parse nameio keywords
+# Utility function to parse iosys keywords
 def _process_iosys_keywords(
         keywords={}, defaults={}, static=False, end=False):
     """Process iosys specification.
@@ -611,7 +611,7 @@ def _process_iosys_keywords(
     return name, inputs, outputs, states, dt
 
 #
-# Parse 'dt' in for named I/O system
+# Parse 'dt' for I/O system
 #
 # The 'dt' keyword is used to set the timebase for a system.  Its
 # processing is a bit unusual: if it is not specified at all, then the

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -2564,7 +2564,7 @@ def _convert_static_iosystem(sys):
             None, lambda t, x, u, params: sys @ u,
             outputs=sys.shape[0], inputs=sys.shape[1])
 
-def signal_table(sys, **kwargs):
+def signal_table(sys, show_names=False):
     """Print table of signal names, sources, and destinations.
 
     Intended primarily for systems that have been connected implicitly
@@ -2595,4 +2595,4 @@ def signal_table(sys, **kwargs):
     assert isinstance(sys, InterconnectedSystem), "system must be"\
         "an InterconnectedSystem."
 
-    sys.signal_table(**kwargs)
+    sys.signal_table(show_names=show_names)

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -395,7 +395,7 @@ class NonlinearIOSystem(InputOutputSystem):
             current state
         u : array_like
             input
-        params : dict (optional)
+        params : dict, optional
             system parameter values
 
         Returns
@@ -436,7 +436,7 @@ class NonlinearIOSystem(InputOutputSystem):
             current state
         u : array_like
             input
-        params : dict (optional)
+        params : dict, optional
             system parameter values
 
         Returns
@@ -1012,13 +1012,13 @@ class InterconnectedSystem(NonlinearIOSystem):
 
         Parameters
         ----------
-        show_names : bool (optional)
+        show_names : bool, optional
             Instead of printing out the system number, print out the name of
             each system. Default is False because system name is not usually
             specified when performing implicit interconnection using
             :func:`interconnect`.
-        column_width : int (optional)
-            Character width of printed columns
+        column_width : int, optional
+            Character width of printed columns.
 
         Examples
         --------
@@ -2590,13 +2590,13 @@ def connection_table(sys, show_names=False, column_width=32):
     ----------
     sys : :class:`InterconnectedSystem`
         Interconnected system object
-    show_names : bool (optional)
+    show_names : bool, optional
         Instead of printing out the system number, print out the name of
         each system. Default is False because system name is not usually
         specified when performing implicit interconnection using
         :func:`interconnect`.
-    column_width : int (optional)
-        Character width of printed columns
+    column_width : int, optional
+        Character width of printed columns.
 
 
     Examples

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -1017,15 +1017,15 @@ class InterconnectedSystem(NonlinearIOSystem):
 
         Examples
         --------
-        >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y')
-        >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u')
+        >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y', name='P')
+        >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u', name='C')
         >>> L = ct.interconnect([C, P], inputs='e', outputs='y')
-        >>> L.signal_table() # doctest: +SKIP
+        >>> L.signal_table(show_names=True) # doctest: +SKIP
         signal    | source                  | destination
         --------------------------------------------------------------
-        e         | input                   | system 0
-        u         | system 0                | system 1
-        y         | system 1                | output
+        e         | input                   | C
+        u         | C                       | P
+        y         | P                       | output
         """
 
         spacing = 26
@@ -1053,12 +1053,12 @@ class InterconnectedSystem(NonlinearIOSystem):
             for idx, sys in enumerate(self.syslist):
                 loc = sys.find_output(signal_label)
                 if loc is not None:
-                    if not sources.endswith(' '):
+                    if not sources.endswith(', '):
                         sources += ', '
                     sources += sys.name if show_names else 'system ' + str(idx)
                 loc = sys.find_input(signal_label)
                 if loc is not None:
-                    if not dests.endswith(' '):
+                    if not dests.endswith(', '):
                         dests += ', '
                     dests += sys.name if show_names else 'system ' + str(idx)
             print(sources.ljust(spacing), end='')
@@ -2582,15 +2582,15 @@ def signal_table(sys, show_names=False):
 
     Examples
     --------
-    >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y')
-    >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u')
+    >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y', name='P')
+    >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u', name='C')
     >>> L = ct.interconnect([C, P], inputs='e', outputs='y')
-    >>> ct.signal_table(L) # doctest: +SKIP
+    >>> L.signal_table(show_names=True) # doctest: +SKIP
     signal    | source                  | destination
     --------------------------------------------------------------
-    e         | input                   | system 0
-    u         | system 0                | system 1
-    y         | system 1                | output
+    e         | input                   | C
+    u         | C                       | P
+    y         | P                       | output
     """
     assert isinstance(sys, InterconnectedSystem), "system must be"\
         "an InterconnectedSystem."

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -31,7 +31,7 @@ from .timeresp import _check_convert_array, _process_time_response, \
 
 __all__ = ['NonlinearIOSystem', 'InterconnectedSystem', 'nlsys',
            'input_output_response', 'find_eqpt', 'linearize',
-           'interconnect']
+           'interconnect', 'signal_table']
 
 
 class NonlinearIOSystem(InputOutputSystem):
@@ -1020,7 +1020,7 @@ class InterconnectedSystem(NonlinearIOSystem):
         >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y')
         >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u')
         >>> L = ct.interconnect([C, P], inputs='e', outputs='y')
-        >>> L.signal_table()
+        >>> L.signal_table() # doctest: +SKIP
         signal    | source                  | destination
         --------------------------------------------------------------
         e         | input                   | system 0
@@ -2563,3 +2563,36 @@ def _convert_static_iosystem(sys):
         return NonlinearIOSystem(
             None, lambda t, x, u, params: sys @ u,
             outputs=sys.shape[0], inputs=sys.shape[1])
+
+def signal_table(sys, **kwargs):
+    """Print table of signal names, sources, and destinations.
+
+    Intended primarily for systems that have been connected implicitly
+    using signal names.
+
+    Parameters
+    ----------
+    sys : :class:`InterconnectedSystem`
+        Interconnected system object
+    show_names : bool (optional)
+        Instead of printing out the system number, print out the name of
+        each system. Default is False because system name is not usually
+        specified when performing implicit interconnection using
+        :func:`interconnect`.
+
+    Examples
+    --------
+    >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y')
+    >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u')
+    >>> L = ct.interconnect([C, P], inputs='e', outputs='y')
+    >>> ct.signal_table(L) # doctest: +SKIP
+    signal    | source                  | destination
+    --------------------------------------------------------------
+    e         | input                   | system 0
+    u         | system 0                | system 1
+    y         | system 1                | output
+    """
+    assert isinstance(sys, InterconnectedSystem), "system must be"\
+        "an InterconnectedSystem."
+
+    sys.signal_table(**kwargs)

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -2132,8 +2132,8 @@ def interconnect(
     If a system is duplicated in the list of systems to be connected,
     a warning is generated and a copy of the system is created with the
     name of the new system determined by adding the prefix and suffix
-    strings in config.defaults['iosys.linearized_system_name_prefix']
-    and config.defaults['iosys.linearized_system_name_suffix'], with the
+    strings in config.defaults['iosys.duplicate_system_name_prefix']
+    and config.defaults['iosys.duplicate_system_name_suffix'], with the
     default being to add the suffix '$copy' to the system name.
 
     In addition to explicit lists of system signals, it is possible to

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -1021,14 +1021,14 @@ class InterconnectedSystem(NonlinearIOSystem):
         >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u', name='C')
         >>> L = ct.interconnect([C, P], inputs='e', outputs='y')
         >>> L.signal_table(show_names=True) # doctest: +SKIP
-        signal    | source                  | destination
-        --------------------------------------------------------------
-        e         | input                   | C
-        u         | C                       | P
-        y         | P                       | output
+        signal    | source                        | destination
+        --------------------------------------------------------------------
+        e         | input                         | C
+        u         | C                             | P
+        y         | P                             | output
         """
 
-        spacing = 26
+        spacing = 32
         print('signal'.ljust(10) + '| source'.ljust(spacing) + '| destination')
         print('-'*(10 + spacing * 2))
 
@@ -1053,12 +1053,12 @@ class InterconnectedSystem(NonlinearIOSystem):
             for idx, sys in enumerate(self.syslist):
                 loc = sys.find_output(signal_label)
                 if loc is not None:
-                    if not sources.endswith(', '):
+                    if not sources.endswith(' '):
                         sources += ', '
                     sources += sys.name if show_names else 'system ' + str(idx)
                 loc = sys.find_input(signal_label)
                 if loc is not None:
-                    if not dests.endswith(', '):
+                    if not dests.endswith(' '):
                         dests += ', '
                     dests += sys.name if show_names else 'system ' + str(idx)
             print(sources.ljust(spacing), end='')

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1459,7 +1459,7 @@ class LinearICSystem(InterconnectedSystem, StateSpace):
 
     """
 
-    def __init__(self, io_sys, ss_sys=None):
+    def __init__(self, io_sys, ss_sys=None, connection_type=None):
         #
         # Because this is a "hybrid" object, the initialization proceeds in
         # stages.  We first create an empty InputOutputSystem of the
@@ -1483,6 +1483,7 @@ class LinearICSystem(InterconnectedSystem, StateSpace):
         self.input_map = io_sys.input_map
         self.output_map = io_sys.output_map
         self.params = io_sys.params
+        self.connection_type = connection_type
 
         # If we didnt' get a state space system, linearize the full system
         if ss_sys is None:

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -202,14 +202,14 @@ def test_interconnect_docstring():
     np.testing.assert_almost_equal(T.D, T_ss.D)
 
 @pytest.mark.parametrize("show_names", (True, False))
-def test_signal_table(capsys, show_names):
+def test_connection_table(capsys, show_names):
     P = ct.ss(1,1,1,0, inputs='u', outputs='y', name='P')
     C = ct.tf(10, [.1, 1], inputs='e', outputs='u', name='C')
     L = ct.interconnect([C, P], inputs='e', outputs='y')
-    L.signal_table(show_names=show_names)
+    L.connection_table(show_names=show_names)
     captured_from_method = capsys.readouterr().out
 
-    ct.signal_table(L, show_names=show_names)
+    ct.connection_table(L, show_names=show_names)
     captured_from_function = capsys.readouterr().out
 
     # break the following strings separately because the printout order varies
@@ -237,10 +237,10 @@ def test_signal_table(capsys, show_names):
     P2 = ct.tf(10, [.1, 1], inputs='e', outputs='y', name='P2')
     P3 = ct.tf(10, [.1, 1], inputs='x', outputs='y', name='P3')
     P = ct.interconnect([P1, P2, P3], inputs=['e', 'u', 'x'], outputs='y')
-    P.signal_table(show_names=show_names)
+    P.connection_table(show_names=show_names)
     captured_from_method = capsys.readouterr().out
 
-    ct.signal_table(P, show_names=show_names)
+    ct.connection_table(P, show_names=show_names)
     captured_from_function = capsys.readouterr().out
 
     mystrings = \
@@ -268,10 +268,10 @@ def test_signal_table(capsys, show_names):
     P2 = ct.tf(10, [.1, 1], inputs='u', outputs='y', name='P2')
     P3 = ct.tf(10, [.1, 1], inputs='u', outputs='z', name='P3')
     P = ct.interconnect([P1, P2, P3], inputs=['u'], outputs=['x','y','z'])
-    P.signal_table(show_names=show_names)
+    P.connection_table(show_names=show_names)
     captured_from_method = capsys.readouterr().out
 
-    ct.signal_table(P, show_names=show_names)
+    ct.connection_table(P, show_names=show_names)
     captured_from_function = capsys.readouterr().out
 
     mystrings = \

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -201,6 +201,24 @@ def test_interconnect_docstring():
     np.testing.assert_almost_equal(T.C @ T. A @ T.B, T_ss.C @ T_ss.A @ T_ss.B)
     np.testing.assert_almost_equal(T.D, T_ss.D)
 
+def test_signal_table(capsys):
+    P = ct.ss(1,1,1,0, inputs='u', outputs='y')
+    C = ct.tf(10, [.1, 1], inputs='e', outputs='u')
+    L = ct.interconnect([C, P], inputs='e', outputs='y')
+    L.signal_table()
+    captured = capsys.readouterr().out
+
+    # break the following strings separately because the printout order varies
+    # because signals are stored as a dict
+    mystrings = \
+    ["signal    | source                  | destination",
+     "-------------------------------------------------------------",
+     "e         | input                   | system 0",
+     "u         | system 0                | system 1",
+     "y         | system 1                | output"]
+
+    for str_ in mystrings:
+        assert str_ in captured
 
 def test_interconnect_exceptions():
     # First make sure the docstring example works

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -276,7 +276,7 @@ def test_connection_table(capsys, show_names):
 
     mystrings = \
             ["signal    | source                        | destination",
-     "-------------------------------------------------------------------"]
+             "-------------------------------------------------------------------"]
     if show_names:
         mystrings += \
             ["u         | input                         | P1, P2, P3",
@@ -293,6 +293,34 @@ def test_connection_table(capsys, show_names):
     for str_ in mystrings:
         assert str_ in captured_from_method
         assert str_ in captured_from_function
+
+    # check change column width
+    P.connection_table(show_names=show_names, column_width=20)
+    captured_from_method = capsys.readouterr().out
+
+    ct.connection_table(P, show_names=show_names, column_width=20)
+    captured_from_function = capsys.readouterr().out
+
+    mystrings = \
+            ["signal    | source            | destination",
+             "------------------------------------------------"]
+    if show_names:
+        mystrings += \
+            ["u         | input             | P1, P2, P3",
+             "x         | P1                | output  ",
+             "y         | P2                | output",
+             "z         | P3                | output"]
+    else:
+        mystrings += \
+            ["u         | input             | system 0, syste.. ",
+             "x         | system 0          | output  ",
+             "y         | system 1          | output",
+             "z         | system 2          | output"]
+
+    for str_ in mystrings:
+        assert str_ in captured_from_method
+        assert str_ in captured_from_function
+
 
 def test_interconnect_exceptions():
     # First make sure the docstring example works

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -215,23 +215,84 @@ def test_signal_table(capsys, show_names):
     # break the following strings separately because the printout order varies
     # because signal names are stored as a set
     mystrings = \
-    ["signal    | source                  | destination",
-     "-------------------------------------------------------------"]
+            ["signal    | source                        | destination",
+             "------------------------------------------------------------------"]
     if show_names:
         mystrings += \
-            ["e         | input                   | C",
-             "u         | C                       | P",
-             "y         | P                       | output"]
+            ["e         | input                         | C",
+             "u         | C                             | P",
+             "y         | P                             | output"]
     else:
         mystrings += \
-            ["e         | input                   | system 0",
-             "u         | system 0                | system 1",
-             "y         | system 1                | output"]
+            ["e         | input                         | system 0",
+             "u         | system 0                      | system 1",
+             "y         | system 1                      | output"]
 
     for str_ in mystrings:
         assert str_ in captured_from_method
         assert str_ in captured_from_function
 
+    # check auto-sum
+    P1 = ct.ss(1,1,1,0, inputs='u', outputs='y', name='P1')
+    P2 = ct.tf(10, [.1, 1], inputs='e', outputs='y', name='P2')
+    P3 = ct.tf(10, [.1, 1], inputs='x', outputs='y', name='P3')
+    P = ct.interconnect([P1, P2, P3], inputs=['e', 'u', 'x'], outputs='y')
+    P.signal_table(show_names=show_names)
+    captured_from_method = capsys.readouterr().out
+
+    ct.signal_table(P, show_names=show_names)
+    captured_from_function = capsys.readouterr().out
+
+    mystrings = \
+            ["signal    | source                        | destination",
+     "-------------------------------------------------------------------"]
+    if show_names:
+        mystrings += \
+            ["u         | input                         | P1",
+             "e         | input                         | P2",
+             "x         | input                         | P3",
+             "y         | P1, P2, P3                    | output"]
+    else:
+        mystrings += \
+            ["u         | input                         | system 0",
+             "e         | input                         | system 1",
+             "x         | input                         | system 2",
+             "y         | system 0, system 1, system 2  | output"]
+
+    for str_ in mystrings:
+        assert str_ in captured_from_method
+        assert str_ in captured_from_function
+
+    # check auto-split
+    P1 = ct.ss(1,1,1,0, inputs='u', outputs='x', name='P1')
+    P2 = ct.tf(10, [.1, 1], inputs='u', outputs='y', name='P2')
+    P3 = ct.tf(10, [.1, 1], inputs='u', outputs='z', name='P3')
+    P = ct.interconnect([P1, P2, P3], inputs=['u'], outputs=['x','y','z'])
+    P.signal_table(show_names=show_names)
+    captured_from_method = capsys.readouterr().out
+
+    ct.signal_table(P, show_names=show_names)
+    captured_from_function = capsys.readouterr().out
+
+    mystrings = \
+            ["signal    | source                        | destination",
+     "-------------------------------------------------------------------"]
+    if show_names:
+        mystrings += \
+            ["u         | input                         | P1, P2, P3",
+             "x         | P1                            | output  ",
+             "y         | P2                            | output",
+             "z         | P3                            | output"]
+    else:
+        mystrings += \
+            ["u         | input                         | system 0, system 1, system 2",
+             "x         | system 0                      | output  ",
+             "y         | system 1                      | output",
+             "z         | system 2                      | output"]
+
+    for str_ in mystrings:
+        assert str_ in captured_from_method
+        assert str_ in captured_from_function
 
 def test_interconnect_exceptions():
     # First make sure the docstring example works

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -36,6 +36,7 @@ System interconnections
     negate
     parallel
     series
+    signal_table
 
 
 Frequency domain plotting

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -36,7 +36,7 @@ System interconnections
     negate
     parallel
     series
-    signal_table
+    connection_table
 
 
 Frequency domain plotting


### PR DESCRIPTION
This PR prints out a table of each signal name, where it comes from (source), and where it goes (destination). It is intended primarily for systems that have been connected implicitly, because in that case all of the signal names have been defined. It doesn't really work for systems that have been connected explicitly, because their signal names may not be unique

It was is inspired by a similar table printout in [bdsim](https://petercorke.github.io/bdsim/bdsim.html#getting-started) and the need to have a means to debug interconnections of many systems. 

Example: 
```python
        >>> P = ct.ss(1,1,1,0, inputs='u', outputs='y')
        >>> C = ct.tf(10, [.1, 1], inputs='e', outputs='u')
        >>> L = ct.interconnect([C, P], inputs='e', outputs='y')
        >>> L.connection_table()
        signal    | source                  | destination
        --------------------------------------------------------------
        e         | input                   | system 0
        u         | system 0                | system 1
        y         | system 1                | output
```
(edit: in the code above, `signal_table` has been changed to `connection_table`)
Remarks: 
* it does not list systems by their name by default because the because default system names (e.g. `sys[17]`) are not very descriptive or helpful when you're connecting systems implicitly with signal names. instead the table just references them by the order they appear in the interconnect list, with an option to print names instead. 
* it would be convenient if instead systems were listed by the name of the variable referencing them, e.g. if the first row looked like  ```e   | input     | C       ```, but this is not straightforward in Python because it is possible to have many variable names pointing to the same object in memory.
* Maybe this could be achieved using a change to the library that automatically populates the 'name' field in new systems with the variable name it is first assigned to, but I am not sure if this is possible or Pythonic
* this PR also includes a couple of docstring cleanups to remove references to the namedio class
