### PR TITLE
Improved speed of ctrb and obsv functions

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -1027,7 +1027,7 @@ def ctrb(A, B, t=None):
     ctrb = np.zeros((n, t * m))
     ctrb[:, :m] = bmat
     for k in range(1, t):
-        ctrb[:, k * m:(k + 1) * m] = amat @ ctrb[:, (k - 1) * m:k * m]
+        ctrb[:, k * m:(k + 1) * m] = np.dot(amat, ctrb[:, (k - 1) * m:k * m])
 
     return _ssmatrix(ctrb)
 
@@ -1070,7 +1070,7 @@ def obsv(A, C, t=None):
     obsv[:p, :] = cmat
         
     for k in range(1, t):
-        obsv[k * p:(k + 1) * p, :] = obsv[(k - 1) * p:k * p, :] @ amat
+        obsv[k * p:(k + 1) * p, :] = np.dot(obsv[(k - 1) * p:k * p, :], amat)
 
     return _ssmatrix(obsv)
 

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -1024,7 +1024,7 @@ def ctrb(A, B):
     return _ssmatrix(ctrb)
 
 
-def obsv(A, C):
+def obsv(A, C, t=None):
     """Observability matrix.
 
     Parameters
@@ -1050,10 +1050,17 @@ def obsv(A, C):
     amat = _ssmatrix(A)
     cmat = _ssmatrix(C)
     n = np.shape(amat)[0]
+    
+    if t is None:
+        t = n
 
     # Construct the observability matrix
-    obsv = np.vstack([cmat] + [cmat @ np.linalg.matrix_power(amat, i)
-                               for i in range(1, n)])
+    obsv = np.zeros((t * ny, n))
+    obsv[:ny, :] = c
+        
+    for k in range(1, t):
+        obsv[k * ny:(k + 1) * ny, :] = np.dot(obsv[(k - 1) * ny:k * ny, :], a)
+
     return _ssmatrix(obsv)
 
 

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -998,7 +998,7 @@ def ctrb(A, B, t=None):
     A, B : array_like or string
         Dynamics and input matrix of the system
     t : None or integer
-        maximum time horizon of the controllability matrix, max = n
+        maximum time horizon of the controllability matrix, max = A.shape[0]
 
     Returns
     -------
@@ -1040,7 +1040,7 @@ def obsv(A, C, t=None):
     A, C : array_like or string
         Dynamics and output matrix of the system
     t : None or integer
-        maximum time horizon of the controllability matrix, max = n
+        maximum time horizon of the controllability matrix, max = A.shape[0]
         
     Returns
     -------

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -1025,9 +1025,9 @@ def ctrb(A, B, t=None):
 
     # Construct the controllability matrix
     ctrb = np.zeros((n, t * m))
-    ctrb[:, :m] = cmat
+    ctrb[:, :m] = bmat
     for k in range(1, t):
-        ctrb[:, k * m:(k + 1) * m] = np.dot(amat, obsv[:, (k - 1) * m:k * m])
+        ctrb[:, k * m:(k + 1) * m] = np.dot(amat, ctrb[:, (k - 1) * m:k * m])
 
     return _ssmatrix(ctrb)
 

--- a/control/tests/statefbk_test.py
+++ b/control/tests/statefbk_test.py
@@ -49,6 +49,14 @@ class TestStatefbk:
         Wc = ctrb(A, B)
         np.testing.assert_array_almost_equal(Wc, Wctrue)
 
+    def testCtrbT(self):
+        A = np.array([[1., 2.], [3., 4.]])
+        B = np.array([[5., 6.], [7., 8.]])
+        t = 1
+        Wctrue = np.array([[5., 6.], [7., 8.]])
+        Wc = ctrb(A, B, t=t)
+        np.testing.assert_array_almost_equal(Wc, Wctrue)
+        
     def testObsvSISO(self):
         A = np.array([[1., 2.], [3., 4.]])
         C = np.array([[5., 7.]])
@@ -61,6 +69,14 @@ class TestStatefbk:
         C = np.array([[5., 6.], [7., 8.]])
         Wotrue = np.array([[5., 6.], [7., 8.], [23., 34.], [31., 46.]])
         Wo = obsv(A, C)
+        np.testing.assert_array_almost_equal(Wo, Wotrue)
+        
+    def testObsvT(self):
+        A = np.array([[1., 2.], [3., 4.]])
+        C = np.array([[5., 6.], [7., 8.]])
+        t = 1
+        Wotrue = np.array([[5., 6.], [7., 8.]])
+        Wo = obsv(A, C, t=t)
         np.testing.assert_array_almost_equal(Wo, Wotrue)
 
     def testCtrbObsvDuality(self):


### PR DESCRIPTION
Current implementation of ctrb and obsv functions utilize `np.linalg.matrix_power` inside of a `for i in range(1,n)` loop. I modified these functions to reduce the number of matrix multiplications by `amat` essentially by utilizing the precomputed matrix exponentiation from the `i-1`the iteration of the loop when computing the `i`th iteration. This is similar to the MATLAB implementation of the similar functions.

Additionally, I added an optional parameter `t` to both functions that defaults to `None` for the case where the reduced observability and controllability matrices are needed. By default, the full observability and controllability matrices are created. 

This appears to pass all test cases.