### PR TITLE
fix sphinx bug (erroneous use of class template)

### DIFF
--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -139,7 +139,6 @@ state) response of an LTI systems:
 
 .. autosummary::
    :toctree: generated/
-   :template: custom-class-template.rst
 
     initial_response
     step_response


### PR DESCRIPTION
Fixes issue #942.  The problem was that there was an autosummary that was erroneously using a class template for functions.

