### PR TITLE
Fix bug in matched transformation + address other issues in #950

### DIFF
--- a/control/dtime.py
+++ b/control/dtime.py
@@ -55,8 +55,7 @@ __all__ = ['sample_system', 'c2d']
 # Sample a continuous time system
 def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
         name=None, copy_names=True, **kwargs):
-    """
-    Convert a continuous time system to discrete time by sampling.
+    """Convert a continuous time system to discrete time by sampling.
 
     Parameters
     ----------
@@ -67,9 +66,9 @@ def sample_system(sysc, Ts, method='zoh', alpha=None, prewarp_frequency=None,
     method : string
         Method to use for conversion, e.g. 'bilinear', 'zoh' (default)
     alpha : float within [0, 1]
-            The generalized bilinear transformation weighting parameter, which
-            should only be specified with method="gbt", and is ignored
-            otherwise. See :func:`scipy.signal.cont2discrete`.
+        The generalized bilinear transformation weighting parameter, which
+        should only be specified with method="gbt", and is ignored
+        otherwise. See :func:`scipy.signal.cont2discrete`.
     prewarp_frequency : float within [0, infinity)
         The frequency [rad/s] at which to match with the input continuous-
         time system's magnitude and phase (only valid for method='bilinear',

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -894,8 +894,10 @@ def bode_plot(
     # list of systems (e.g., "Step response for sys[1], sys[2]").
     #
 
-    # Set the initial title for the data (unique system names)
-    sysnames = list(set([response.sysname for response in data]))
+    # Set the initial title for the data (unique system names, preserving order)
+    seen = set()
+    sysnames = [response.sysname for response in data \
+                if not (response.sysname in seen or seen.add(response.sysname))]
     if title is None:
         if data[0].title is None:
             title = "Bode plot for " + ", ".join(sysnames)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1288,8 +1288,7 @@ class TransferFunction(LTI):
 # c2d function contributed by Benjamin White, Oct 2012
 def _c2d_matched(sysC, Ts, **kwargs):
     if not sysC.issiso():
-            raise ControlMIMONotImplemented("Not implemented for MIMO systems")
-        raise ValueError("MIMO transfer functions not supported")
+        raise ControlMIMONotImplemented("Not implemented for MIMO systems")
 
     # Pole-zero match method of continuous to discrete time conversion
     szeros, spoles, _ = tf2zpk(sysC.num[0][0], sysC.den[0][0])

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1287,7 +1287,8 @@ class TransferFunction(LTI):
 
 # c2d function contributed by Benjamin White, Oct 2012
 def _c2d_matched(sysC, Ts, **kwargs):
-    if sysC.ninputs > 1 or sysC.noutputs > 1:
+    if not sysC.issiso():
+            raise ControlMIMONotImplemented("Not implemented for MIMO systems")
         raise ValueError("MIMO transfer functions not supported")
 
     # Pole-zero match method of continuous to discrete time conversion


### PR DESCRIPTION
This PR fixes the calculation of the DC gain in the 'matched' transformation from continuous time to discrete time.  It also fixes some other issues identified in #950.  Also adds unit test for `sample_system` that catches the original error.
