### PR TITLE
Fix CI warnings 

### DIFF
--- a/control/flatsys/linflat.py
+++ b/control/flatsys/linflat.py
@@ -119,10 +119,10 @@ class LinearFlatSystem(FlatSystem, StateSpace):
         x = np.reshape(x, (-1, 1))
         u = np.reshape(u, (1, -1))
         zflag = [np.zeros(self.nstates + 1)]
-        zflag[0][0] = self.Cf @ x
+        zflag[0][0] = (self.Cf @ x).item()
         H = self.Cf                     # initial state transformation
         for i in range(1, self.nstates + 1):
-            zflag[0][i] = H @ (self.A @ x + self.B @ u)
+            zflag[0][i] = (H @ (self.A @ x + self.B @ u)).item()
             H = H @ self.A       # derivative for next iteration
         return zflag
 

--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -473,7 +473,7 @@ def bode_plot(
     if ax is None:
         with plt.rc_context(_freqplot_rcParams):
             ax_array = fig.subplots(nrows, ncols, squeeze=False)
-            fig.set_tight_layout(True)
+            fig.set_layout_engine('tight')
             fig.align_labels()
 
         # Set up default sharing of axis limits if not specified

--- a/control/optimal.py
+++ b/control/optimal.py
@@ -956,7 +956,7 @@ def solve_ocp(
         transpose=None, return_states=True, print_summary=True, log=False,
         **kwargs):
 
-    """Compute the solution to an optimal control problem.
+    r"""Compute the solution to an optimal control problem.
 
     The optimal trajectory (states and inputs) is computed so as to
     approximately mimimize a cost function of the following form (for

--- a/control/robust.py
+++ b/control/robust.py
@@ -41,6 +41,7 @@
 
 # External packages and modules
 import numpy as np
+import warnings
 from .exception import *
 from .statesp import StateSpace
 from .statefbk import *
@@ -357,7 +358,12 @@ def augw(g, w1=None, w2=None, w3=None):
     # output indices
     oi = np.arange(1, 1 + now1 + now2 + now3 + ny)
 
-    p = connect(sysall, q, ii, oi)
+    # Filter out known warning due to use of connect
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore', message="`connect`", category=DeprecationWarning)
+
+        p = connect(sysall, q, ii, oi)
 
     return p
 

--- a/control/sisotool.py
+++ b/control/sisotool.py
@@ -186,7 +186,11 @@ def _SisotoolUpdate(sys, fig, K, bode_plot_params, tvect=None):
         sys_closed = append(sys, -K)
         connects = [[1, 3],
                     [3, 1]]
-        sys_closed = connect(sys_closed, connects, 2, 2)
+        # Filter out known warning due to use of connect
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', message="`connect`", category=DeprecationWarning)
+            sys_closed = connect(sys_closed, connects, 2, 2)
     if tvect is None:
         tvect, yout = step_response(sys_closed, T_num=100)
     else:

--- a/control/stochsys.py
+++ b/control/stochsys.py
@@ -183,14 +183,14 @@ def lqe(*args, **kwargs):
 
 # contributed by Sawyer B. Fuller <minster@uw.edu>
 def dlqe(*args, **kwargs):
-    """dlqe(A, G, C, QN, RN, [, N])
+    r"""dlqe(A, G, C, QN, RN, [, N])
 
     Linear quadratic estimator design (Kalman filter) for discrete-time
     systems. Given the system
 
     .. math::
 
-        x[n+1] &= Ax[n] + Bu[n] + Gw[n] \\\\
+        x[n+1] &= Ax[n] + Bu[n] + Gw[n] \\
         y[n] &= Cx[n] + Du[n] + v[n]
 
     with unbiased process noise w and measurement noise v with covariances

--- a/control/tests/flatsys_test.py
+++ b/control/tests/flatsys_test.py
@@ -194,14 +194,17 @@ class TestFlatSys:
         else:
             initial_guess = None
 
-        # Solve the optimal trajectory
-        traj_ocp = fs.solve_flat_ocp(
-            vehicle_flat, timepts, x0, u0,
-            cost=traj_cost, constraints=input_constraints,
-            terminal_cost=terminal_cost, basis=basis,
-            initial_guess=initial_guess,
-            minimize_kwargs={'method': method},
-        )
+        # Solve the optimal trajectory (allow warnings)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', message="unable to solve", category=UserWarning)
+            traj_ocp = fs.solve_flat_ocp(
+                vehicle_flat, timepts, x0, u0,
+                cost=traj_cost, constraints=input_constraints,
+                terminal_cost=terminal_cost, basis=basis,
+                initial_guess=initial_guess,
+                minimize_kwargs={'method': method},
+            )
         xd, ud = traj_ocp.eval(timepts)
 
         if not traj_ocp.success:

--- a/control/tests/optimal_test.py
+++ b/control/tests/optimal_test.py
@@ -745,12 +745,15 @@ def test_optimal_doc(method, npts, initial_guess, fail):
         initial_guess = (state_guess, input_guess)
 
     # Solve the optimal control problem
-    result = opt.solve_ocp(
-        vehicle, timepts, x0, traj_cost, constraints,
-        terminal_cost=term_cost, initial_guess=initial_guess,
-        trajectory_method=method,
-        # minimize_method='COBYLA', # SLSQP',
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore', message="unable to solve", category=UserWarning)
+        result = opt.solve_ocp(
+            vehicle, timepts, x0, traj_cost, constraints,
+            terminal_cost=term_cost, initial_guess=initial_guess,
+            trajectory_method=method,
+            # minimize_method='COBYLA', # SLSQP',
+        )
 
     if fail == 'xfail':
         assert not result.success

--- a/control/tests/sisotool_test.py
+++ b/control/tests/sisotool_test.py
@@ -79,8 +79,7 @@ class TestSisotool:
             'omega_limits': None,
             'omega_num': None,
             'ax': np.array([[ax_mag], [ax_phase]]),
-            'margins': True,
-            'margin_info': True,
+            'display_margins': 'overlay',
         }
 
         # Check that the xaxes of the bode plot are shared before the rlocus click

--- a/control/timeplot.py
+++ b/control/timeplot.py
@@ -292,7 +292,7 @@ def time_response_plot(
     if ax is None:
         with plt.rc_context(timeplot_rcParams):
             ax_array = fig.subplots(nrows, ncols, sharex=True, squeeze=False)
-            fig.set_tight_layout(True)
+            fig.set_layout_engine('tight')
             fig.align_labels()
 
     else:

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -1084,7 +1084,7 @@ def forced_response(sys, T=None, U=0., X0=0., transpose=False,
             if U.ndim == 1:
                 U = U.reshape(1, -1)  # pylint: disable=E1103
 
-        # Algorithm: to integrate from time 0 to time dt, with linear
+            # Algorithm: to integrate from time 0 to time dt, with linear
             # interpolation between inputs u(0) = u0 and u(dt) = u1, we solve
             #   xdot = A x + B u,        x(0) = x0
             #   udot = (u1 - u0) / dt,   u(0) = u0.

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -470,7 +470,7 @@ class TransferFunction(LTI):
                 elif self.display_format == 'zpk':
                     num = self.num[no][ni]
                     if num.size == 1 and num.item() == 0:
-                        # Catch a special case taht SciPy doesn't handle
+                        # Catch a special case that SciPy doesn't handle
                         z, p, k = tf2zpk([1.], self.den[no][ni])
                         k = 0
                     else:

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -468,7 +468,13 @@ class TransferFunction(LTI):
                     numstr = _tf_polynomial_to_string(self.num[no][ni], var=var)
                     denstr = _tf_polynomial_to_string(self.den[no][ni], var=var)
                 elif self.display_format == 'zpk':
-                    z, p, k = tf2zpk(self.num[no][ni], self.den[no][ni])
+                    num = self.num[no][ni]
+                    if num.size == 1 and num.item() == 0:
+                        # Catch a special case taht SciPy doesn't handle
+                        z, p, k = tf2zpk([1.], self.den[no][ni])
+                        k = 0
+                    else:
+                        z, p, k = tf2zpk(self.num[no][ni], self.den[no][ni])
                     numstr = _tf_factorized_polynomial_to_string(
                         z, gain=k, var=var)
                     denstr = _tf_factorized_polynomial_to_string(p, var=var)


### PR DESCRIPTION
This PR makes a bunch of small changes to remove warning messages in the GitHub actions CI runs:
* Access scalar NumPy arrays using `item()` (old usage is newly deprecated in NumPy).
* Change `set_tight_layout(True)` to `fig.set_layout_engine('tight')` (newly deprecated in Matplotlib).
* Update unit tests using deprecated functionality to use current functionality.
* Add warning filters for internal calls to `connect` (which are OK for now).
* Avoid calling tf2zpk with zero in the numerator (SciPy generates warning).
* Fix up some strings that had newly deprecated escape sequences (by using raw strings)
* Turn off warnings for optimal control problems that fail to hit desired precision (but still return valid answers)

Note: it is likely that this PR will conflict with #953.  We should probably merge #953 first and then rebase this PR since the changes here are pretty straightforward.