### PR TITLE
Support Python 3.12, Bump minimum support according to SPEC 0

### DIFF
--- a/.github/conda-env/build-env.yml
+++ b/.github/conda-env/build-env.yml
@@ -1,4 +1,4 @@
 name: build-env
 dependencies:
   - boa
-  - numpy !=1.23.0
+  - numpy

--- a/.github/conda-env/doctest-env.yml
+++ b/.github/conda-env/doctest-env.yml
@@ -1,11 +1,7 @@
-name: test-env
+name: doctest-env
 dependencies:
-  - conda-build  # for conda index
   - pip
-  - coverage
-  - coveralls
   - pytest
-  - pytest-cov
   - pytest-timeout
   - pytest-xvfb
   - numpy

--- a/.github/conda-env/test-env.yml
+++ b/.github/conda-env/test-env.yml
@@ -1,9 +1,7 @@
 name: test-env
 dependencies:
-  - conda-build  # for conda index
   - pip
   - coverage
-  - coveralls
   - pytest
   - pytest-cov
   - pytest-timeout

--- a/.github/workflows/control-slycot-src.yml
+++ b/.github/workflows/control-slycot-src.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install Python dependencies and test tools
       run: pip install -v './python-control[test]'
 

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.11
-        activate-environment: test-env
+        python-version: 3.12
+        activate-environment: doctest-env
         environment-file: .github/conda-env/doctest-env.yml
         miniforge-version: latest
         miniforge-variant: Mambaforge
@@ -32,8 +32,6 @@ jobs:
 
     - name: Run doctest
       shell: bash -l {0}
-      env:
-        MPLBACKEND: ${{ matrix.mplbackend }}
       working-directory: doc
       run: |
         make html

--- a/.github/workflows/install_examples.yml
+++ b/.github/workflows/install_examples.yml
@@ -18,7 +18,7 @@ jobs:
            --channel conda-forge \
            --strict-channel-priority \
            --quiet --yes \
-           python=3.11 pip \
+           python=3.12 pip \
            numpy matplotlib scipy \
            slycot pmw jupyter
 

--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -21,24 +21,24 @@ jobs:
               - 'ubuntu'
               - 'macos'
             python:
-              - '3.8'
-              - '3.11'
+              - '3.10'
+              - '3.12'
             bla_vendor: [ 'unset' ]
             include:
               - os: 'ubuntu'
-                python: '3.11'
+                python: '3.12'
                 bla_vendor: 'Generic'
               - os: 'ubuntu'
-                python: '3.11'
+                python: '3.12'
                 bla_vendor: 'OpenBLAS'
               - os: 'macos'
-                python: '3.11'
+                python: '3.12'
                 bla_vendor: 'Apple'
               - os: 'macos'
-                python: '3.11'
+                python: '3.12'
                 bla_vendor: 'Generic'
               - os: 'macos'
-                python: '3.11'
+                python: '3.12'
                 bla_vendor: 'OpenBLAS'
 
     steps:
@@ -108,7 +108,7 @@ jobs:
             - 'macos'
             - 'windows'
           python:
-            - '3.9'
+            # build on one, expand matrix in conda-build from the Sylcot/conda-recipe/conda_build_config.yaml
             - '3.11'
 
     steps:
@@ -133,14 +133,14 @@ jobs:
         shell: bash -l {0}
         run: |
           set -e
-          numpyversion=$(python -c 'import numpy; print(numpy.version.version)')
-          conda mambabuild --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
+          conda mambabuild conda-recipe
           # preserve directory structure for custom conda channel
           find "${CONDA_PREFIX}/conda-bld" -maxdepth 2 -name 'slycot*.tar.bz2' | while read -r conda_pkg; do
             conda_platform=$(basename $(dirname "${conda_pkg}"))
             mkdir -p "slycot-conda-pkgs/${conda_platform}"
             cp "${conda_pkg}" "slycot-conda-pkgs/${conda_platform}/"
           done
+          conda index --no-progress ./slycot-conda-pkgs
       - name: Save to local conda pkg channel
         uses: actions/upload-artifact@v3
         with:
@@ -247,7 +247,7 @@ jobs:
       - name: Install Wheel
         run: |
           python -m pip install --upgrade pip
-          pip install matplotlib scipy pytest pytest-cov pytest-timeout coverage coveralls
+          pip install matplotlib scipy pytest pytest-cov pytest-timeout coverage
           pip install slycot-wheels/${{ matrix.packagekey }}/slycot*.whl
           pip show slycot
       - name: Test with pytest
@@ -316,7 +316,6 @@ jobs:
               echo "libblas * *mkl" >> $CONDA_PREFIX/conda-meta/pinned
               ;;
           esac
-          conda index --no-progress ./slycot-conda-pkgs
           mamba install -c ./slycot-conda-pkgs slycot
           conda list
       - name: Test with pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -16,13 +16,13 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.8', '3.12']
         slycot: ["", "conda"]
         pandas: [""]
         cvxopt: ["", "conda"]
         mplbackend: [""]
         include:
-          - python-version: '3.11'
+          - python-version: '3.12'
             slycot: conda
             pandas: conda
             cvxopt: conda

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.12']
+        python-version: ['3.10', '3.12']
         slycot: ["", "conda"]
         pandas: [""]
         cvxopt: ["", "conda"]
@@ -61,20 +61,27 @@ jobs:
       shell: bash -l {0}
       env:
         MPLBACKEND: ${{ matrix.mplbackend }}
-      run: pytest -v --cov=control --cov-config=.coveragerc control/tests
+      run: |
+        pytest -v --cov=control --cov-config=.coveragerc control/tests
+        coverage xml
 
-    - name: Coveralls parallel
-      # https://github.com/coverallsapp/github-action
-      uses: AndreMiras/coveralls-python-action@develop
+    - name: report coverage
+      uses: coverallsapp/github-action@v2
       with:
+        flag-name: conda-pytest_py${{ matrix.python-version }}_${{ matrix.slycot || 'no' }}-Slycot_${{ matrix.pandas || 'no' }}-Pandas_${{ matrix.cvxopt || 'no' }}_CVXOPT-${{ matrix.mplbackend && format('; {0}', matrix.mplbackend) }}
         parallel: true
+        file: coverage.xml
 
-  coveralls:
-    name: coveralls completion
-    needs: test-linux-conda
+  coveralls-final:
+    name: Finalize parallel coveralls
+    if: always()
+    needs:
+      - test-linux-conda
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@develop
+      uses: coverallsapp/github-action@v2
       with:
-        parallel-finished: true
+        parallel-finished: true  
+
+

--- a/control/config.py
+++ b/control/config.py
@@ -48,6 +48,20 @@ class DefaultDict(collections.UserDict):
         else:
             raise KeyError(key)
 
+    # New get function for Python 3.12+ to replicate old behavior
+    def get(self, key, defval=None):
+        # If the key exists, return it
+        if self.__contains__(key):
+            return self[key]
+
+        # If not, see if it is deprecated
+        repl = self._check_deprecation(key)
+        if self.__contains__(repl):
+            return self.get(repl, defval)
+
+        # Otherwise, call the usual dict.get() method
+        return super().get(key, defval)
+
     def _check_deprecation(self, key):
         if self.__contains__(f"deprecated.{key}"):
             repl = self[f"deprecated.{key}"]

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -409,16 +409,16 @@ def test_linear_interconnect():
         ct.StateSpace)
 
     # Interconnections with nonliner I/O systems should not be linear
-    assert ~isinstance(
+    assert not isinstance(
         ct.interconnect([nl_ctrl, ss_plant, sumblk], inputs='r', outputs='y'),
         ct.StateSpace)
-    assert ~isinstance(
+    assert not isinstance(
         ct.interconnect([nl_ctrl, tf_plant, sumblk], inputs='r', outputs='y'),
         ct.StateSpace)
-    assert ~isinstance(
+    assert not isinstance(
         ct.interconnect([ss_ctrl, nl_plant, sumblk], inputs='r', outputs='y'),
         ct.StateSpace)
-    assert ~isinstance(
+    assert not isinstance(
         ct.interconnect([tf_ctrl, nl_plant, sumblk], inputs='r', outputs='y'),
         ct.StateSpace)
 

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -1579,12 +1579,12 @@ def test_linear_interconnection():
     assert isinstance(ss_siso*ss_siso, ct.StateSpace)
     assert isinstance(tf_siso*ss_siso, ct.TransferFunction)
     assert isinstance(ss_siso*tf_siso, ct.StateSpace)
-    assert ~isinstance(ss_siso*nl_siso, ct.StateSpace)
-    assert ~isinstance(nl_siso*ss_siso, ct.StateSpace)
-    assert ~isinstance(nl_siso*nl_siso, ct.StateSpace)
-    assert ~isinstance(tf_siso*nl_siso, ct.StateSpace)
-    assert ~isinstance(nl_siso*tf_siso, ct.StateSpace)
-    assert ~isinstance(nl_siso*nl_siso, ct.StateSpace)
+    assert not isinstance(ss_siso*nl_siso, ct.StateSpace)
+    assert not isinstance(nl_siso*ss_siso, ct.StateSpace)
+    assert not isinstance(nl_siso*nl_siso, ct.StateSpace)
+    assert not isinstance(tf_siso*nl_siso, ct.StateSpace)
+    assert not isinstance(nl_siso*tf_siso, ct.StateSpace)
+    assert not isinstance(nl_siso*nl_siso, ct.StateSpace)
 
 
 def predprey(t, x, u, params={}):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",
@@ -29,11 +28,11 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
-    "numpy",
-    "scipy>=1.3",
-    "matplotlib",
+    "numpy>=1.23",
+    "scipy>=1.8",
+    "matplotlib>=3.6",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Follow [SPEC 0](https://scientific-python.org/specs/spec-0000/): Drop Python <3.9, bump as much of the CI as we can to the current Python 3.12

This is a follow-up on https://github.com/python-control/python-control/pull/955#issuecomment-1888463800

Also replaces out of date coveralls-python with the official coveralls github action.