### PR TITLE
Add pandas to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = ["pytest", "pytest-timeout"]
 slycot = [ "slycot>=0.4.0" ]
 cvxopt = [ "cvxopt>=1.2.0" ]
 pandas = [ "pandas>=1.5.0" ]
+full = [ "control[slycot,cvxopt,pandas]" ]
 
 [project.urls]
 homepage = "https://python-control.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ packages = ["control"]
 test = ["pytest", "pytest-timeout"]
 slycot = [ "slycot>=0.4.0" ]
 cvxopt = [ "cvxopt>=1.2.0" ]
+pandas = [ "pandas>=1.5.0" ]
 
 [project.urls]
 homepage = "https://python-control.org"


### PR DESCRIPTION
Adds pandas to pyproject.toml.

Allows optional install

```bash
pip install control[pandas]
pip install control[pandas,slycot]
...
```