### PR TITLE
Fix examples

### DIFF
--- a/examples/bode-and-nyquist-plots.ipynb
+++ b/examples/bode-and-nyquist-plots.ipynb
@@ -16,6 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "import scipy as sp\n",
     "import matplotlib.pyplot as plt\n",
     "import control as ct"
@@ -109,9 +110,9 @@
     "w001rad = 1.    # 1 rad/s\n",
     "w010rad = 10.   # 10 rad/s\n",
     "w100rad = 100.  # 100 rad/s\n",
-    "w001hz = 2*sp.pi*1.    # 1 Hz\n",
-    "w010hz = 2*sp.pi*10.   # 10 Hz\n",
-    "w100hz = 2*sp.pi*100.  # 100 Hz\n",
+    "w001hz = 2*np.pi*1.    # 1 Hz\n",
+    "w010hz = 2*np.pi*10.   # 10 Hz\n",
+    "w100hz = 2*np.pi*100.  # 100 Hz\n",
     "# First order systems\n",
     "pt1_w001rad = ct.tf([1.], [1./w001rad, 1.], name='pt1_w001rad')\n",
     "display(pt1_w001rad)\n",
@@ -153,7 +154,7 @@
    ],
    "source": [
     "sampleTime = 0.001\n",
-    "display('Nyquist frequency: {:.0f} Hz, {:.0f} rad/sec'.format(1./sampleTime /2., 2*sp.pi*1./sampleTime /2.))"
+    "display('Nyquist frequency: {:.0f} Hz, {:.0f} rad/sec'.format(1./sampleTime /2., 2*np.pi*1./sampleTime /2.))"
    ]
   },
   {

--- a/examples/genswitch.py
+++ b/examples/genswitch.py
@@ -60,7 +60,7 @@ plt.plot(tim2, sol2[:, 0], 'b-', tim2, sol2[:, 1], 'g--')
 # set(pl, 'LineWidth', AM_data_linewidth)
 plt.axis([0, 25, 0, 5])
 
-plt.xlabel('Time {\itt} [scaled]')
+plt.xlabel('Time {\\itt} [scaled]')
 plt.ylabel('Protein concentrations [scaled]')
 plt.legend(('z1 (A)', 'z2 (B)'))  # 'Orientation', 'horizontal')
 # legend(legh, 'boxoff')

--- a/examples/kincar-flatsys.py
+++ b/examples/kincar-flatsys.py
@@ -100,8 +100,8 @@ def plot_results(t, x, ud, rescale=True):
 
     plt.subplot(2, 4, 8)
     plt.plot(t, ud[1])
-    plt.xlabel('Ttime t [sec]')
-    plt.ylabel('$\delta$ [rad]')
+    plt.xlabel('Time t [sec]')
+    plt.ylabel('$\\delta$ [rad]')
     plt.tight_layout()
 
 #

--- a/examples/singular-values-plot.ipynb
+++ b/examples/singular-values-plot.ipynb
@@ -90,7 +90,7 @@
    ],
    "source": [
     "sampleTime = 10\n",
-    "display('Nyquist frequency: {:.4f} Hz, {:.4f} rad/sec'.format(1./sampleTime /2., 2*sp.pi*1./sampleTime /2.))"
+    "display('Nyquist frequency: {:.4f} Hz, {:.4f} rad/sec'.format(1./sampleTime /2., 2*np.pi*1./sampleTime /2.))"
    ]
   },
   {

--- a/examples/type2_type3.py
+++ b/examples/type2_type3.py
@@ -5,7 +5,7 @@
 import os
 import matplotlib.pyplot as plt  # Grab MATLAB plotting functions
 from control.matlab import *     # MATLAB-like functions
-from scipy import pi
+from numpy import pi
 integrator = tf([0, 1], [1, 0])  # 1/s
 
 # Parameters defining the system


### PR DESCRIPTION
Conda deployed scipy 1.12 and the examples job started to fail with
> ImportError: cannot import name 'pi' from 'scipy'

* Use the officially documented NumPy API instead.
* Use the opportunity to escape two unescaped strings with LaTeX formatted labels.