### PR TITLE
remove np.int

### DIFF
--- a/external/yottalab.py
+++ b/external/yottalab.py
@@ -510,7 +510,7 @@ def placep(A,B,P):
     wrka = zeros((n,m))
     wrk1 = zeros(m)
     wrk2 = zeros(m)
-    iwrk = zeros((m),np.int)
+    iwrk = zeros((m),np.int64)
 
     A,B,ncont,indcont,nblk,z = _wrapper.ssxmc(n,m,A,n,B,wrka,wrk1,wrk2,iwrk,tol,mode)
     P = sort(P)

--- a/external/yottalab.py
+++ b/external/yottalab.py
@@ -510,7 +510,7 @@ def placep(A,B,P):
     wrka = zeros((n,m))
     wrk1 = zeros(m)
     wrk2 = zeros(m)
-    iwrk = zeros((m),np.int64)
+    iwrk = zeros((m),int)
 
     A,B,ncont,indcont,nblk,z = _wrapper.ssxmc(n,m,A,n,B,wrka,wrk1,wrk2,iwrk,tol,mode)
     P = sort(P)


### PR DESCRIPTION
In `numpy` versions >1.24 the usage of `np.int` has been deprecated. This is the only file that uses this.

This PR makes a change to allow `python-control` to be compatible with `numpy`  > 1.24.

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations