### PR TITLE
Update conda_index command in os-blas-test-matrix workflow

### DIFF
--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -140,7 +140,7 @@ jobs:
             mkdir -p "slycot-conda-pkgs/${conda_platform}"
             cp "${conda_pkg}" "slycot-conda-pkgs/${conda_platform}/"
           done
-          conda index --no-progress ./slycot-conda-pkgs
+          python -m conda_index ./slycot-conda-pkgs
       - name: Save to local conda pkg channel
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This PR updates the code used for the os-blas-test-matrix GitHub Actions workflow to reflect changes in the way conda index is implemented: https://conda.github.io/conda-index/.

This does not affect users, so I will merge this somewhat quick (w/ or w/out review -:).  Need it to run the full OS/BLAS test matrix before release 0.10.0.