### PR TITLE
Allow passing and saving of params in time responses

### DIFF
--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -1367,6 +1367,8 @@ def input_output_response(
 
         * inputs (array): Input(s) to the system, indexed by input and time.
 
+        * params (dict): Parameters values used for the simulation.
+
         The return value of the system can also be accessed by assigning the
         function to a tuple of length 2 (time, output) or of length 3 (time,
         output, state) if ``return_x`` is ``True``.  If the input/output
@@ -1643,7 +1645,7 @@ def input_output_response(
         raise TypeError("Can't determine system type")
 
     return TimeResponseData(
-        soln.t, y, soln.y, u, issiso=sys.issiso(),
+        soln.t, y, soln.y, u, params=params, issiso=sys.issiso(),
         output_labels=sys.output_labels, input_labels=sys.input_labels,
         state_labels=sys.state_labels, sysname=sys.name,
         title="Input/output response for " + sys.name,

--- a/control/tests/nlsys_test.py
+++ b/control/tests/nlsys_test.py
@@ -75,3 +75,20 @@ def test_lti_nlsys_response(nin, nout, input, output):
     resp_nl = ct.forced_response(sys_nl, timepts, U, X0=X0)
     np.testing.assert_equal(resp_ss.time, resp_nl.time)
     np.testing.assert_allclose(resp_ss.states, resp_nl.states, atol=0.05)
+
+
+# Test to make sure that impulse responses are not allowed
+def test_nlsys_impulse():
+    sys_ss = ct.rss(4, 1, 1, strictly_proper=True)
+    sys_nl = ct.nlsys(
+        lambda t, x, u, params: sys_ss.A @ x + sys_ss.B @ u,
+        lambda t, x, u, params: sys_ss.C @ x + sys_ss.D @ u,
+        inputs=1, outputs=1, states=4)
+
+    # Figure out the time to use from the linear impulse response
+    resp_ss = ct.impulse_response(sys_ss)
+    timepts = np.linspace(0, resp_ss.time[-1]/10, 100)
+
+    # Impulse_response (not implemented)
+    with pytest.raises(ValueError, match="system must be LTI"):
+        resp_nl = ct.impulse_response(sys_nl, timepts)


### PR DESCRIPTION
This PR allows parameter values to be saved in time responses as well as passing parameter values (via the `params` keyword) for the `initial_response`, ,`step_response`, and `final_response` functions (which call through to `input_output_response` for nonlinear I/O systems).

With this functionality, you can do things like
```
    nlsys = ct.nlsys(
        lambda t, x, u, params: params['a'] * x[0] + u[0],
        states = 1, inputs = 1, outputs = 1, params={'a': 0})
    timevec = np.linspace(0, 1)
    resp = step_response(nlsys, timevec, params={'a': -0.5})
```
The simulation will run with params['a'] = -0.5 and this information will be stored in `resp.params`.
