### PR TITLE
Fix warning messages in tests; update rlocus/pzmap limits

### DIFF
--- a/control/pzmap.py
+++ b/control/pzmap.py
@@ -330,7 +330,7 @@ def pole_zero_plot(
             if grid == 'empty':
                 # Leave off grid entirely
                 ax = plt.axes()
-                xlim = ylim = [0, 0]    # use data to set limits
+                xlim = ylim = [np.inf, -np.inf] # use data to set limits
             else:
                 # draw stability boundary; use first response timebase
                 ax, fig = nogrid(data[0].dt, scaling=scaling)
@@ -574,7 +574,7 @@ def _compute_root_locus_limits(response):
         ]
         ylim = max(0, np.max(response.sys.zeros().imag))
     else:
-        xlim, ylim = [0, 0], 0
+        xlim, ylim = [np.inf, -np.inf], 0
 
     # Go through each locus and look for features
     rho = config._get_param('pzmap', 'buffer_factor')
@@ -602,6 +602,12 @@ def _compute_root_locus_limits(response):
         xlim[0] = rho * xlim[0] if xlim[0] < 0 else 0
         xlim[1] = rho * xlim[1] if xlim[1] > 0 else 0
         ylim = rho * ylim if ylim > 0 else np.max(np.abs(xlim))
+
+    # Make sure the limits make sense
+    if xlim == [0, 0]:
+        xlim = [-1, 1]
+    if ylim == 0:
+        ylim = 1
 
     return xlim, [-ylim, ylim]
 

--- a/control/tests/rlocus_test.py
+++ b/control/tests/rlocus_test.py
@@ -186,11 +186,13 @@ def test_root_locus_documentation(savefigs=False):
     sys = ct.tf([1, 2], [1, 2, 3], name='SISO transfer function')
     response = ct.pole_zero_map(sys)
     ct.pole_zero_plot(response)
-    plt.savefig('pzmap-siso_ctime-default.png')
+    if savefigs:
+        plt.savefig('pzmap-siso_ctime-default.png')
 
     plt.figure()
     ct.root_locus_map(sys).plot()
-    plt.savefig('rlocus-siso_ctime-default.png')
+    if savefigs:
+        plt.savefig('rlocus-siso_ctime-default.png')
 
     # TODO: generate event in order to generate real title
     plt.figure()
@@ -200,18 +202,21 @@ def test_root_locus_documentation(savefigs=False):
     with plt.rc_context(freqplot_rcParams):
         ax.set_title(
             "Clicked at: -2.729+1.511j  gain = 3.506  damping = 0.8748")
-    plt.savefig('rlocus-siso_ctime-clicked.png')
+    if savefigs:
+        plt.savefig('rlocus-siso_ctime-clicked.png')
 
     plt.figure()
     sysd = sys.sample(0.1)
     ct.root_locus_plot(sysd)
-    plt.savefig('rlocus-siso_dtime-default.png')
+    if savefigs:
+        plt.savefig('rlocus-siso_dtime-default.png')
 
     plt.figure()
     sys1 = ct.tf([1, 2], [1, 2, 3], name='sys1')
     sys2 = ct.tf([1, 0.2], [1, 1, 3, 1, 1], name='sys2')
     ct.root_locus_plot([sys1, sys2], grid=False)
-    plt.savefig('rlocus-siso_multiple-nogrid.png')
+    if savefigs:
+        plt.savefig('rlocus-siso_multiple-nogrid.png')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes some warning messages that were showing up due to bad default limits in root locus plots and pole-zero diagrams.

(There are still a few warnings that show up in unit tests, but these seem to be due to some deprecations that matplotlib needs to fix and some strange "divide by zero" errors in computing determinants that must be in numpy or openblas.)
