### PR TITLE
Fix typo in ICSystem updfcn, outfcn: update_params -> _update_params

### DIFF
--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -706,10 +706,10 @@ class InterconnectedSystem(NonlinearIOSystem):
 
         # Create updfcn and outfcn
         def updfcn(t, x, u, params):
-            self.update_params(params)
+            self._update_params(params)
             return self._rhs(t, x, u)
         def outfcn(t, x, u, params):
-            self.update_params(params)
+            self._update_params(params)
             return self._out(t, x, u)
 
         # Initialize NonlinearIOSystem object


### PR DESCRIPTION
This PR fixes a bug in the `InterconnectedSystem` class, where the `updfcn` and `outfcn` methods call `update_params` instead of `_update_params`.  This bug didn't who up because there were no direct calls to `updfcn` and `outfcn` for an IC system.  However, these show up in the new phaseplot module code, so it can generate a error.

Simple fix; just adding an underscore in two places (and a unit test to uncover the bug).
