### PR TITLE
set response I/O labels from system for frequency response

### DIFF
--- a/control/lti.py
+++ b/control/lti.py
@@ -120,7 +120,8 @@ class LTI(InputOutputSystem):
         response = self(s)
         return FrequencyResponseData(
             response, omega, return_magphase=True, squeeze=squeeze,
-            dt=self.dt, sysname=self.name, plot_type='bode')
+            dt=self.dt, sysname=self.name, inputs=self.input_labels,
+            outputs=self.output_labels, plot_type='bode')
 
     def dcgain(self):
         """Return the zero-frequency gain"""


### PR DESCRIPTION
This is a small PR that transfers labels from a system to the labels for a frequency response.  Reviewed in #995.
