### PR TITLE
add place_varga in API doc

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -195,7 +195,7 @@ def place_varga(A, B, p, dtime=False, alpha=None):
     >>> B = [[0], [1]]
     >>> K = place_varga(A, B, [-2, -5])
 
-    See Also:
+    See Also
     --------
     place, acker
 

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -124,6 +124,7 @@ Control system synthesis
     lqr
     mixsyn
     place
+    place_varga
     rootlocus_pid_designer
 
 Model simplification tools


### PR DESCRIPTION
Hello,

This is a tiny PR proposal to add `place_varga` to the [Function reference/Control system synthesis](https://python-control.readthedocs.io/en/0.10.0/control.html#control-system-synthesis) documentation page.

I guess this was forgotten in https://github.com/python-control/python-control/pull/176 when the original `place` was renamed  `place_varga`. Unless it is intentional?

Also, this may fix the non working of link to `place_varga` in [place](https://python-control.readthedocs.io/en/0.10.0/generated/control.place.html#control.place) doc (in See also section: `acker` link is fine, but not `place_varga` ).