### PR TITLE
Improve `acker` pole placement doc

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -151,7 +151,7 @@ def place_varga(A, B, p, dtime=False, alpha=None):
     K = place_varga(A, B, p, dtime=False, alpha=None)
 
     Required Parameters
-    ----------
+    -------------------
     A : 2D array_like
         Dynamics matrix
     B : 2D array_like
@@ -160,7 +160,7 @@ def place_varga(A, B, p, dtime=False, alpha=None):
         Desired eigenvalue locations
 
     Optional Parameters
-    ---------------
+    -------------------
     dtime : bool
         False for continuous time pole placement or True for discrete time.
         The default is dtime=False.
@@ -193,7 +193,7 @@ def place_varga(A, B, p, dtime=False, alpha=None):
     --------
     >>> A = [[-1, -1], [0, 1]]
     >>> B = [[0], [1]]
-    >>> K = place_varga(A, B, [-2, -5])
+    >>> K = ct.place_varga(A, B, [-2, -5])
 
     See Also
     --------

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -269,6 +269,10 @@ def acker(A, B, poles):
     -------
     K : 2D array (or matrix)
         Gains such that A - B K has given eigenvalues
+    
+    See Also
+    --------
+    place, place_varga
 
     """
     # Convert the inputs to matrices


### PR DESCRIPTION
Hello,

This is a follow-up of #1004, still on pole placement, but now turning to [`acker` docstring](https://python-control.readthedocs.io/en/0.10.0/generated/control.acker.html#control.acker).

As a first step, this adds a "See Also" section to `place` and `place varga`.

However, I have two more ideas to extend this PR:
- add reference to the Ackermann's formula. I've found § 2.3.5 in the "Linear Control Theory" book by F. W. Fairman, 1998, but I'm not sure it matches perfectly with what's implemented.
- to the best of my (quite limited) knownledge, Ackermann's formula is for *single input* systems (and I got some linear algebra error on a test with a system with 2 inputs). If correct, I suggest to add a `ValueError` if `B.shape[1] > 1`.