### PR TITLE
Updates for NumPy 2.0 compatibility in CI tests

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -201,11 +201,11 @@ def negate(sys):
     --------
     >>> G = ct.tf([2], [1, 1])
     >>> G.dcgain()
-    2.0
+    np.float64(2.0)
 
     >>> Gn = ct.negate(G) # Same as sys2 = -sys1.
     >>> Gn.dcgain()
-    -2.0
+    np.float64(-2.0)
 
     """
     return -sys

--- a/control/descfcn.py
+++ b/control/descfcn.py
@@ -525,11 +525,11 @@ class saturation_nonlinearity(DescribingFunctionNonlinearity):
     --------
     >>> nl = ct.saturation_nonlinearity(5)
     >>> nl(1)
-    1
+    np.int64(1)
     >>> nl(10)
-    5
+    np.int64(5)
     >>> nl(-10)
-    -5
+    np.int64(-5)
 
     """
     def __init__(self, ub=1, lb=None):

--- a/control/lti.py
+++ b/control/lti.py
@@ -525,7 +525,7 @@ def dcgain(sys):
     --------
     >>> G = ct.tf([1], [1, 2])
     >>> ct.dcgain(G)                                            # doctest: +SKIP
-    0.5
+    np.float(0.5)
 
     """
     return sys.dcgain()

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -87,7 +87,7 @@ def hsvd(sys):
     >>> G = ct.tf2ss([1], [1, 2])
     >>> H = ct.hsvd(G)
     >>> H[0]
-    0.25
+    np.float64(0.25)
 
     """
     # TODO: implement for discrete time systems

--- a/control/robust.py
+++ b/control/robust.py
@@ -73,7 +73,7 @@ def h2syn(P, nmeas, ncon):
     --------
     >>> # Unstable first order SISI system
     >>> G = ct.tf([1], [1, -1], inputs=['u'], outputs=['y'])
-    >>> max(G.poles()) < 0  # Is G stable?
+    >>> all(G.poles() < 0)  # Is G stable?
     False
 
     >>> # Create partitioned system with trivial unity systems
@@ -87,7 +87,7 @@ def h2syn(P, nmeas, ncon):
     >>> # Synthesize H2 optimal stabilizing controller
     >>> K = ct.h2syn(P, nmeas=1, ncon=1)
     >>> T = ct.feedback(G, K, sign=1)
-    >>> max(T.poles()) < 0  # Is T stable?
+    >>> all(T.poles() < 0)  # Is T stable?
     True
 
     """
@@ -154,7 +154,7 @@ def hinfsyn(P, nmeas, ncon):
     --------
     >>> # Unstable first order SISI system
     >>> G = ct.tf([1], [1,-1], inputs=['u'], outputs=['y'])
-    >>> max(G.poles()) < 0
+    >>> all(G.poles() < 0)
     False
 
     >>> # Create partitioned system with trivial unity systems
@@ -167,7 +167,7 @@ def hinfsyn(P, nmeas, ncon):
     >>> # Synthesize Hinf optimal stabilizing controller
     >>> K, CL, gam, rcond = ct.hinfsyn(P, nmeas=1, ncon=1)
     >>> T = ct.feedback(G, K, sign=1)
-    >>> max(T.poles()) < 0
+    >>> all(T.poles() < 0)
     True
 
     """

--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -1011,7 +1011,7 @@ def ctrb(A, B, t=None):
     >>> G = ct.tf2ss([1], [1, 2, 3])
     >>> C = ct.ctrb(G.A, G.B)
     >>> np.linalg.matrix_rank(C)
-    2
+    np.int64(2)
 
     """
 
@@ -1053,7 +1053,7 @@ def obsv(A, C, t=None):
     >>> G = ct.tf2ss([1], [1, 2, 3])
     >>> C = ct.obsv(G.A, G.C)
     >>> np.linalg.matrix_rank(C)
-    2
+    np.int64(2)
 
     """
 

--- a/control/sysnorm.py
+++ b/control/sysnorm.py
@@ -117,7 +117,7 @@ def norm(system, p=2, tol=1e-6, print_warning=True, method=None):
     >>> round(ct.norm(Gc, 2), 3)
     0.5
     >>> round(ct.norm(Gc, 'inf', tol=1e-5, method='scipy'), 3)
-    1.0
+    np.float64(1.0)
     """
            
     if not isinstance(system, (ct.StateSpace, ct.TransferFunction)):

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1241,7 +1241,7 @@ class TransferFunction(LTI):
         --------
         >>> G = ct.tf([1], [1, 4])
         >>> G.dcgain()
-        0.25
+        np.float64(0.25)
 
         """
         return self._dcgain(warn_infinite)

--- a/examples/tfvis.py
+++ b/examples/tfvis.py
@@ -45,13 +45,8 @@ import sys
 import Pmw
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from numpy.lib.polynomial import polymul
-from numpy.lib.type_check import real
-from numpy.core.multiarray import array
-from numpy.core.fromnumeric import size
-# from numpy.lib.function_base import logspace
 from control.matlab import logspace
-from numpy import conj
+from numpy import array, conj, polymul, real, size
 
 
 def make_poly(facts):


### PR DESCRIPTION
This PR updates docstrings and imports to be compatible with NumPy 2.0, which was released on 16 June.  PR #994  already made changes to the base code for NumPy 2.0 compatibility, but there were some small changes required for doctests and examples to match the changes.

We should merge this quickly since CI tests are failing now that NumPy 2.0 is the default.
