### PR TITLE
fix parallel input or output interconnect bug (issue #1015)

### DIFF
--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -2086,10 +2086,8 @@ def interconnect(
 
     inplist : list of input connections, optional
         List of connections for how the inputs for the overall system are
-        mapped to the subsystem inputs.  The input specification is similar to
-        the form defined in the connection specification, except that
-        connections do not specify an input-spec, since these are the system
-        inputs. The entries for a connection are thus of the form:
+        mapped to the subsystem inputs.  The entries for a connection are
+        of the form:
 
             [input-spec1, input-spec2, ...]
 
@@ -2102,11 +2100,10 @@ def interconnect(
 
     outlist : list of output connections, optional
         List of connections for how the outputs from the subsystems are
-        mapped to overall system outputs.  The output connection
-        description is the same as the form defined in the inplist
-        specification (including the optional gain term).  Numbered outputs
-        must be chosen from the list of subsystem outputs, but named
-        outputs can also be contained in the list of subsystem inputs.
+        mapped to overall system outputs.  The entris for a connection are
+        of the form:
+
+            [output-spec1, output-spec2, ...]
 
         If an output connection contains more than one signal specification,
         then those signals are added together (multiplying by the any gain

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -2510,8 +2510,8 @@ def interconnect(
                     # First trying looking in the output signals
                     osys, indices, gain = _parse_spec(syslist, spec, 'output')
                     for osig in indices:
-                            dprint(f"  adding output {(osys, osig, gain)}")
-                            signal_list.append((osys, osig, gain))
+                        dprint(f"  adding output {(osys, osig, gain)}")
+                        signal_list.append((osys, osig, gain))
                 except ValueError:
                     # If not, see if we can find it in inputs
                     isys, indices, gain = _parse_spec(

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -2100,7 +2100,7 @@ def interconnect(
 
     outlist : list of output connections, optional
         List of connections for how the outputs from the subsystems are
-        mapped to overall system outputs.  The entris for a connection are
+        mapped to overall system outputs.  The entries for a connection are
         of the form:
 
             [output-spec1, output-spec2, ...]

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -689,3 +689,19 @@ def test_interconnect_params():
     timepts = np.linspace(0, 10)
     resp = ct.input_output_response(sys, timepts, 0, params={'a': -1})
     assert resp.states[0, -1].item() < 2 * math.exp(-10)
+
+
+# Bug identified in issue #1015
+def test_parallel_interconnect():
+    sys1 = ct.rss(2, 1, 1, name='S1')
+    sys2 = ct.rss(2, 1, 1, name='S2')
+
+    sys_bd = sys1 + sys2
+    sys_ic = ct.interconnect(
+        [sys1, sys2],
+        inplist=[['S1.u[0]', 'S2.u[0]']],
+        outlist=[['S1.y[0]', 'S2.y[0]']])
+    np.testing.assert_allclose(sys_bd.A, sys_ic.A)
+    np.testing.assert_allclose(sys_bd.B, sys_ic.B)
+    np.testing.assert_allclose(sys_bd.C, sys_ic.C)
+    np.testing.assert_allclose(sys_bd.D, sys_ic.D)


### PR DESCRIPTION
This PR fixes the bug identified in #1015, where specification of a list of signals as the input was not handled properly (each signal in the list was treated as a separate input rather than connecting a single input to the list).  There was a similar bug in the output processing code.  Unit test that exposes the bug included.

I think this code can be cleaned up a bit (to avoid the duplication in processing for the two cases), but want to get a fix out quickly since there is no easy workaround.

(Also found and fixed a typo in a docstring.)