### PR TITLE
Improve markov function, add mimo support, change api to TimeResponseData

### DIFF
--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -575,4 +575,5 @@ def markov(data, m=None, dt=True, truncate=False):
                             trace_labels=trace_labels,
                             trace_types=trace_types,
                             transpose=data.transpose,
+                            plot_inputs=False,
                             issiso=data.issiso)

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -405,52 +405,52 @@ def era(YY, m, n, nin, nout, r):
 def markov(*args, m=None, transpose=False, dt=True, truncate=False):
     """markov(Y, U, [, m])
     
-    Calculate the first `m` Markov parameters [D CB CAB ...]
-    from data
+    Calculate the first `m` Markov parameters [D CB CAB ...] from data.
 
-    This function computes the Markov parameters for a discrete time system
+    This function computes the Markov parameters for a discrete time
+    system
 
     .. math::
 
         x[k+1] &= A x[k] + B u[k] \\\\
         y[k] &= C x[k] + D u[k]
 
-    given data for u and y.  The algorithm assumes that that C A^k B = 0 for
-    k > m-2 (see [1]_).  Note that the problem is ill-posed if the length of
-    the input data is less than the desired number of Markov parameters (a
-    warning message is generated in this case).
+    given data for u and y.  The algorithm assumes that that C A^k B = 0
+    for k > m-2 (see [1]_).  Note that the problem is ill-posed if the
+    length of the input data is less than the desired number of Markov
+    parameters (a warning message is generated in this case).
 
     The function can be called with either 1, 2 or 3 arguments:
 
-    * ``H = markov(response)``
-    * ``H = markov(respnose, m)``
+    * ``H = markov(data)``
+    * ``H = markov(data, m)``
     * ``H = markov(Y, U)``
     * ``H = markov(Y, U, m)``
 
-    where `response` is an `TimeResponseData` object, and `Y`, `U`, are 1D or 2D
-    array and m is an integer.
+    where `data` is a `TimeResponseData` object, `YY` is a 1D or 3D
+    array, and r is an integer.
 
     Parameters
     ----------
     Y : array_like
-        Output data.  If the array is 1D, the system is assumed to be single
-        input.  If the array is 2D and transpose=False, the columns of `Y`
-        are taken as time points, otherwise the rows of `Y` are taken as
-        time points.
+        Output data. If the array is 1D, the system is assumed to be
+        single input. If the array is 2D and transpose=False, the columns
+        of `Y` are taken as time points, otherwise the rows of `Y` are
+        taken as time points.
     U : array_like
         Input data, arranged in the same way as `Y`.
     data : TimeResponseData
         Response data from which the Markov parameters where estimated.
         Input and output data must be 1D or 2D array.
     m : int, optional
-        Number of Markov parameters to output.  Defaults to len(U).
+        Number of Markov parameters to output. Defaults to len(U).
     dt : True of float, optional
-        True indicates discrete time with unspecified sampling time,
-        positive number is discrete time with specified sampling time.It
-        can be used to scale the markov parameters in order to match the
-        impulse response of this library. Default is True.
+        True indicates discrete time with unspecified sampling time and a
+        positive float is discrete time with the specified sampling time.
+        It can be used to scale the Markov parameters in order to match
+        the unit-area impulse response of python-control. Default is True.
     truncate : bool, optional
-        Do not use first m equation for least least squares. Default is False.
+        Do not use first m equation for least squares. Default is False.
     transpose : bool, optional
         Assume that input data is transposed relative to the standard
         :ref:`time-series-convention`. For TimeResponseData this parameter
@@ -459,7 +459,7 @@ def markov(*args, m=None, transpose=False, dt=True, truncate=False):
     Returns
     -------
     H : ndarray
-        First m Markov parameters, [D CB CAB ...]
+        First m Markov parameters, [D CB CAB ...].
 
     References
     ----------
@@ -476,10 +476,10 @@ def markov(*args, m=None, transpose=False, dt=True, truncate=False):
     >>> H = ct.markov(Y, U, 3, transpose=False)
 
     """
-    # Convert input parameters to 2D arrays (if they aren't already)
 
+    # Convert input parameters to 2D arrays (if they aren't already)
     # Get the system description
-    if (len(args) < 1):
+    if len(args) < 1:
         raise ControlArgument("not enough input arguments")
     
     if isinstance(args[0], TimeResponseData):
@@ -488,20 +488,20 @@ def markov(*args, m=None, transpose=False, dt=True, truncate=False):
         transpose = args[0].transpose
         if args[0].transpose and not args[0].issiso:
             Umat, Ymat = np.transpose(Umat), np.transpose(Ymat)
-        if (len(args) == 2):
+        if len(args) == 2:
             m = args[1]
-        elif (len(args) > 2):
+        elif len(args) > 2:
             raise ControlArgument("too many positional arguments")
     else:
-        if (len(args) < 2):
+        if len(args) < 2:
             raise ControlArgument("not enough input arguments")
         Umat = np.array(args[1], ndmin=2)
         Ymat = np.array(args[0], ndmin=2)
         if transpose:
             Umat, Ymat = np.transpose(Umat), np.transpose(Ymat)
-        if (len(args) == 3):
+        if len(args) == 3:
             m = args[2]
-        elif (len(args) > 3):
+        elif len(args) > 3:
             raise ControlArgument("too many positional arguments")
 
     # Make sure the number of time points match
@@ -577,6 +577,7 @@ def markov(*args, m=None, transpose=False, dt=True, truncate=False):
     H = H.reshape(q,m,p) # output, time*input -> output, time, input
     H = H.transpose(0,2,1) # output, input, time
 
+    # for siso return a 1D array instead of a 3D array
     if q == 1 and p == 1:
         H = np.squeeze(H)
 

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -438,21 +438,9 @@ def markov(data, m=None, dt=True, truncate=False):
 
     Returns
     -------
-    H : TimeResponseData
-        Markov parameters / impulse response [D CB CAB ...] represented as
-        a :class:`TimeResponseData` object containing the following properties:
-
-        * time (array): Time values of the output.
-
-        * outputs (array): Response of the system.  If the system is SISO,
-          the array is 1D (indexed by time).  If the
-          system is not SISO, the array is 3D (indexed
-          by the output, trace, and time).
-
-        * inputs (array): Inputs of the system.  If the system is SISO,
-          the array is 1D (indexed by time).  If the
-          system is not SISO, the array is 3D (indexed
-          by the output, trace, and time).
+    H : ndarray
+        First m Markov parameters, [D CB CAB ...]
+    
 
     Notes
     -----
@@ -557,23 +545,8 @@ def markov(data, m=None, dt=True, truncate=False):
     H = H.reshape(q,m,p) # output, time*input -> output, time, input
     H = H.transpose(0,2,1) # output, input, time
 
-    # Create unit area impulse inputs
-    inputs = np.zeros((p,p,m))
-    trace_labels, trace_types = [], []
-    for i in range(p):
-        inputs[i,i,0] = 1/dt # unit area impulse
-        trace_labels.append(f"From {data.input_labels[i]}")
-        trace_types.append('impulse')
+    if q == 1 and p == 1:
+        H = np.squeeze(H)
 
-    # Markov parameters as TimeResponseData with unit area impulse inputs
     # Return the first m Markov parameters
-    return TimeResponseData(time=data.time[:m],
-                            outputs=H,
-                            output_labels=data.output_labels,
-                            inputs=inputs,
-                            input_labels=data.input_labels,
-                            trace_labels=trace_labels,
-                            trace_types=trace_types,
-                            transpose=data.transpose,
-                            plot_inputs=False,
-                            issiso=data.issiso)
+    return H if not data.transpose else np.transpose(H)

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -558,7 +558,7 @@ def markov(data, m=None, dt=True, truncate=False):
     H = H.transpose(0,2,1) # output, input, time
 
     # Create unit area impulse inputs
-    inputs = np.zeros((q,p,m))
+    inputs = np.zeros((p,p,m))
     trace_labels, trace_types = [], []
     for i in range(p):
         inputs[i,i,0] = 1/dt # unit area impulse

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -44,17 +44,17 @@ class TestModelsimp:
         m = 3
         H = markov(response, m)
         Htrue = np.array([1., 0., 0.])
-        np.testing.assert_array_almost_equal(H.outputs, Htrue)
+        np.testing.assert_array_almost_equal(H, Htrue)
 
         # Make sure that transposed data also works
         response.transpose=True
         H = markov(response, m)
-        np.testing.assert_array_almost_equal(H.outputs, np.transpose(Htrue))
+        np.testing.assert_array_almost_equal(H, np.transpose(Htrue))
 
         # Generate Markov parameters without any arguments
         response.transpose=False
         H = markov(response, m)
-        np.testing.assert_array_almost_equal(H.outputs, Htrue)
+        np.testing.assert_array_almost_equal(H, Htrue)
 
         # Test example from docstring
         T = np.linspace(0, 10, 100)
@@ -119,7 +119,7 @@ class TestModelsimp:
         # experimentally determined probability to get non matching results
         # with rtot=1e-6 and atol=1e-8 due to numerical errors
         # for k=5, m=n=10: 0.015 %
-        np.testing.assert_allclose(Mtrue, Mcomp.outputs, rtol=1e-6, atol=1e-8)
+        np.testing.assert_allclose(Mtrue, Mcomp, rtol=1e-6, atol=1e-8)
 
     def testModredMatchDC(self):
         #balanced realization computed in matlab for the transfer function:

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -45,11 +45,11 @@ class TestModelsimp:
         m = 3
         Htrue = np.array([1., 0., 0.])
 
-        H = markov(Y, U, m, transpose=False)
+        H = markov(Y, U, m=m, transpose=False)
         np.testing.assert_array_almost_equal(H, Htrue)
 
         response.transpose=False
-        H = markov(response, m)
+        H = markov(response, m=m)
         np.testing.assert_array_almost_equal(H, Htrue)
 
         # Make sure that transposed data also works
@@ -68,20 +68,25 @@ class TestModelsimp:
         H = markov(response, m)
         np.testing.assert_array_almost_equal(H, Htrue)
 
+        H = markov(Y, U, m=m)
+        np.testing.assert_array_almost_equal(H, Htrue)
+
+        H = markov(response, m=m)
+        np.testing.assert_array_almost_equal(H, Htrue)
+
         # Test example from docstring
-        # TODO: There is a problem here
-        # Htrue = np.array([1., 0.5, 0.])
+        # TODO: There is a problem here, last markov parameter does not fit
+        # the approximation error could be to big
+        Htrue = np.array([0, 1., -0.5])
         T = np.linspace(0, 10, 100)
         U = np.ones((1, 100))
         T, Y = forced_response(tf([1], [1, 0.5], True), T, U)
-        H = markov(Y, U, 3, transpose=False)
-        #np.testing.assert_array_almost_equal(H, Htrue)
+        H = markov(Y, U, 4, transpose=False)
+        np.testing.assert_array_almost_equal(H[:3], Htrue[:3])
 
-        T = np.linspace(0, 10, 100)
-        U = np.ones((1, 100))
         response = forced_response(tf([1], [1, 0.5], True), T, U)
-        H = markov(response, 3)
-        #np.testing.assert_array_almost_equal(H, Htrue)
+        H = markov(response, 4)
+        np.testing.assert_array_almost_equal(H[:3], Htrue[:3])
 
         # Test example from issue #395
         inp = np.array([1, 2])

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -43,13 +43,13 @@ class TestModelsimp:
         
         # Basic usage
         m = 3
-        H = markov(Y, U, m, transpose=False)
         Htrue = np.array([1., 0., 0.])
+
+        H = markov(Y, U, m, transpose=False)
         np.testing.assert_array_almost_equal(H, Htrue)
 
         response.transpose=False
         H = markov(response, m)
-        Htrue = np.array([1., 0., 0.])
         np.testing.assert_array_almost_equal(H, Htrue)
 
         # Make sure that transposed data also works
@@ -69,15 +69,19 @@ class TestModelsimp:
         np.testing.assert_array_almost_equal(H, Htrue)
 
         # Test example from docstring
+        # TODO: There is a problem here
+        # Htrue = np.array([1., 0.5, 0.])
         T = np.linspace(0, 10, 100)
         U = np.ones((1, 100))
-        _, Y = forced_response(tf([1], [1, 0.5], True), T, U)
-        H = markov(Y, U, 3)
+        T, Y = forced_response(tf([1], [1, 0.5], True), T, U)
+        H = markov(Y, U, 3, transpose=False)
+        #np.testing.assert_array_almost_equal(H, Htrue)
 
         T = np.linspace(0, 10, 100)
         U = np.ones((1, 100))
         response = forced_response(tf([1], [1, 0.5], True), T, U)
         H = markov(response, 3)
+        #np.testing.assert_array_almost_equal(H, Htrue)
 
         # Test example from issue #395
         inp = np.array([1, 2])

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -35,6 +35,7 @@ other sources.
    kincar-flatsys
    mrac_siso_mit
    mrac_siso_lyapunov
+   markov
 
 Jupyter notebooks
 =================

--- a/doc/markov.py
+++ b/doc/markov.py
@@ -1,0 +1,1 @@
+../examples/markov.py

--- a/doc/markov.rst
+++ b/doc/markov.rst
@@ -1,0 +1,15 @@
+Estimation of Makrov parameters
+-------------------------------
+
+Code
+....
+.. literalinclude:: markov.py
+   :language: python
+   :linenos:
+
+
+Notes
+.....
+
+1. The environment variable `PYCONTROL_TEST_EXAMPLES` is used for
+testing to turn off plotting of the outputs.0

--- a/examples/markov.py
+++ b/examples/markov.py
@@ -48,7 +48,7 @@ def create_impulse_response(H, time, transpose, dt):
                             issiso=issiso)
 
 # set up a mass spring damper system (2dof, MIMO case)
-# Mechanical Vibartions: Theory and Application, SI Edition, 1st ed.
+# Mechanical Vibrations: Theory and Application, SI Edition, 1st ed.
 # Figure 6.5 / Example 6.7
 # m q_dd + c q_d + k q = f
 m1, k1, c1 = 1., 4., 1.
@@ -91,10 +91,9 @@ response.plot()
 plt.show()
 
 m = 50
-ir_true = ct.impulse_response(sysd,T=dt*m)
-ir_true.tranpose = True
+ir_true = ct.impulse_response(sysd, T=dt*m)
 
-H_est = ct.markov(response,m=m,dt=dt)
+H_est = ct.markov(response, m, dt=dt)
 # Helper function for plotting only
 ir_est = create_impulse_response(H_est,
                                  ir_true.time,

--- a/examples/markov.py
+++ b/examples/markov.py
@@ -10,6 +10,43 @@ import os
 
 import control as ct
 
+def create_impulse_response(H, time, transpose, dt):
+    """Helper function to use TimeResponseData type for plotting"""
+    
+    H = np.array(H, ndmin=3)
+
+    if transpose:
+        H = np.transpose(H)
+    
+    q, p, m = H.shape
+    inputs = np.zeros((p,p,m))
+
+    issiso = True if (q == 1 and p == 1) else False
+    
+    input_labels = []
+    trace_labels, trace_types = [], []
+    for i in range(p):
+        inputs[i,i,0] = 1/dt # unit area impulse
+        input_labels.append(f"u{[i]}")
+        trace_labels.append(f"From u{[i]}")
+        trace_types.append('impulse')
+
+    output_labels = []
+    for i in range(q):
+        output_labels.append(f"y{[i]}")
+
+    return ct.TimeResponseData(time=time[:m],
+                            outputs=H,
+                            output_labels=output_labels,
+                            inputs=inputs,
+                            input_labels=input_labels,
+                            trace_labels=trace_labels,
+                            trace_types=trace_types,
+                            sysname="H_est",
+                            transpose=transpose,
+                            plot_inputs=False,
+                            issiso=issiso)
+
 # set up a mass spring damper system (2dof, MIMO case)
 # m q_dd + c q_d + k q = u
 m1, k1, c1 = 1., 1., .1
@@ -41,19 +78,29 @@ match xixo:
 
 dt = 0.5
 sysd = sys.sample(dt, method='zoh')
+sysd.name = "H_true"
 
-t = np.arange(0,5000,dt)
-u = np.random.randn(sysd.B.shape[-1], len(t)) # random forcing input
+ # random forcing input
+t = np.arange(0,500,dt)
+u = np.random.randn(sysd.B.shape[-1], len(t))
 
 response = ct.forced_response(sysd, U=u)
 response.plot()
 plt.show()
 
-markov_true = ct.impulse_response(sysd,T=dt*100)
-markov_est = ct.markov(response,m=100,dt=dt)
+m = 100
+ir_true = ct.impulse_response(sysd,T=dt*m)
+ir_true.tranpose = True
 
-markov_true.plot(title=xixo)
-markov_est.plot(color='orange',linestyle='dashed')
+H_est = ct.markov(response,m=m,dt=dt)
+# Helper function for plotting only
+ir_est = create_impulse_response(H_est,
+                                 ir_true.time,
+                                 ir_true.transpose,
+                                 dt)
+
+ir_true.plot(title=xixo)
+ir_est.plot(color='orange',linestyle='dashed')
 plt.show()
 
 if 'PYCONTROL_TEST_EXAMPLES' not in os.environ:

--- a/examples/markov.py
+++ b/examples/markov.py
@@ -1,0 +1,60 @@
+# markov.py
+# Johannes Kaisinger, 4 July 2024
+#
+# Demonstrate estimation of markov parameters.
+# SISO, SIMO, MISO, MIMO case
+
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+
+import control as ct
+
+# set up a mass spring damper system (2dof, MIMO case)
+# m q_dd + c q_d + k q = u
+m1, k1, c1 = 1., 1., .1
+m2, k2, c2 = 2., .5, .1
+k3, c3 = .5, .1
+
+A = np.array([
+    [0., 0., 1., 0.],
+    [0., 0., 0., 1.],
+    [-(k1+k2)/m1, (k2)/m1, -(c1+c2)/m1, c2/m1],
+    [(k2)/m2, -(k2+k3)/m2, c2/m2, -(c2+c3)/m2]
+])
+B = np.array([[0.,0.],[0.,0.],[1/m1,0.],[0.,1/m2]])
+C = np.array([[1.0, 0.0, 0.0, 0.0],[0.0, 1.0, 0.0, 0.0]])
+D = np.zeros((2,2))
+
+
+xixo_list = ["SISO","SIMO","MISO","MIMO"]
+xixo = xixo_list[3] # choose a system for estimation
+match xixo:
+    case "SISO":
+        sys = ct.StateSpace(A, B[:,0], C[0,:], D[0,0])
+    case "SIMO":
+        sys = ct.StateSpace(A, B[:,:1], C, D[:,:1])
+    case "MISO":
+        sys = ct.StateSpace(A, B, C[:1,:], D[:1,:])
+    case "MIMO":
+        sys = ct.StateSpace(A, B, C, D)
+
+dt = 0.5
+sysd = sys.sample(dt, method='zoh')
+
+t = np.arange(0,5000,dt)
+u = np.random.randn(sysd.B.shape[-1], len(t)) # random forcing input
+
+response = ct.forced_response(sysd, U=u)
+response.plot()
+plt.show()
+
+markov_true = ct.impulse_response(sysd,T=dt*100)
+markov_est = ct.markov(response,m=100,dt=dt)
+
+markov_true.plot(title=xixo)
+markov_est.plot(color='orange',linestyle='dashed')
+plt.show()
+
+if 'PYCONTROL_TEST_EXAMPLES' not in os.environ:
+    plt.show()

--- a/examples/markov.py
+++ b/examples/markov.py
@@ -48,10 +48,12 @@ def create_impulse_response(H, time, transpose, dt):
                             issiso=issiso)
 
 # set up a mass spring damper system (2dof, MIMO case)
-# m q_dd + c q_d + k q = u
-m1, k1, c1 = 1., 1., .1
-m2, k2, c2 = 2., .5, .1
-k3, c3 = .5, .1
+# Mechanical Vibartions: Theory and Application, SI Edition, 1st ed.
+# Figure 6.5 / Example 6.7
+# m q_dd + c q_d + k q = f
+m1, k1, c1 = 1., 4., 1.
+m2, k2, c2 = 2., 2., 1.
+k3, c3 = 6., 2.
 
 A = np.array([
     [0., 0., 1., 0.],
@@ -76,19 +78,19 @@ match xixo:
     case "MIMO":
         sys = ct.StateSpace(A, B, C, D)
 
-dt = 0.5
+dt = 0.25
 sysd = sys.sample(dt, method='zoh')
 sysd.name = "H_true"
 
  # random forcing input
-t = np.arange(0,500,dt)
+t = np.arange(0,100,dt)
 u = np.random.randn(sysd.B.shape[-1], len(t))
 
 response = ct.forced_response(sysd, U=u)
 response.plot()
 plt.show()
 
-m = 100
+m = 50
 ir_true = ct.impulse_response(sysd,T=dt*m)
 ir_true.tranpose = True
 


### PR DESCRIPTION
This PR adds 
- MIMO support to the markov function and
- it uses the TimeResponseData Type.

```python
T = np.linspace(0, 10, 100)
U = np.ones((1, 100))
response = ct.forced_response(ct.tf([1], [1, 0.5], True), T, U)
H = ct.markov(response, 3)
```

~~This breaks old user code!~~
Does not break old user code!

```python
T = np.linspace(0, 10, 100)
U = np.ones((1, 100))
T, Y = ct.forced_response(ct.tf([1], [1, 0.5], True), T, U)
H = ct.markov(Y, U, 3, transpose=False)
```

