### PR TITLE
Fix impuse response, input data only contains one input[0]==1 in each trace

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -536,6 +536,32 @@ class TestTimeresp:
         sysdt = sys.sample(dt, 'impulse')
         np.testing.assert_array_almost_equal(impulse_response(sys, t)[1],
                                              impulse_response(sysdt, t)[1])
+        
+    def test_discrete_time_impulse_input(self):
+        # discrete time impulse input, Only one active input for each trace
+        A = [[.5, 0.25],[.0, .5]]
+        B = [[1., 0,],[0., 1.]]
+        C = [[1., 0.],[0., 1.]]
+        D = [[0., 0.],[0., 0.]]
+        dt = True
+        sysd = ct.ss(A,B,C,D, dt=dt)
+        response = ct.impulse_response(sysd,T=dt*3)
+
+        Uexpected = np.zeros((2,2,4), dtype=float).astype(object)
+        Uexpected[0,0,0] = 1./dt
+        Uexpected[1,1,0] = 1./dt
+
+        np.testing.assert_array_equal(response.inputs,Uexpected)
+
+        dt = 0.5
+        sysd = ct.ss(A,B,C,D, dt=dt)
+        response = ct.impulse_response(sysd,T=dt*3)
+
+        Uexpected = np.zeros((2,2,4), dtype=float).astype(object)
+        Uexpected[0,0,0] = 1./dt
+        Uexpected[1,1,0] = 1./dt
+
+        np.testing.assert_array_equal(response.inputs,Uexpected)
 
     @pytest.mark.parametrize("tsystem", ["siso_ss1"], indirect=True)
     def test_impulse_response_warnD(self, tsystem):

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -1960,7 +1960,7 @@ def impulse_response(sys, T=None, input=None, output=None, T_num=None,
         yout[:, inpidx, :] = response.y if output is None \
             else response.y[output]
         xout[:, inpidx, :] = response.x
-        uout[:, inpidx, :] = U[i]
+        uout[:, inpidx, :] = U if input is None else U[i]
 
     # Figure out if the system is SISO or not
     issiso = sys.issiso() or (input is not None and output is not None)


### PR DESCRIPTION
Computation of impulse response was correct, but input in impulse response was not.