### PR TITLE
add pyqt dependency for QtAgg testing

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -56,6 +56,9 @@ jobs:
         if [[ '${{matrix.pandas}}' == 'conda' ]]; then
           mamba install pandas
         fi
+        if [[ '${{matrix.mplbackend}}' == 'QtAgg' ]]; then
+          mamba install pyqt
+        fi
 
     - name: Test with pytest
       shell: bash -l {0}


### PR DESCRIPTION
This PR fixes a problem in the CI tests where the QtAgg case in `python-package-conda` is failing.  I'm not sure what changed, but it looks like pyqt needs to be installed in order for the dependencies to be satisfied.

This should get merged quickly so that we can rebase other tests on top of it to fix CI test failures.
