### PR TITLE
Update OS/BLAS test matrix workflow

### DIFF
--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -71,8 +71,8 @@ jobs:
             unset | Generic | Apple ) ;; # Found in system
             OpenBLAS )
               brew install openblas
-              echo "BLAS_ROOT=/usr/local/opt/openblas/" >> $GITHUB_ENV
-              echo "LAPACK_ROOT=/usr/local/opt/openblas/" >> $GITHUB_ENV
+              echo "LDFLAGS=-L/opt/homebrew/opt/openblas/lib" >> $GITHUB_ENV
+              echo "CPPFLAGS=-I/opt/homebrew/opt/openblas/include" >> $GITHUB_ENV
               ;;
             *)
               echo "bla_vendor option ${{ matrix.bla_vendor }} not supported"

--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -204,8 +204,6 @@ jobs:
           path: slycot-src
       - name: Checkout python-control
         uses: actions/checkout@v3
-        with:
-          repository: 'python-control/python-control'
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/control/tests/nyquist_test.py
+++ b/control/tests/nyquist_test.py
@@ -144,14 +144,6 @@ def test_nyquist_basic():
         else:
             pytest.fails("multiple warnings in nyquist_response (?)")
 
-    # Nyquist plot with poles on imaginary axis, omega specified, with contour
-    sys = ct.tf([1], [1, 3, 2]) * ct.tf([1], [1, 0, 1])
-    with pytest.warns(UserWarning, match="does not match") as records:
-        count, contour = ct.nyquist_response(
-            sys, np.linspace(1e-3, 1e1, 1000), return_contour=True)
-    if len(records) == 0:
-        assert _Z(sys) == count + _P(sys)
-
     # Nyquist plot with poles on imaginary axis, return contour
     sys = ct.tf([1], [1, 3, 2]) * ct.tf([1], [1, 0, 1])
     count, contour = ct.nyquist_response(sys, return_contour=True)

--- a/control/tests/nyquist_test.py
+++ b/control/tests/nyquist_test.py
@@ -142,7 +142,7 @@ def test_nyquist_basic():
             assert issubclass(records[0].category, UserWarning)
             assert "encirclements does not match" in str(records[0].message)
         else:
-            pytest.fails("multiple warnings in nyquist_response (?)")
+            pytest.fail("multiple warnings in nyquist_response (?)")
 
     # Nyquist plot with poles on imaginary axis, return contour
     sys = ct.tf([1], [1, 3, 2]) * ct.tf([1], [1, 0, 1])


### PR DESCRIPTION
This PR updates the OS/BLAS test matrix workflow that is used to test releases against various combinations of operating systems and BLAS implementations.  Changes:

* Found and fixed an issue in `nyquist_test.py` in which some calls with a manually specified frequency response would generate a user warning and others wouldn't.  Both cases are not handled properly (and a redundant check has been removed).
* Fixed some issues with paths for OpenBLAS on macos that were causing compiler errors.
* Updated pip-based tests to check out current branch instead of main (mainly useful when using a development branch, like this one).

No changes to the actual control toolbox itself.
