### PR TITLE
update macos gfortran version

### DIFF
--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -78,7 +78,7 @@ jobs:
               echo "bla_vendor option ${{ matrix.bla_vendor }} not supported"
               exit 1 ;;
           esac
-          echo "FC=gfortran-11" >> $GITHUB_ENV
+          echo "FC=gfortran-14" >> $GITHUB_ENV
       - name: Build wheel
         env:
           BLA_VENDOR: ${{ matrix.bla_vendor }}


### PR DESCRIPTION
This PR updates the version of the FORTRAN compiler that is used in the OS/BLAS test matrix.  Apparently gfortran11 is no longer available on the Github Actions macos runner.
