### PR TITLE
Small user documentation fixes

### DIFF
--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -25,11 +25,11 @@ a :class:`~control.StateSpace` linear system.  Use the
   ss_sys = ct.linearize(io_sys, xeq, ueq)
 
 Input/output systems are automatically created for state space LTI systems
-when using the :func:`ss` function.  Nonlinear input/output systems can be
-created using the :func:`~control.nlsys` function, which requires
-the definition of an update function (for the right hand side of the
-differential or different equation) and an output function (computes the
-outputs from the state)::
+when using the :func:`~control.ss` function.  Nonlinear input/output
+systems can be created using the :func:`~control.nlsys` function, which
+requires the definition of an update function (for the right hand side of
+the differential or different equation) and an output function (computes
+the outputs from the state)::
 
   io_sys = ct.nlsys(updfcn, outfcn, inputs=M, outputs=P, states=N)
 
@@ -434,8 +434,8 @@ of an individual system are used in a given specification::
     inplist=['sum.r', 'P.v'], outlist=['P', 'C.u']
   )
 
-And finally, since we have named the signals throughout the system in
-a consistent way, we could let :func:`ct.interconnect` do all of the
+And finally, since we have named the signals throughout the system in a
+consistent way, we could let :func:`~control.interconnect` do all of the
 work::
 
   clsys5 = ct.interconnect(

--- a/doc/optimal.rst
+++ b/doc/optimal.rst
@@ -221,7 +221,7 @@ state and/or input, either along the trajectory and at the terminal time.
 The optimal control module operates by converting the optimal control
 problem into a standard optimization problem that can be solved by
 :func:`scipy.optimize.minimize`.  The optimal control problem can be solved
-by using the :func:`~control.obc.solve_ocp` function::
+by using the :func:`~control.optimal.solve_ocp` function::
 
   res = obc.solve_ocp(sys, timepts, X0, cost, constraints)
 
@@ -467,6 +467,10 @@ formulations.
 
 Module classes and functions
 ============================
+
+The following classes and functions are defined in the
+``optimal`` module:
+
 .. autosummary::
    :toctree: generated/
    :template: custom-class-template.rst

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -215,8 +215,8 @@ plot, use `plot_type='nichols'`::
 
 .. image:: freqplot-siso_nichols-default.png
 
-Another response function that can be used to generate Bode plots is
-the :func:`~control.gangof4` function, which computes the four primary
+Another response function that can be used to generate Bode plots is the
+:func:`~control.gangof4_response` function, which computes the four primary
 sensitivity functions for a feedback control system in standard form::
 
   proc = ct.tf([1], [1, 1, 1], name="process")

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -1,5 +1,7 @@
 .. _plotting-module:
 
+.. currentmodule:: control
+
 *************
 Plotting data
 *************
@@ -408,10 +410,10 @@ are part of the :mod:`~control.phaseplot` (pp) module::
 The following helper functions are available:
 
 .. autosummary::
-   ~control.phaseplot.equilpoints
-   ~control.phaseplot.separatrices
-   ~control.phaseplot.streamlines
-   ~control.phaseplot.vectorfield
+   phaseplot.equilpoints
+   phaseplot.separatrices
+   phaseplot.streamlines
+   phaseplot.vectorfield
 
 The :func:`~control.phase_plane_plot` function calls these helper functions
 based on the options it is passed.
@@ -653,10 +655,10 @@ Plotting functions
    ~control.nichols_plot
    ~control.nyquist_plot
    ~control.phase_plane_plot
-   ~control.phaseplot.equilpoints
-   ~control.phaseplot.separatrices
-   ~control.phaseplot.streamlines
-   ~control.phaseplot.vectorfield
+   phaseplot.equilpoints
+   phaseplot.separatrices
+   phaseplot.streamlines
+   phaseplot.vectorfield
    ~control.pole_zero_plot
    ~control.root_locus_plot
    ~control.singular_values_plot
@@ -665,7 +667,6 @@ Plotting functions
 
 Utility functions
 -----------------
-
 These additional functions can be used to manipulate response data or
 carry out other operations in creating control plots.
 
@@ -673,7 +674,7 @@ carry out other operations in creating control plots.
 .. autosummary::
    :toctree: generated/
 
-   ~control.box_grid
+   phaseplot.boxgrid
    ~control.combine_time_responses
    ~control.pole_zero_subplots
    ~control.reset_rcParams


### PR DESCRIPTION
This PR fixes a few small glitches in the user documentation:
* The deprecated `box_grid` function was being included instead of `boxgrid`.
* References to the `phaseplot` module were omitting the required `phaseplot` prefix, so that it might look like the could be called as `ct.function` (instead of `ct.phaseplot.function` or `pp.function` if you have imported `control.phaseplot` as `pp`).
* There was an incorrect reference in the optimization-based control module than I found and fixed along the way.

This doesn't really need review.  I'll leave it here for a few hours just in case someone wants to have a look, but I'll merge it in when I work on the 0.10.1 release starting later tonight (PDT) or tomorrow.
