### PR TITLE
Upgrade GitHub action dependencies: upload-artifact, download-artifact

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -38,7 +38,7 @@ jobs:
         make doctest
 
     - name: Archive results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: doctest-output
         path: doc/_build/doctest/output.txt

--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p ${wheeldir}
           cp ./slycot*.whl ${wheeldir}/
       - name: Save wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -142,7 +142,7 @@ jobs:
           done
           python -m conda_index ./slycot-conda-pkgs
       - name: Save to local conda pkg channel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
@@ -159,7 +159,7 @@ jobs:
       - name: Checkout python-control
         uses: actions/checkout@v3
       - name: Download wheels (if any)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -178,7 +178,7 @@ jobs:
       - name: Checkout python-control
         uses: actions/checkout@v3
       - name: Download conda packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
@@ -238,7 +238,7 @@ jobs:
               exit 1 ;;
           esac
       - name: Download wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -290,7 +290,7 @@ jobs:
           channel-priority: strict
           auto-activate-base: false
       - name: Download conda packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs

--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -9,7 +9,7 @@ on:
       - .github/scripts/set-conda-pip-matrix.py
       - .github/conda-env/build-env.yml
       - .github/conda-env/test-env.yml
-      
+
 jobs:
   build-pip:
     name: Build pip Py${{ matrix.python }}, ${{ matrix.os }}, ${{ matrix.bla_vendor}} BLA_VENDOR
@@ -93,8 +93,9 @@ jobs:
       - name: Save wheel
         uses: actions/upload-artifact@v4
         with:
-          name: slycot-wheels
+          name: slycot-wheels-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.bla_vendor }}
           path: slycot-wheels
+          retention-days: 5
 
 
   build-conda:
@@ -144,8 +145,9 @@ jobs:
       - name: Save to local conda pkg channel
         uses: actions/upload-artifact@v4
         with:
-          name: slycot-conda-pkgs
+          name: slycot-conda-pkgs-${{ matrix.os }}-${{ matrix.python }}
           path: slycot-conda-pkgs
+          retention-days: 5
 
 
   create-wheel-test-matrix:
@@ -156,6 +158,11 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: slycot-wheels
+          pattern: slycot-wheels-*
       - name: Checkout python-control
         uses: actions/checkout@v3
       - name: Download wheels (if any)
@@ -175,6 +182,11 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: slycot-conda-pkgs
+          pattern: slycot-conda-pkgs-*
       - name: Checkout python-control
         uses: actions/checkout@v3
       - name: Download conda packages


### PR DESCRIPTION
Following deprecation notice at https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
