### PR TITLE
Update find_eqpt to find_operating_point, adding root_method + better docs

### DIFF
--- a/control/matlab/__init__.py
+++ b/control/matlab/__init__.py
@@ -84,10 +84,12 @@ from ..rlocus import rlocus
 from ..dtime import c2d
 from ..sisotool import sisotool
 from ..stochsys import lqe, dlqe
+from ..nlsys import find_operating_point
 
 # Functions that are renamed in MATLAB
 pole, zero = poles, zeros
 freqresp = frequency_response
+trim = find_operating_point
 
 # Import functions specific to Matlab compatibility package
 from .timeresp import *

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -93,7 +93,7 @@ class NonlinearIOSystem(InputOutputSystem):
         generic name <sys[id]> is generated with a unique integer id.
 
     params : dict, optional
-       Parameter values for the system.  Passed to the evaluation functions
+        Parameter values for the system.  Passed to the evaluation functions
         for the system as default values, overriding internal defaults.
 
     See Also
@@ -1671,7 +1671,7 @@ def input_output_response(
         success=soln.success, message=message)
 
 
-class OperatingPoint(object):
+class OperatingPoint():
     """A class for representing the operating point of a nonlinear I/O system.
 
     The ``OperatingPoint`` class stores the operating point of a nonlinear
@@ -1693,18 +1693,18 @@ class OperatingPoint(object):
 
     """
     def __init__(
-            self, states, inputs=None, outputs=None, result=None,
+            self, states, inputs, outputs=None, result=None,
             return_outputs=False, return_result=False):
         self.states = states
         self.inputs = inputs
 
         if outputs is None and return_outputs and not return_result:
-            raise SystemError("return_outputs specified by no y0 value")
+            raise ValueError("return_outputs specified but no outputs value")
         self.outputs = outputs
         self.return_outputs = return_outputs
 
         if result is None and return_result:
-            raise SystemError("return_result specified by no result value")
+            raise ValueError("return_result specified but no result value")
         self.result = result
         self.return_result = return_result
 
@@ -1799,7 +1799,7 @@ def find_operating_point(
         values will be ignored in solving for an operating point.  State
         indices can be listed in any order.  By default, all updates will be
         fixed at `dx0` in searching for an operating point.
-    root_method : str, optonal
+    root_method : str, optional
         Method to find the operating point.  If specified, this parameter
         is passed to the :func:`scipy.optimize.root` function.
     root_kwargs : dict, optional

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -32,7 +32,8 @@ from .timeresp import _check_convert_array, _process_time_response, \
 
 __all__ = ['NonlinearIOSystem', 'InterconnectedSystem', 'nlsys',
            'input_output_response', 'find_eqpt', 'linearize',
-           'interconnect', 'connection_table', 'find_operating_point']
+           'interconnect', 'connection_table', 'OperatingPoint',
+           'find_operating_point']
 
 
 class NonlinearIOSystem(InputOutputSystem):
@@ -92,7 +93,7 @@ class NonlinearIOSystem(InputOutputSystem):
         generic name <sys[id]> is generated with a unique integer id.
 
     params : dict, optional
-        Parameter values for the system.  Passed to the evaluation functions
+       Parameter values for the system.  Passed to the evaluation functions
         for the system as default values, overriding internal defaults.
 
     See Also
@@ -1685,6 +1686,8 @@ class OperatingPoint(object):
         State vector at the operating point.
     inputs : array
         Input vector at the operating point.
+    outputs : array, optional
+        Output vector at the operating point.
     result : :class:`scipy.optimize.OptimizeResult`, optional
         Result from the :func:`scipy.optimize.root` function, if available.
 
@@ -1740,7 +1743,7 @@ def find_operating_point(
     for the desired inputs, outputs, states, or state updates of the system.
 
     In its simplest form, `find_operating_point` finds an equilibrium point
-    given either the desired input or desired output:
+    given either the desired input or desired output::
 
         xeq, ueq = find_operating_point(sys, x0, u0)
         xeq, ueq = find_operating_point(sys, x0, u0, y0)
@@ -1810,19 +1813,15 @@ def find_operating_point(
 
     Returns
     -------
-    states : array of states
-        Value of the states at the equilibrium point, or `None` if no
-        equilibrium point was found and `return_result` was False.
-    inputs : array of input values
-        Value of the inputs at the equilibrium point, or `None` if no
-        equilibrium point was found and `return_result` was False.
-    outputs : array of output values, optional
-        If `return_y` is True, returns the value of the outputs at the
-        equilibrium point, or `None` if no equilibrium point was found and
-        `return_result` was False.
-    result : :class:`scipy.optimize.OptimizeResult`, optional
-        If `return_result` is True, returns the `result` from the
-        :func:`scipy.optimize.root` function.
+    op_point : OperatingPoint
+        The solution represented as an `OperatingPoint` object.  The main
+        attributes are `states` and `inputs`, which represent the state
+        and input arrays at the operating point.  See
+        :class:`OperatingPoint` for a description of other attributes.
+
+        If accessed as a tuple, returns `states`, `inputs`, and optionally
+        `outputs` and `result` based on the `return_y` and `return_result`
+        parameters.
 
     Notes
     -----
@@ -1839,7 +1838,7 @@ def find_operating_point(
     `False`, the returned state and input for the operating point will be
     `None`.  If `return_result` is `True`, then the return values from
     :func:`scipy.optimize.root` will be returned (but may not be valid).
-    If `root_method` is set to `lm`, then the least squares solution (in
+    If `root_method` is set to 'lm', then the least squares solution (in
     the free variables) will be returned.
 
     """
@@ -1956,8 +1955,8 @@ def find_operating_point(
         # * output_vars: indices of outputs that must be constrained
         #
         # This index lists can all be precomputed based on the `iu`, `iy`,
-        # `ix`, and `idx` lists that were passed as arguments to `find_eqpt`
-        # and were processed above.
+        # `ix`, and `idx` lists that were passed as arguments to
+        # `find_operating_point` and were processed above.
 
         # Get the states and inputs that were not listed as fixed
         state_vars = (range(nstates) if not len(ix)

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -39,7 +39,8 @@ from . import config
 from .ctrlplot import ControlPlot, _add_arrows_to_line2D, _get_color, \
     _process_ax_keyword, _update_plot_title
 from .exception import ControlNotImplemented
-from .nlsys import NonlinearIOSystem, find_eqpt, input_output_response
+from .nlsys import NonlinearIOSystem, find_operating_point, \
+    input_output_response
 
 __all__ = ['phase_plane_plot', 'phase_plot', 'box_grid']
 
@@ -853,7 +854,7 @@ def _find_equilpts(sys, points, params=None):
     equilpts = []
     for i, x0 in enumerate(points):
         # Look for an equilibrium point near this point
-        xeq, ueq = find_eqpt(sys, x0, 0, params=params)
+        xeq, ueq = find_operating_point(sys, x0, 0, params=params)
 
         if xeq is None:
             continue            # didn't find anything

--- a/control/tests/docstrings_test.py
+++ b/control/tests/docstrings_test.py
@@ -53,6 +53,7 @@ keyword_skiplist = {
     control.create_estimator_iosystem: ['state_labels'],    # deprecated
     control.bode_plot: ['sharex', 'sharey', 'margin_info'], # deprecated
     control.eigensys_realization: ['arg'],                  # quasi-positional
+    control.find_operating_point: ['method'],               # internal use
 }
 
 # Decide on the level of verbosity (use -rP when running pytest)

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -2089,7 +2089,6 @@ def test_find_eqpt(x0, ix, u0, iu, y0, iy, dx0, idx, dt, x_expect, u_expect):
 
 
 # Test out new operating point version of find_eqpt
-# TODO: add return_)y tests
 def test_find_operating_point():
     dt = 1
     sys = ct.NonlinearIOSystem(
@@ -2148,7 +2147,7 @@ def test_operating_point():
     np.testing.assert_allclose(linsys_orig.C, linsys_oppt.C)
     np.testing.assert_allclose(linsys_orig.D, linsys_oppt.D)
 
-    # Call find_operating point with method and keyword arguments
+    # Call find_operating_point with method and keyword arguments
     op_point = ct.find_operating_point(
         sys, 0, 0, root_method='lm', root_kwargs={'tol': 1e-6})
 

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -2087,6 +2087,42 @@ def test_find_eqpt(x0, ix, u0, iu, y0, iy, dx0, idx, dt, x_expect, u_expect):
     np.testing.assert_allclose(np.array(ueq), u_expect, atol=1e-6)
 
 
+# Test out new operating point version of find_eqpt
+def test_find_operating_point():
+    dt = 1
+    sys = ct.NonlinearIOSystem(
+        eqpt_rhs, eqpt_out, dt=dt, states=3, inputs=2, outputs=2)
+
+    # Conditions that lead to no exact solution (from previous unit test)
+    x0 = 0;       ix = None
+    u0 = [-1, 0]; iu = None
+    y0 = None;    iy = None
+    dx0 = None;  idx = None
+
+    # Default version: no equilibrium solution => returns None
+    op_point = ct.find_operating_point(
+        sys, x0, u0, y0, ix=ix, iu=iu, iy=iy, dx0=dx0, idx=idx)
+    assert op_point.xop is None
+    assert op_point.uop is None
+    assert op_point.result.success is False
+
+    # Change the method to Levenberg-Marquardt (gives nearest point)
+    op_point = ct.find_operating_point(
+        sys, x0, u0, y0, ix=ix, iu=iu, iy=iy, dx0=dx0, idx=idx,
+        root_method='lm')
+    assert op_point.xop is not None
+    assert op_point.uop is not None
+    assert op_point.result.success is True
+
+    # Make sure we get a solution if we ask for the result explicitly
+    op_point = ct.find_operating_point(
+        sys, x0, u0, y0, ix=ix, iu=iu, iy=iy, dx0=dx0, idx=idx,
+        return_result=True)
+    assert op_point.xop is not None
+    assert op_point.uop is not None
+    assert op_point.result.success is False
+
+
 def test_iosys_sample():
     csys = ct.rss(2, 1, 1)
     dsys = csys.sample(0.1)

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -2142,6 +2142,10 @@ def test_operating_point():
     np.testing.assert_allclose(linsys_orig.C, linsys_oppt.C)
     np.testing.assert_allclose(linsys_orig.D, linsys_oppt.D)
 
+    # Call find_operating point with method and keyword arguments
+    op_point = ct.find_operating_point(
+        sys, 0, 0, root_method='lm', root_kwargs={'tol': 1e-6})
+
 
 def test_iosys_sample():
     csys = ct.rss(2, 1, 1)

--- a/control/tests/kwargs_test.py
+++ b/control/tests/kwargs_test.py
@@ -24,6 +24,7 @@ import control.tests.flatsys_test as flatsys_test
 import control.tests.frd_test as frd_test
 import control.tests.freqplot_test as freqplot_test
 import control.tests.interconnect_test as interconnect_test
+import control.tests.iosys_test as iosys_test
 import control.tests.optimal_test as optimal_test
 import control.tests.statefbk_test as statefbk_test
 import control.tests.stochsys_test as stochsys_test
@@ -252,6 +253,8 @@ kwarg_unittest = {
     'dlqr': test_unrecognized_kwargs,
     'drss': test_unrecognized_kwargs,
     'feedback': test_unrecognized_kwargs,
+    'find_eqpt': iosys_test.test_find_operating_point,
+    'find_operating_point': iosys_test.test_find_operating_point,
     'flatsys.flatsys': test_unrecognized_kwargs,
     'frd': frd_test.TestFRD.test_unrecognized_keyword,
     'gangof4': test_matplotlib_kwargs,

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -144,7 +144,7 @@ Nonlinear system support
    :toctree: generated/
 
     describing_function
-    find_eqpt
+    find_operating_point
     linearize
     input_output_response
     summing_junction

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -289,10 +289,10 @@ element of the `control.config.defaults` dictionary::
 
     ct.config.defaults['module.parameter'] = value
 
-The `~control.config.set_defaults` function can also be used to set multiple
-configuration parameters at the same time::
+The :func:`~control.set_defaults` function can also be used to
+set multiple configuration parameters at the same time::
 
-    ct.config.set_defaults('module', param1=val1, param2=val2, ...]
+    ct.set_defaults('module', param1=val1, param2=val2, ...]
 
 Finally, there are also functions available set collections of variables based
 on standard configurations.

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -56,7 +56,7 @@ they are not already present.
 .. note::
    Mixing packages from conda-forge and the default conda channel
    can sometimes cause problems with dependencies, so it is usually best to
-   instally NumPy, SciPy, and Matplotlib from conda-forge as well.
+   install NumPy, SciPy, and Matplotlib from conda-forge as well.
 
 To install using pip::
 

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -16,12 +16,13 @@ function::
   resp = ct.input_output_response(io_sys, T, U, X0, params)
   t, y, x = resp.time, resp.outputs, resp.states
 
-An input/output system can be linearized around an equilibrium point to obtain
-a :class:`~control.StateSpace` linear system.  Use the
-:func:`~control.find_eqpt` function to obtain an equilibrium point and the
-:func:`~control.linearize` function to linearize about that equilibrium point::
+An input/output system can be linearized around an equilibrium point
+to obtain a :class:`~control.StateSpace` linear system.  Use the
+:func:`~control.find_operating_point` function to obtain an
+equilibrium point and the :func:`~control.linearize` function to
+linearize about that equilibrium point::
 
-  xeq, ueq = ct.find_eqpt(io_sys, X0, U0)
+  xeq, ueq = ct.find_operating_point(io_sys, X0, U0)
   ss_sys = ct.linearize(io_sys, xeq, ueq)
 
 Input/output systems are automatically created for state space LTI systems
@@ -123,9 +124,8 @@ system and computing the linearization about that point.
 
 .. code-block:: python
 
-  eqpt = ct.find_eqpt(io_predprey, X0, 0)
-  xeq = eqpt[0]                         # choose the nonzero equilibrium point
-  lin_predprey = ct.linearize(io_predprey, xeq, 0)
+  eqpt = ct.find_operating_point(io_predprey, X0, 0)
+  lin_predprey = ct.linearize(io_predprey, eqpt)
 
 We next compute a controller that stabilizes the equilibrium point using
 eigenvalue placement and computing the feedforward gain using the number of
@@ -548,7 +548,7 @@ Module classes and functions
 .. autosummary::
    :toctree: generated/
 
-   ~control.find_eqpt
+   ~control.find_operating_point
    ~control.interconnect
    ~control.input_output_response
    ~control.linearize

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -544,6 +544,7 @@ Module classes and functions
    ~control.InterconnectedSystem
    ~control.LinearICSystem
    ~control.NonlinearIOSystem
+   ~control.OperatingPoint
 
 .. autosummary::
    :toctree: generated/

--- a/examples/cruise-control.py
+++ b/examples/cruise-control.py
@@ -349,7 +349,7 @@ theta0 = np.zeros(T.shape)
 # and u given the gear, slope, and desired output velocity)
 X0, U0, Y0 = ct.find_operating_point(
     cruise_pi, [vref[0], 0], [vref[0], gear[0], theta0[0]],
-    y0=[0, vref[0]], iu=[1, 2], iy=[1], return_y=True)
+    y0=[0, vref[0]], iu=[1, 2], iy=[1], return_outputs=True)
 
 # Now simulate the effect of a hill at t = 5 seconds
 plt.figure()

--- a/examples/cruise-control.py
+++ b/examples/cruise-control.py
@@ -165,7 +165,7 @@ theta_hill = np.array([
 
 for m in (1200, 1600, 2000):
     # Compute the equilibrium state for the system
-    X0, U0 = ct.find_eqpt(
+    X0, U0 = ct.find_operating_point(
         cruise_tf, [0, vref[0]], [vref[0], gear[0], theta0[0]], 
         iu=[1, 2], y0=[vref[0], 0], iy=[0], params={'m': m})
 
@@ -347,7 +347,7 @@ theta0 = np.zeros(T.shape)
 
 # Compute the equilibrium throttle setting for the desired speed (solve for x
 # and u given the gear, slope, and desired output velocity)
-X0, U0, Y0 = ct.find_eqpt(
+X0, U0, Y0 = ct.find_operating_point(
     cruise_pi, [vref[0], 0], [vref[0], gear[0], theta0[0]],
     y0=[0, vref[0]], iu=[1, 2], iy=[1], return_y=True)
 

--- a/examples/cruise.ipynb
+++ b/examples/cruise.ipynb
@@ -804,7 +804,7 @@
     "# Compute the equilibrium throttle setting for the desired speed\n",
     "X0, U0, Y0 = ct.find_eqpt(\n",
     "    cruise_pi, [vref[0], 0], [vref[0], gear[0], theta0[0]],\n",
-    "    y0=[0, vref[0]], iu=[1, 2], iy=[1], return_y=True)\n",
+    "    y0=[0, vref[0]], iu=[1, 2], iy=[1], return_outputs=True)\n",
     "\n",
     "# Now simulate the effect of a hill at t = 5 seconds\n",
     "plt.figure()\n",


### PR DESCRIPTION
This PR is motivated by discussion #1053 in which a situation the current implementation of `find_eqpt` does not find a good solution due to the problem being over/underconstrained.  The main functional change is this PR is to help address that by adding a `root_method` method that allows a least squares solution to be obtained.

In addition, while looking through this (fairly old) code, it seemed worth making some additional changes:

* Renamed `find_eqpt` to `find_operating_point` to be more consistent with python-control naming conventions (and the fact that an operating point is not always an equilibrium point.
* Changed the return type for `find_operating_point` from a tuple of various lengths (depending on parameter settings) to a `OperatingPoint` object, which contains the states, inputs, and outputs corresponding to the operating point, along with the result of the call to the `scipy.minimize.root` function.
* Added `root_method` and `root_kwargs` parameters to allow customization of the root finding method.
* Maintained backward compatibility so that `find_eqpt` still works, as well as `return_y` (now `return_outputs`, with legacy processing of `return_y`) and `return_result`.  In addition, the return object can be accessed as a tuple for consistency with the previous return signature.
* Updated docstrings and documentation to use the new conventions.
* Added unit tests to check all new functionality.

In the context of #1053, a solution to the issue there can be obtained by calling `find_eqpt` (now `find_operating_point`) with `root_method='lm'`.