### PR TITLE
Add `combine()` and `split()` functions for transfer matrices

### DIFF
--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -543,7 +543,8 @@ def combine(tf_array):
     ValueError
         If ``tf_array`` has incorrect dimensions.
     ValueError
-        If the transfer functions in a row have mismatched output dimensions.
+        If the transfer functions in a row have mismatched output or input
+        dimensions.
 
     Examples
     --------
@@ -554,7 +555,8 @@ def combine(tf_array):
     ...     [1 / (s + 1)],
     ...     [s / (s + 2)],
     ... ])
-    TransferFunction([[array([1])], [array([1, 0])]], [[array([1, 1])], [array([1, 2])]])
+    TransferFunction([[array([1])], [array([1, 0])]],
+                     [[array([1, 1])], [array([1, 2])]])
     """
     # Find common timebase or raise error
     dt_list = []
@@ -596,6 +598,16 @@ def combine(tf_array):
                     den_row.append(col.den[j_out][j_in])
             num.append(num_row)
             den.append(den_row)
+    for row_index, row in enumerate(num):
+        if len(row) != len(num[0]):
+            raise ValueError(
+                f"Mismatched number transfer function inputs in row {row_index} of numerator."
+            )
+    for row_index, row in enumerate(den):
+        if len(row) != len(den[0]):
+            raise ValueError(
+                f"Mismatched number transfer function inputs in row {row_index} of denominator."
+            )
     G_tf = tf.TransferFunction(num, den, dt=dt)
     return G_tf
 

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -548,6 +548,19 @@ def combine_tf(tf_array):
     ... ])
     TransferFunction([[array([1])], [array([1, 0])]],
                      [[array([1, 1])], [array([1, 2])]])
+
+    Combine NumPy arrays with transfer functions
+
+    >>> control.combine_tf([
+    ...     [np.eye(2), np.zeros((2, 1))],
+    ...     [np.zeros((1, 2)), control.TransferFunction([1], [1, 0])],
+    ... ])
+    TransferFunction([[array([1.]), array([0.]), array([0.])],
+                      [array([0.]), array([1.]), array([0.])],
+                      [array([0.]), array([0.]), array([1])]],
+                     [[array([1.]), array([1.]), array([1.])],
+                      [array([1.]), array([1.]), array([1.])],
+                      [array([1.]), array([1.]), array([1, 0])]])
     """
     # Find common timebase or raise error
     dt_list = []

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -580,11 +580,15 @@ def combine(tf_array):
     # Iterate over
     num = []
     den = []
-    for row in ensured_tf_array:
+    for row_index, row in enumerate(ensured_tf_array):
         for j_out in range(row[0].noutputs):
             num_row = []
             den_row = []
             for col in row:
+                if col.noutputs != row[0].noutputs:
+                    raise ValueError(
+                        f"Mismatched number of transfer function outputs in row {row_index}."
+                    )
                 for j_in in range(col.ninputs):
                     num_row.append(col.num[j_out][j_in])
                     den_row.append(col.den[j_out][j_in])

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -573,7 +573,8 @@ def combine_tf(tf_array):
     dt_set = set(dt_list)
     dt_set.discard(None)
     if len(dt_set) > 1:
-        raise ValueError(f"Timesteps of transfer functions are mismatched: {dt_set}")
+        raise ValueError("Timesteps of transfer functions are "
+                         f"mismatched: {dt_set}")
     elif len(dt_set) == 0:
         dt = None
     else:
@@ -595,7 +596,8 @@ def combine_tf(tf_array):
             for col in row:
                 if col.noutputs != row[0].noutputs:
                     raise ValueError(
-                        f"Mismatched number of transfer function outputs in row {row_index}."
+                        "Mismatched number of transfer function outputs in "
+                        f"row {row_index}."
                     )
                 for j_in in range(col.ninputs):
                     num_row.append(col.num[j_out][j_in])
@@ -605,12 +607,14 @@ def combine_tf(tf_array):
     for row_index, row in enumerate(num):
         if len(row) != len(num[0]):
             raise ValueError(
-                f"Mismatched number transfer function inputs in row {row_index} of numerator."
+                "Mismatched number transfer function inputs in row "
+                f"{row_index} of numerator."
             )
     for row_index, row in enumerate(den):
         if len(row) != len(den[0]):
             raise ValueError(
-                f"Mismatched number transfer function inputs in row {row_index} of denominator."
+                "Mismatched number transfer function inputs in row "
+                f"{row_index} of denominator."
             )
     return tf.TransferFunction(num, den, dt=dt)
 
@@ -692,12 +696,14 @@ def _ensure_tf(arraylike_or_tf, dt=None):
         # If timesteps don't match, raise an exception
         if (dt is not None) and (arraylike_or_tf.dt != dt):
             raise ValueError(
-                f"`arraylike_or_tf.dt={arraylike_or_tf.dt}` does not match argument `dt={dt}`."
+                f"`arraylike_or_tf.dt={arraylike_or_tf.dt}` does not match "
+                f"argument `dt={dt}`."
             )
         return arraylike_or_tf
     if np.ndim(arraylike_or_tf) > 2:
         raise ValueError(
-            "Array-like must have less than two dimensions to be converted into a transfer function."
+            "Array-like must have less than two dimensions to be converted "
+            "into a transfer function."
         )
     # If it's not, then convert it to a transfer function
     arraylike_3d = np.atleast_3d(arraylike_or_tf)
@@ -709,6 +715,7 @@ def _ensure_tf(arraylike_or_tf, dt=None):
         )
     except TypeError:
         raise ValueError(
-            "`arraylike_or_tf` must only contain array-likes or transfer functions."
+            "`arraylike_or_tf` must only contain array-likes or transfer "
+            "functions."
         )
     return tfn

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -516,17 +516,16 @@ def combine_tf(tf_array):
 
     Parameters
     ----------
-    tf_array : List[List[Union[ArrayLike, control.TransferFunction]]]
+    tf_array : list of list of TransferFunction or array_like
         Transfer matrix represented as a two-dimensional array or list-of-lists
-        containing :class:`TransferFunction` objects. The
-        :class:`TransferFunction` objects can have multiple outputs and inputs,
-        as long as the dimensions are compatible.
+        containing TransferFunction objects. The TransferFunction objects can
+        have multiple outputs and inputs, as long as the dimensions are
+        compatible.
 
     Returns
     -------
-    control.TransferFunction
-        Transfer matrix represented as a single MIMO :class:`TransferFunction`
-        object.
+    TransferFunction
+        Transfer matrix represented as a single MIMO TransferFunction object.
 
     Raises
     ------
@@ -600,15 +599,14 @@ def combine_tf(tf_array):
             raise ValueError(
                 f"Mismatched number transfer function inputs in row {row_index} of denominator."
             )
-    G_tf = tf.TransferFunction(num, den, dt=dt)
-    return G_tf
+    return tf.TransferFunction(num, den, dt=dt)
 
 def split_tf(transfer_function):
     """Split MIMO transfer function into NumPy array of SISO tranfer functions.
 
     Parameters
     ----------
-    transfer_function : control.TransferFunction
+    transfer_function : TransferFunction
         MIMO transfer function to split.
 
     Returns
@@ -648,25 +646,25 @@ def split_tf(transfer_function):
                 )
             )
         tf_split_lst.append(row)
-    tf_split = np.array(tf_split_lst, dtype=object)
-    return tf_split
+    return np.array(tf_split_lst, dtype=object)
 
 def _ensure_tf(arraylike_or_tf, dt=None):
     """Convert an array-like to a transfer function.
 
     Parameters
     ----------
-    arraylike_or_tf : Union[ArrayLike, control.TransferFunction]
+    arraylike_or_tf : TransferFunction or array_like
         Array-like or transfer function.
-    dt : Union[None, bool, float]
-        Timestep (s). ``True`` indicates a discrete-time system with
-        unspecified timestep, ``0`` indicates a continuous-time system, and
-        ``None`` indicates a continuous- or discrete-time system with
-        unspecified timestep. If ``None``, timestep is not validated.
+    dt : None, True or float, optional
+        System timebase. 0 (default) indicates continuous
+        time, True indicates discrete time with unspecified sampling
+        time, positive number is discrete time with specified
+        sampling time, None indicates unspecified timebase (either
+        continuous or discrete time). If None, timestep is not validated.
 
     Returns
     -------
-    control.TransferFunction
+    TransferFunction
         Transfer function.
 
     Raises

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -542,6 +542,8 @@ def combine(tf_array):
         If timesteps of transfer functions do not match.
     ValueError
         If ``tf_array`` has incorrect dimensions.
+    ValueError
+        If the transfer functions in a row have mismatched output dimensions.
 
     Examples
     --------

--- a/control/bdalg.py
+++ b/control/bdalg.py
@@ -10,8 +10,8 @@ parallel
 negate
 feedback
 connect
-combine
-split
+combine_tf
+split_tf
 
 """
 
@@ -65,16 +65,8 @@ from . import statesp as ss
 from . import xferfcn as tf
 from .iosys import InputOutputSystem
 
-__all__ = [
-    'series',
-    'parallel',
-    'negate',
-    'feedback',
-    'append',
-    'connect',
-    'combine',
-    'split',
-]
+__all__ = ['series', 'parallel', 'negate', 'feedback', 'append', 'connect',
+           'combine_tf', 'split_tf']
 
 
 def series(sys1, *sysn, **kwargs):
@@ -519,7 +511,7 @@ def connect(sys, Q, inputv, outputv):
 
     return Ytrim * sys * Utrim
 
-def combine(tf_array):
+def combine_tf(tf_array):
     """Combine array-like of transfer functions into MIMO transfer function.
 
     Parameters
@@ -551,7 +543,7 @@ def combine(tf_array):
     Combine two transfer functions
 
     >>> s = control.TransferFunction.s
-    >>> control.combine([
+    >>> control.combine_tf([
     ...     [1 / (s + 1)],
     ...     [s / (s + 2)],
     ... ])
@@ -611,7 +603,7 @@ def combine(tf_array):
     G_tf = tf.TransferFunction(num, den, dt=dt)
     return G_tf
 
-def split(transfer_function):
+def split_tf(transfer_function):
     """Split MIMO transfer function into NumPy array of SISO tranfer functions.
 
     Parameters
@@ -638,7 +630,7 @@ def split(transfer_function):
     ...         [[1, 1], [1, 1]],
     ...     ],
     ... )
-    >>> control.split(G)
+    >>> control.split_tf(G)
     array([[TransferFunction(array([87.8]), array([1, 1])),
             TransferFunction(array([-86.4]), array([1, 1]))],
            [TransferFunction(array([108.2]), array([1, 1])),

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -366,7 +366,7 @@ def test_bdalg_udpate_names_errors():
 
 
 class TestEnsureTf:
-    """Test :func:`_ensure_tf`."""
+    """Test ``_ensure_tf``."""
 
     @pytest.mark.parametrize(
         "arraylike_or_tf, dt, tf",
@@ -466,7 +466,7 @@ class TestEnsureTf:
 
 
 class TestTfCombineSplit:
-    """Test :func:`combine_tf` and :func:`split_tf`."""
+    """Test ``combine_tf`` and ``split_tf``."""
 
     @pytest.mark.parametrize(
         "tf_array, tf",
@@ -833,9 +833,9 @@ def _tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):
     tf_b : TransferFunction
         Second transfer function.
     rtol : float
-        Relative tolerance for :func:`np.allclose`.
+        Relative tolerance for ``np.allclose``.
     atol : float
-        Absolute tolerance for :func:`np.allclose`.
+        Absolute tolerance for ``np.allclose``.
 
     Returns
     -------

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -432,7 +432,6 @@ class TestEnsureTf:
     def test_ensure(self, arraylike_or_tf, dt, tf):
         """Test nominal cases"""
         ensured_tf = _ensure_tf(arraylike_or_tf, dt)
-        pass
         assert _tf_close_coeff(tf, ensured_tf)
 
     @pytest.mark.parametrize(

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -815,6 +815,55 @@ class TestTfCombineSplit:
                 ],
                 ValueError,
             ),
+            (
+                [
+                    [
+                        ctrl.TransferFunction(
+                            [
+                                [[2], [1]],
+                                [[1], [3]],
+                            ],
+                            [
+                                [[1, 0], [1, 0]],
+                                [[1, 0], [1, 0]],
+                            ],
+                        ),
+                        ctrl.TransferFunction(
+                            [
+                                [[2], [1]],
+                                [[1], [3]],
+                            ],
+                            [
+                                [[1, 0], [1, 0]],
+                                [[1, 0], [1, 0]],
+                            ],
+                        ),
+                    ],
+                    [
+                        ctrl.TransferFunction(
+                            [
+                                [[2], [1], [1]],
+                                [[1], [3], [2]],
+                            ],
+                            [
+                                [[1, 0], [1, 0], [1, 0]],
+                                [[1, 0], [1, 0], [1, 0]],
+                            ],
+                        ),
+                        ctrl.TransferFunction(
+                            [
+                                [[2], [1]],
+                                [[1], [3]],
+                            ],
+                            [
+                                [[1, 0], [1, 0]],
+                                [[1, 0], [1, 0]],
+                            ],
+                        ),
+                    ],
+                ],
+                ValueError,
+            ),
         ],
     )
     def test_error_combine_tf(self, tf_array, exception):

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -466,7 +466,7 @@ class TestEnsureTf:
 
 
 class TestTfCombineSplit:
-    """Test :func:`combine` and :func:`split`."""
+    """Test :func:`combine_tf` and :func:`split_tf`."""
 
     @pytest.mark.parametrize(
         "tf_array, tf",
@@ -621,9 +621,9 @@ class TestTfCombineSplit:
             ),
         ],
     )
-    def test_combine(self, tf_array, tf):
+    def test_combine_tf(self, tf_array, tf):
         """Test combining transfer functions."""
-        tf_combined = ctrl.combine(tf_array)
+        tf_combined = ctrl.combine_tf(tf_array)
         assert _tf_close_coeff(tf_combined, tf)
 
     @pytest.mark.parametrize(
@@ -706,9 +706,9 @@ class TestTfCombineSplit:
             ),
         ],
     )
-    def test_split(self, tf_array, tf):
+    def test_split_tf(self, tf_array, tf):
         """Test splitting transfer functions."""
-        tf_split = ctrl.split(tf)
+        tf_split = ctrl.split_tf(tf)
         # Test entry-by-entry
         for i in range(tf_split.shape[0]):
             for j in range(tf_split.shape[1]):
@@ -718,8 +718,8 @@ class TestTfCombineSplit:
                 )
         # Test combined
         assert _tf_close_coeff(
-            ctrl.combine(tf_split),
-            ctrl.combine(tf_array),
+            ctrl.combine_tf(tf_split),
+            ctrl.combine_tf(tf_array),
         )
 
     @pytest.mark.parametrize(
@@ -817,10 +817,10 @@ class TestTfCombineSplit:
             ),
         ],
     )
-    def test_error_combine(self, tf_array, exception):
+    def test_error_combine_tf(self, tf_array, exception):
         """Test error cases."""
         with pytest.raises(exception):
-            ctrl.combine(tf_array)
+            ctrl.combine_tf(tf_array)
 
 
 def _tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -853,8 +853,18 @@ def _tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):
     # Check coefficient arrays
     for i in range(tf_a.noutputs):
         for j in range(tf_a.ninputs):
-            if not np.allclose(tf_a.num[i][j], tf_b.num[i][j], rtol=rtol, atol=atol):
+            if not np.allclose(
+                tf_a.num[i][j],
+                tf_b.num[i][j],
+                rtol=rtol,
+                atol=atol,
+            ):
                 return False
-            if not np.allclose(tf_a.den[i][j], tf_b.den[i][j], rtol=rtol, atol=atol):
+            if not np.allclose(
+                tf_a.den[i][j],
+                tf_b.den[i][j],
+                rtol=rtol,
+                atol=atol,
+            ):
                 return False
     return True

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -756,6 +756,65 @@ class TestTfCombineSplit:
                 ],
                 ValueError,
             ),
+            # Incompatible dimensions
+            (
+                [
+                    [
+                        ctrl.TransferFunction(
+                            [
+                                [
+                                    [1],
+                                ]
+                            ],
+                            [
+                                [
+                                    [1, 1],
+                                ]
+                            ],
+                        ),
+                        ctrl.TransferFunction(
+                            [
+                                [[2], [1]],
+                                [[1], [3]],
+                            ],
+                            [
+                                [[1, 0], [1, 0]],
+                                [[1, 0], [1, 0]],
+                            ],
+                        ),
+                    ],
+                ],
+                ValueError,
+            ),
+            (
+                [
+                    [
+                        ctrl.TransferFunction(
+                            [
+                                [[2], [1]],
+                                [[1], [3]],
+                            ],
+                            [
+                                [[1, 0], [1, 0]],
+                                [[1, 0], [1, 0]],
+                            ],
+                        ),
+                        ctrl.TransferFunction(
+                            [
+                                [
+                                    [1],
+                                ]
+                            ],
+                            [
+                                [
+                                    [1, 1],
+                                ]
+                            ],
+                        ),
+                    ],
+                ],
+                ValueError,
+            ),
         ],
     )
     def test_error_combine(self, tf_array, exception):
@@ -769,9 +828,9 @@ def _tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):
 
     Parameters
     ----------
-    tf_a : control.TransferFunction
+    tf_a : TransferFunction
         First transfer function.
-    tf_b : control.TransferFunction
+    tf_b : TransferFunction
         Second transfer function.
     rtol : float
         Relative tolerance for :func:`np.allclose`.


### PR DESCRIPTION
RE #325 

I've run into a few times where it would be convenient to construct MIMO `TransferMatrix` objects from SISO ones, or the reverse. In particular, this came up as I've been working on a D-K iteration package, [`dkpy`](https://github.com/decargroup/dkpy). The specific implementation here is from [utilities.py](https://github.com/decargroup/dkpy/blob/main/src/dkpy/utilities.py) in `dkpy`.

I saw there was a related issue (#325 ) and people seemed open to it. Specifically, I've added

- `control.combine()` that takes an `ArrayLike` of `TransferFunction` objects, scalars, and NumPy arrays, and creates a MIMO transfer matrix, and
- `control.split()` that takes a MIMO `TransferFunction` and returns a NumPy array with SISO `TransferFunction` objectss.

I'm new to the `python-control` codebase, so I'm not 100% sure if I've placed things in the correct files, but I've added unit tests and would appreciate some feedback.