### PR TITLE
update model_reduction to allow input/output selection + unstable warning (vs exception)

### DIFF
--- a/control/canonical.py
+++ b/control/canonical.py
@@ -205,7 +205,7 @@ def similarity_transform(xsys, T, timescale=1, inverse=False):
     timescale : float, optional
         If present, also rescale the time unit to tau = timescale * t
     inverse : bool, optional
-        If True (default), transform so z = T x.  If False, transform
+        If False (default), transform so z = T x.  If True, transform
         so x = T z.
 
     Returns

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -146,6 +146,9 @@ def model_reduction(
     other checking is done, so users to be careful not to render a system
     unobservable or unreachable.
 
+    States, inputs, and outputs can be specified using integer offers.
+    Slices can also be specified, but must use the Python ``slice()`` function.
+
     """
     if not isinstance(sys, StateSpace):
         raise TypeError("system must be a a StateSpace system")
@@ -158,8 +161,16 @@ def model_reduction(
 
     # Utility function to process keep/elim keywords
     def _process_elim_or_keep(elim, keep, labels, allow_both=False):
-        elim = [] if elim is None else np.atleast_1d(elim)
-        keep = [] if keep is None else np.atleast_1d(keep)
+        def _expand_key(key):
+            if key is None:
+                return []
+            elif isinstance(key, slice):
+                return range(len(labels))[key]
+            else:
+                return np.atleast_1d(key)
+
+        elim = _expand_key(elim)
+        keep = _expand_key(keep)
             
         if len(elim) > 0 and len(keep) > 0:
             if not allow_both:

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -108,7 +108,7 @@ def hankel_singular_values(sys):
     return hsv[::-1]
 
 
-def model_reduction(sys, ELIM, method='matchdc'):
+def model_reduction(sys, ELIM, method='matchdc', warn_unstable=True):
     """Model reduction by state elimination.
     
     Model reduction of `sys` by eliminating the states in `ELIM` using a given
@@ -122,7 +122,9 @@ def model_reduction(sys, ELIM, method='matchdc'):
         Vector of states to eliminate.
     method : string
         Method of removing states in `ELIM`: either 'truncate' or
-        'matchdc'.
+        'matchdc' (default).
+    warn_unstable: bool, option
+        If `False`, don't warn if system is unstable.
 
     Returns
     -------
@@ -132,12 +134,14 @@ def model_reduction(sys, ELIM, method='matchdc'):
     Raises
     ------
     ValueError
-        Raised under the following conditions:
+        If `method` is not either ``'matchdc'`` or ``'truncate'``.
+    NotImplementedError
+        If `sys` is a discrete time system.
 
-            * if `method` is not either ``'matchdc'`` or ``'truncate'``
-
-            * if eigenvalues of `sys.A` are not all in left half plane
-              (`sys` must be stable)
+    Warns
+    -----
+    UserWarning
+        If eigenvalues of `sys.A` are not all stable.
 
     Examples
     --------
@@ -162,8 +166,8 @@ def model_reduction(sys, ELIM, method='matchdc'):
         raise NotImplementedError("Function not implemented in discrete time")
 
     # Check system is stable
-    if np.any(np.linalg.eigvals(sys.A).real >= 0.0):
-        raise ValueError("Oops, the system is unstable!")
+    if np.any(np.linalg.eigvals(sys.A).real >= 0.0) and warn_unstable:
+        warnings.warn("System is unstable; reduction may be meaningless")
 
     ELIM = np.sort(ELIM)
     # Create list of elements not to eliminate (NELIM)

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -83,12 +83,15 @@ def model_reduction(
     """Model reduction by input, output, or state elimination.
 
     This function produces a reduced-order model of a system by eliminating
-    specified inputs,outputs, or states from the original system.  The
+    specified inputs, outputs, and/or states from the original system.  The
     specific states, inputs, or outputs that are eliminated can be
-    specified by listing either the states, inputs, or outputs to be
-    eliminated or those to be kept.  In addition, unused states (those that
-    do not affect the inputs or outputs of the reduced system) can also be
-    eliminated.
+    specified by either listing the states, inputs, or outputs to be
+    eliminated or those to be kept.
+
+    Two methods of state reduction are possible: 'truncate' removes the
+    states marked for elimination, while 'matchdc' replaces the the
+    eliminated states with their equilibrium values (thereby keeping the
+    input/output gain unchanged at zero frequency ["DC"]).
 
     Parameters
     ----------
@@ -100,9 +103,6 @@ def model_reduction(
     keep_inputs, keep_outputs, keep_states : array, optional
         Vector of inputs, outputs, or states to keep.  Can be specified
         either as an offset into the appropriate vector or as a signal name.
-    remove_hidden_states : str, optional
-        If `unobs` (default), then eliminate any states that are unobservable
-        via the reduced-order system outputs.
     method : string
         Method of removing states in `elim`: either 'truncate' or
         'matchdc' (default).
@@ -117,7 +117,9 @@ def model_reduction(
     Raises
     ------
     ValueError
-        If `method` is not either ``'matchdc'`` or ``'truncate'``.
+        If `method` is not either 'matchdc' or 'truncate'.
+    NotImplementedError
+        If the 'matchdc' method is used for a discrete time system.
 
     Warns
     -----
@@ -130,6 +132,19 @@ def model_reduction(
     >>> Gr = ct.model_reduction(G, [0, 2], method='matchdc')
     >>> Gr.nstates
     2
+
+    See Also
+    --------
+    balanced_reduction : Eliminate states using Hankel singular values.
+    minimal_realization : Eliminate unreachable or unobseravble states.
+
+    Notes
+    -----
+    The model_reduction function issues a warning if the system has
+    unstable eigenvalues, since in those situations the stability reduced
+    order model may be different that the stability of the full model.  No
+    other checking is done, so users to be careful not to render a system
+    unobservable or unreachable.
 
     """
     if not isinstance(sys, StateSpace):

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -89,9 +89,9 @@ def model_reduction(
     eliminated or those to be kept.
 
     Two methods of state reduction are possible: 'truncate' removes the
-    states marked for elimination, while 'matchdc' replaces the the
-    eliminated states with their equilibrium values (thereby keeping the
-    input/output gain unchanged at zero frequency ["DC"]).
+    states marked for elimination, while 'matchdc' replaces the eliminated
+    states with their equilibrium values (thereby keeping the input/output
+    gain unchanged at zero frequency ["DC"]).
 
     Parameters
     ----------
@@ -104,9 +104,8 @@ def model_reduction(
         Vector of inputs, outputs, or states to keep.  Can be specified
         either as an offset into the appropriate vector or as a signal name.
     method : string
-        Method of removing states in `elim`: either 'truncate' or
-        'matchdc' (default).
-    warn_unstable: bool, option
+        Method of removing states: either 'truncate' or 'matchdc' (default).
+    warn_unstable : bool, option
         If `False`, don't warn if system is unstable.
 
     Returns
@@ -136,23 +135,23 @@ def model_reduction(
     See Also
     --------
     balanced_reduction : Eliminate states using Hankel singular values.
-    minimal_realization : Eliminate unreachable or unobseravble states.
+    minimal_realization : Eliminate unreachable or unobservable states.
 
     Notes
     -----
     The model_reduction function issues a warning if the system has
-    unstable eigenvalues, since in those situations the stability reduced
-    order model may be different that the stability of the full model.  No
-    other checking is done, so users to be careful not to render a system
-    unobservable or unreachable.
+    unstable eigenvalues, since in those situations the stability of the
+    reduced order model may be different than the stability of the full
+    model.  No other checking is done, so users must to be careful not to
+    render a system unobservable or unreachable.
 
-    States, inputs, and outputs can be specified using integer offers or
+    States, inputs, and outputs can be specified using integer offsets or
     using signal names.  Slices can also be specified, but must use the
     Python ``slice()`` function.
 
     """
     if not isinstance(sys, StateSpace):
-        raise TypeError("system must be a a StateSpace system")
+        raise TypeError("system must be a StateSpace system")
 
     # Check system is stable
     if warn_unstable:
@@ -161,7 +160,7 @@ def model_reduction(
             warnings.warn("System is unstable; reduction may be meaningless")
 
     # Utility function to process keep/elim keywords
-    def _process_elim_or_keep(elim, keep, labels, allow_both=False):
+    def _process_elim_or_keep(elim, keep, labels):
         def _expand_key(key):
             if key is None:
                 return []
@@ -178,9 +177,8 @@ def model_reduction(
         keep = np.atleast_1d(_expand_key(keep))
             
         if len(elim) > 0 and len(keep) > 0:
-            if not allow_both:
-                raise ValueError(
-                    "can't provide both 'keep' and 'elim' for same variables")
+            raise ValueError(
+                "can't provide both 'keep' and 'elim' for same variables")
         elif len(keep) > 0:
             keep = np.sort(keep).tolist()
             elim = [i for i in range(len(labels)) if i not in keep]

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -79,7 +79,7 @@ def hankel_singular_values(sys):
 def model_reduction(
         sys, elim_states=None, method='matchdc', elim_inputs=None,
         elim_outputs=None, keep_states=None, keep_inputs=None,
-        keep_outputs=None, remove_hidden_states='unobs', warn_unstable=True):
+        keep_outputs=None, warn_unstable=True):
     """Model reduction by input, output, or state elimination.
 
     This function produces a reduced-order model of a system by eliminating
@@ -146,8 +146,9 @@ def model_reduction(
     other checking is done, so users to be careful not to render a system
     unobservable or unreachable.
 
-    States, inputs, and outputs can be specified using integer offers.
-    Slices can also be specified, but must use the Python ``slice()`` function.
+    States, inputs, and outputs can be specified using integer offers or
+    using signal names.  Slices can also be specified, but must use the
+    Python ``slice()`` function.
 
     """
     if not isinstance(sys, StateSpace):
@@ -164,13 +165,17 @@ def model_reduction(
         def _expand_key(key):
             if key is None:
                 return []
+            elif isinstance(key, str):
+                return labels.index(key)
+            elif isinstance(key, list):
+                return [_expand_key(k) for k in key]
             elif isinstance(key, slice):
                 return range(len(labels))[key]
             else:
-                return np.atleast_1d(key)
+                return key
 
-        elim = _expand_key(elim)
-        keep = _expand_key(keep)
+        elim = np.atleast_1d(_expand_key(elim))
+        keep = np.atleast_1d(_expand_key(keep))
             
         if len(elim) > 0 and len(keep) > 0:
             if not allow_both:

--- a/control/tests/docstrings_test.py
+++ b/control/tests/docstrings_test.py
@@ -39,7 +39,7 @@ function_docstring_hash = {
     control.ss2tf:                      '48ff25d22d28e7b396e686dd5eb58831',
     control.tf:                         '53a13f4a7f75a31c81800e10c88730ef',
     control.tf2ss:                      '086a3692659b7321c2af126f79f4bc11',
-    control.markov:                     'eda7c4635bbb863ae6659e574285d356',
+    control.markov:                     'a4199c54cb50f07c0163d3790739eafe',
     control.gangof4:                    '0e52eb6cf7ce024f9a41f3ae3ebf04f7',
 }
 

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -481,6 +481,7 @@ class TestModelsimp:
     ({'elim_outputs': [1, 2], 'keep_inputs': [0, 1],}, 5, 1, 2),
     ({'keep_states': [2, 0], 'keep_outputs': [0, 1]}, 2, 2, 3),
     ({'keep_states': slice(0, 4, 2), 'keep_outputs': slice(None, 2)}, 2, 2, 3),
+    ({'keep_states': ['x[0]', 'x[3]'], 'keep_inputs': 'u[0]'}, 2, 3, 1),
     ({'elim_inputs': [0, 1, 2]}, 5, 3, 0),              # no inputs
     ({'elim_outputs': [0, 1, 2]}, 5, 0, 3),             # no outputs
     ({'elim_states': [0, 1, 2, 3, 4]}, 0, 3, 3),        # no states

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -480,6 +480,7 @@ class TestModelsimp:
     ({'elim_inputs': [1, 2], 'keep_states': [1, 3]}, 2, 3, 1),
     ({'elim_outputs': [1, 2], 'keep_inputs': [0, 1],}, 5, 1, 2),
     ({'keep_states': [2, 0], 'keep_outputs': [0, 1]}, 2, 2, 3),
+    ({'keep_states': slice(0, 4, 2), 'keep_outputs': slice(None, 2)}, 2, 2, 3),
     ({'elim_inputs': [0, 1, 2]}, 5, 3, 0),              # no inputs
     ({'elim_outputs': [0, 1, 2]}, 5, 0, 3),             # no outputs
     ({'elim_states': [0, 1, 2, 3, 4]}, 0, 3, 3),        # no states

--- a/control/tests/modelsimp_test.py
+++ b/control/tests/modelsimp_test.py
@@ -485,7 +485,7 @@ class TestModelsimp:
     ({'elim_inputs': [0, 1, 2]}, 5, 3, 0),              # no inputs
     ({'elim_outputs': [0, 1, 2]}, 5, 0, 3),             # no outputs
     ({'elim_states': [0, 1, 2, 3, 4]}, 0, 3, 3),        # no states
-    ({'elim_states': [0, 1], 'keep_states': [1, 2]}, None, None, None)
+    ({'elim_states': [0, 1], 'keep_states': [1, 2]}, None, None, None),
 ])
 @pytest.mark.parametrize("method", ['truncate', 'matchdc'])
 def test_model_reduction(method, kwargs, nstates, noutputs, ninputs):


### PR DESCRIPTION
This PR updates the `model_reduction` function to add some additional functionality.  From the docstring:

> This function produces a reduced-order model of a system by eliminating specified inputs, outputs, and/or states from the original system.  The specific states, inputs, or outputs that are eliminated can be specified by either listing the states, inputs, or outputs to be eliminated or those to be kept.

Specific updates:
* Changed the `ELIM` positional parameter to `elim_states` (positional or keyword).
* Added `keep_states` to allow specifying the list of states to keep instead of those to eliminate.
* Added `elim_inputs`, `elim_outputs`, `keep_inputs`, `keep_outputs` to allow selection of inputs and outputs.
* Specifications of states, inputs, and outputs can be done by a list of integers (original implementation) as well as slices or lists of signal names (new).
* In the case of eliminating states, inputs, or outputs from an unstable system, a warning is issued (versus an exception) and this warning can be suppressed using `warn_unstable=False`.
* Removed the copyright info from the top of `modelsimp.py` since we know just use the `LICENSE` file.
* Add unit tests and documentation updates.
* Cleaned up import order (isort -m2) and removed extraneous spaces.

This PR was motivated by an example from FBS2e (see [steering.py](https://github.com/murrayrm/fbs2e-python/blob/main/steering.py)), where I wanted to extract the dynamics of a subsystem (and the original system had an eigenvalue at the origin).  It is possible to accomplish the same result by using the old implementation (assuming the exception is changed to a warning) and then indexing the system directly to handle the inputs and outputs, but it seemed natural to include in a single function call.
