### PR TITLE
fix issue with multiplying MIMO LTI system by scalar

### DIFF
--- a/control/tests/lti_test.py
+++ b/control/tests/lti_test.py
@@ -350,3 +350,21 @@ def test_subsys_indexing(fcn, outdx, inpdx, key):
             np.testing.assert_almost_equal(
                 subsys_fcn.frequency_response(omega).response,
                 subsys_chk.frequency_response(omega).response)
+
+
+@slycotonly
+@pytest.mark.parametrize("op", [
+    '__mul__', '__rmul__', '__add__', '__radd__', '__sub__', '__rsub__'])
+@pytest.mark.parametrize("fcn", [ct.ss, ct.tf, ct.frd])
+def test_scalar_algebra(op, fcn):
+    sys_ss = ct.rss(4, 2, 2)
+    match fcn:
+        case ct.ss:
+            sys = sys_ss
+        case ct.tf:
+            sys = ct.tf(sys_ss)
+        case ct.frd:
+            sys = ct.frd(sys_ss, [0.1, 1, 10])
+
+    scaled = getattr(sys, op)(2)
+    np.testing.assert_almost_equal(getattr(sys(1j), op)(2), scaled(1j))

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -634,11 +634,11 @@ class TransferFunction(LTI):
         from .statesp import StateSpace
 
         # Convert the second argument to a transfer function.
-        if isinstance(other, StateSpace):
+        if isinstance(other, (StateSpace, np.ndarray)):
             other = _convert_to_transfer_function(other)
-        elif isinstance(other, (int, float, complex, np.number, np.ndarray)):
-            other = _convert_to_transfer_function(other, inputs=self.ninputs,
-                                                  outputs=self.noutputs)
+        elif isinstance(other, (int, float, complex, np.number)):
+            # Multiply by a scaled identify matrix (transfer function)
+            other = _convert_to_transfer_function(np.eye(self.ninputs) * other)
         if not isinstance(other, TransferFunction):
             return NotImplemented
 
@@ -681,8 +681,8 @@ class TransferFunction(LTI):
 
         # Convert the second argument to a transfer function.
         if isinstance(other, (int, float, complex, np.number)):
-            other = _convert_to_transfer_function(other, inputs=self.ninputs,
-                                                  outputs=self.ninputs)
+            # Multiply by a scaled identify matrix (transfer function)
+            other = _convert_to_transfer_function(np.eye(self.noutputs) * other)
         else:
             other = _convert_to_transfer_function(other)
 
@@ -723,9 +723,8 @@ class TransferFunction(LTI):
         """Divide two LTI objects."""
 
         if isinstance(other, (int, float, complex, np.number)):
-            other = _convert_to_transfer_function(
-                other, inputs=self.ninputs,
-                outputs=self.ninputs)
+            # Multiply by a scaled identify matrix (transfer function)
+            other = _convert_to_transfer_function(np.eye(self.ninputs) * other)
         else:
             other = _convert_to_transfer_function(other)
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -723,7 +723,7 @@ class TransferFunction(LTI):
         """Divide two LTI objects."""
 
         if isinstance(other, (int, float, complex, np.number)):
-            # Multiply by a scaled identify matrix (transfer function)
+            # Multiply by a scaled identity matrix (transfer function)
             other = _convert_to_transfer_function(np.eye(self.ninputs) * other)
         else:
             other = _convert_to_transfer_function(other)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -681,7 +681,7 @@ class TransferFunction(LTI):
 
         # Convert the second argument to a transfer function.
         if isinstance(other, (int, float, complex, np.number)):
-            # Multiply by a scaled identify matrix (transfer function)
+            # Multiply by a scaled identity matrix (transfer function)
             other = _convert_to_transfer_function(np.eye(self.noutputs) * other)
         else:
             other = _convert_to_transfer_function(other)

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -637,7 +637,7 @@ class TransferFunction(LTI):
         if isinstance(other, (StateSpace, np.ndarray)):
             other = _convert_to_transfer_function(other)
         elif isinstance(other, (int, float, complex, np.number)):
-            # Multiply by a scaled identify matrix (transfer function)
+            # Multiply by a scaled identity matrix (transfer function)
             other = _convert_to_transfer_function(np.eye(self.ninputs) * other)
         if not isinstance(other, TransferFunction):
             return NotImplemented


### PR DESCRIPTION
This PR addresses #1075 and also fixes a small bug with constant FRD systems with small numbers of frequency points.

Changes:
* Multiplying (*), adding (+), or subtracting (-) a constant from any (MIMO) LTI object now acts element-wise (same as ndarray's).  This fixes a bug where multiplying a MIMO LTI system by a constant was multiplying by a matrix filled with the constant rather than a diagonal matrix (scaled identity).
* Specifying an FRD system with fewer than 4 frequency points was generating an error because the default settings try to set up a smooth (interpolating) response and the default degree of the fit was 3.  The SciPy interpolation function requires k+1 data points for a degree k fit, so an exception was generated. 
* Added unit tests that catch the bug in #1075 but also check across all LTI system representations (frd, ss, tf).
