### PR TITLE
update GitHub Actions to use miniforge v3 (fixes mambaforge deprecation)

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -13,13 +13,12 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: 3.12
         activate-environment: doctest-env
         environment-file: .github/conda-env/doctest-env.yml
         miniforge-version: latest
-        miniforge-variant: Mambaforge
         channels: conda-forge
         channel-priority: strict
         auto-update-conda: false

--- a/.github/workflows/os-blas-test-matrix.yml
+++ b/.github/workflows/os-blas-test-matrix.yml
@@ -120,13 +120,12 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python }}
           activate-environment: build-env
           environment-file: .github/conda-env/build-env.yml
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           channel-priority: strict
           auto-update-conda: false
           auto-activate-base: false
@@ -292,11 +291,10 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install coreutils
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python }}
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: test-env
           environment-file: .github/conda-env/test-env.yml
           channel-priority: strict

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -32,13 +32,12 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: test-env
         environment-file: .github/conda-env/test-env.yml
         miniforge-version: latest
-        miniforge-variant: Mambaforge
         channels: conda-forge
         channel-priority: strict
         auto-update-conda: false


### PR DESCRIPTION
Mambaforge support in Miniconda is being deprecated since mamba is now included directly in miniforge, as described [here](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/).  To "encourage users to switch to Miniforge" a set of "brownouts" has been scheduled at increasing frequency, and one of them happened today, causing GitHub Actions workflows to stop working.

This PR updates the GitHub Actions workflows to use miniconda@v3, which fixes the issue.

Note: there are still some failures in the OS/BLAS test matrix workflow for Intel-based MacOS ([example](https://github.com/murrayrm/python-control/actions/runs/12333951479/job/34423656180)).  I'm not sure these are directly related to miniforge/mamba since they appear to affect only certain configurations in the test matrix.  I'll post a separate issue on that one.