### PR TITLE
Add test for Nyquist evaluation at a pole

### DIFF
--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -1447,6 +1447,12 @@ def nyquist_response(
         else:
             contour = np.exp(splane_contour * sys.dt)
 
+        # Make sure we don't try to evaluate at a pole
+        if isinstance(sys, (StateSpace, TransferFunction)):
+            if any([pole in contour for pole in sys.poles()]):
+                raise RuntimeError(
+                    "attempt to evaluate at a pole; indent required")
+
         # Compute the primary curve
         resp = sys(contour)
 

--- a/control/tests/nyquist_test.py
+++ b/control/tests/nyquist_test.py
@@ -517,6 +517,15 @@ def test_nyquist_frd():
     warnings.resetwarnings()
 
 
+def test_no_indent_pole():
+    s = ct.tf('s')
+    sys = ((1 + 5/s)/(1 + 0.5/s))**2   # Double-Lag-Compensator
+
+    with pytest.raises(RuntimeError, match="evaluate at a pole"):
+        resp = ct.nyquist_response(
+            sys, warn_encirclements=False, indent_direction='none')
+
+
 if __name__ == "__main__":
     #
     # Interactive mode: generate plots for manual viewing


### PR DESCRIPTION
This PR addresses #1103 by adding a check and raising an exception if the Nyquist contour includes a pole.  In this case the Nyquist curve is not well defined and hence an exception is raised.  (As noted in #1103, this case was already raising an exception, but not quite for the right reason.)

Unit test added that covers the situation.
