### PR TITLE
Fix typo in statefbk.py

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -1074,7 +1074,7 @@ def create_statefbk_iosystem(
 
 
 def ctrb(A, B, t=None):
-    """Controllabilty matrix.
+    """Controllability matrix.
 
     Parameters
     ----------


### PR DESCRIPTION
I found a small typo in `statefbk.py`:

Controllabilty matrix -> Controllability matrix