### PR TITLE
Move _tf_close_coeff back to testing realm and make better use of assertion messages

### DIFF
--- a/.github/scripts/set-conda-test-matrix.py
+++ b/.github/scripts/set-conda-test-matrix.py
@@ -1,8 +1,5 @@
-""" set-conda-test-matrix.py
+"""Create test matrix for conda packages in OS/BLAS test matrix workflow."""
 
-Create test matrix for conda packages
-"""
-import json, re
 from pathlib import Path
 
 osmap = {'linux': 'ubuntu',

--- a/.github/scripts/set-pip-test-matrix.py
+++ b/.github/scripts/set-pip-test-matrix.py
@@ -1,7 +1,5 @@
-""" set-pip-test-matrix.py
+"""Create test matrix for pip wheels in OS/BLAS test matrix workflow."""
 
-Create test matrix for pip wheels
-"""
 import json
 from pathlib import Path
 

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -1,24 +1,21 @@
-"""bdalg_test.py - test suite for block diagram algebra
+"""bdalg_test.py - test suite for block diagram algebra.
 
 RMM, 30 Mar 2011 (based on TestBDAlg from v0.4a)
 """
 
-import numpy as np
-from numpy import sort
-import pytest
-
 import control as ctrl
-from control.xferfcn import TransferFunction, _tf_close_coeff
+import numpy as np
+import pytest
+from control.bdalg import _ensure_tf, append, connect, feedback
+from control.lti import poles, zeros
 from control.statesp import StateSpace
-from control.bdalg import feedback, append, connect
-from control.lti import zeros, poles
-from control.bdalg import _ensure_tf
+from control.tests.conftest import assert_tf_close_coeff
+from control.xferfcn import TransferFunction
+from numpy import sort
 
 
 class TestFeedback:
-    """These are tests for the feedback function in bdalg.py.  Currently, some
-    of the tests are not implemented, or are not working properly.  TODO: these
-    need to be fixed."""
+    """Tests for the feedback function in bdalg.py."""
 
     @pytest.fixture
     def tsys(self):
@@ -180,7 +177,7 @@ class TestFeedback:
                                              [[[1., 4., 9., 8., 5.]]])
 
     def testLists(self, tsys):
-        """Make sure that lists of various lengths work for operations"""
+        """Make sure that lists of various lengths work for operations."""
         sys1 = ctrl.tf([1, 1], [1, 2])
         sys2 = ctrl.tf([1, 3], [1, 4])
         sys3 = ctrl.tf([1, 5], [1, 6])
@@ -237,7 +234,7 @@ class TestFeedback:
             sort(zeros(sys1 + sys2 + sys3 + sys4 + sys5)))
 
     def testMimoSeries(self, tsys):
-        """regression: bdalg.series reverses order of arguments"""
+        """regression: bdalg.series reverses order of arguments."""
         g1 = ctrl.ss([], [], [], [[1, 2], [0, 3]])
         g2 = ctrl.ss([], [], [], [[1, 0], [2, 3]])
         ref = g2 * g1
@@ -430,9 +427,9 @@ class TestEnsureTf:
         ],
     )
     def test_ensure(self, arraylike_or_tf, dt, tf):
-        """Test nominal cases"""
+        """Test nominal cases."""
         ensured_tf = _ensure_tf(arraylike_or_tf, dt)
-        assert _tf_close_coeff(tf, ensured_tf)
+        assert_tf_close_coeff(tf, ensured_tf)
 
     @pytest.mark.parametrize(
         "arraylike_or_tf, dt, exception",
@@ -460,7 +457,7 @@ class TestEnsureTf:
         ],
     )
     def test_error_ensure(self, arraylike_or_tf, dt, exception):
-        """Test error cases"""
+        """Test error cases."""
         with pytest.raises(exception):
             _ensure_tf(arraylike_or_tf, dt)
 
@@ -624,7 +621,7 @@ class TestTfCombineSplit:
     def test_combine_tf(self, tf_array, tf):
         """Test combining transfer functions."""
         tf_combined = ctrl.combine_tf(tf_array)
-        assert _tf_close_coeff(tf_combined, tf)
+        assert_tf_close_coeff(tf_combined, tf)
 
     @pytest.mark.parametrize(
         "tf_array, tf",
@@ -712,12 +709,12 @@ class TestTfCombineSplit:
         # Test entry-by-entry
         for i in range(tf_split.shape[0]):
             for j in range(tf_split.shape[1]):
-                assert _tf_close_coeff(
+                assert_tf_close_coeff(
                     tf_split[i, j],
                     tf_array[i, j],
                 )
         # Test combined
-        assert _tf_close_coeff(
+        assert_tf_close_coeff(
             ctrl.combine_tf(tf_split),
             ctrl.combine_tf(tf_array),
         )

--- a/control/tests/conftest.py
+++ b/control/tests/conftest.py
@@ -92,15 +92,13 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
 
 
-def assert_tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):
+def assert_tf_close_coeff(actual, desired, rtol=1e-5, atol=1e-8):
     """Check if two transfer functions have close coefficients.
 
     Parameters
     ----------
-    tf_a : TransferFunction
-        First transfer function.
-    tf_b : TransferFunction
-        Second transfer function.
+    actual, desired : TransferFunction
+        Transfer functions to compare.
     rtol : float
         Relative tolerance for ``np.testing.assert_allclose``.
     atol : float
@@ -111,18 +109,18 @@ def assert_tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):
     AssertionError
     """
     # Check number of outputs and inputs
-    assert tf_a.noutputs == tf_b.noutputs
-    assert tf_a.ninputs == tf_b.ninputs
+    assert actual.noutputs == desired.noutputs
+    assert actual.ninputs == desired.ninputs
     # Check timestep
-    assert  tf_a.dt == tf_b.dt
+    assert  actual.dt == desired.dt
     # Check coefficient arrays
-    for i in range(tf_a.noutputs):
-        for j in range(tf_a.ninputs):
+    for i in range(actual.noutputs):
+        for j in range(actual.ninputs):
             np.testing.assert_allclose(
-                tf_a.num[i][j],
-                tf_b.num[i][j],
+                actual.num[i][j],
+                desired.num[i][j],
                 rtol=rtol, atol=atol)
             np.testing.assert_allclose(
-                tf_a.den[i][j],
-                tf_b.den[i][j],
+                actual.den[i][j],
+                desired.den[i][j],
                 rtol=rtol, atol=atol)

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -7,22 +7,22 @@ BG,  26 Jul 2020 merge statesp_array_test.py differences into statesp_test.py
                  convert to pytest
 """
 
-import numpy as np
-from numpy.testing import assert_array_almost_equal
-import pytest
 import operator
-from numpy.linalg import solve
-from scipy.linalg import block_diag, eigvals
 
 import control as ct
+import numpy as np
+import pytest
 from control.config import defaults
 from control.dtime import sample_system
 from control.lti import evalfr
-from control.statesp import StateSpace, _convert_to_statespace, tf2ss, \
-    _statesp_defaults, _rss_generate, linfnorm, ss, rss, drss
-from control.xferfcn import TransferFunction, ss2tf, _tf_close_coeff
+from control.statesp import (StateSpace, _convert_to_statespace, _rss_generate,
+                             _statesp_defaults, drss, linfnorm, rss, ss, tf2ss)
+from control.xferfcn import TransferFunction, ss2tf
+from numpy.linalg import solve
+from numpy.testing import assert_array_almost_equal
+from scipy.linalg import block_diag, eigvals
 
-from .conftest import editsdefaults, slycotonly
+from .conftest import assert_tf_close_coeff, editsdefaults, slycotonly
 
 
 class TestStateSpace:
@@ -384,7 +384,7 @@ class TestStateSpace:
             (StateSpace.__rsub__, -expected_sub),
         ]:
             result = op(ss_mimo, ss_siso)
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 expected.minreal(),
                 ss2tf(result).minreal(),
             )
@@ -404,7 +404,7 @@ class TestStateSpace:
             (StateSpace.__rsub__, -expected_sub),
         ]:
             result = op(ss_siso, np.eye(2))
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 expected.minreal(),
                 ss2tf(result).minreal(),
             )
@@ -479,7 +479,7 @@ class TestStateSpace:
     )
     def test_mul_mimo_siso(self, left, right, expected):
         result = tf2ss(left).__mul__(right)
-        assert _tf_close_coeff(
+        assert_tf_close_coeff(
             expected.minreal(),
             ss2tf(result).minreal(),
         )
@@ -554,7 +554,7 @@ class TestStateSpace:
     )
     def test_rmul_mimo_siso(self, left, right, expected):
         result = tf2ss(right).__rmul__(left)
-        assert _tf_close_coeff(
+        assert_tf_close_coeff(
             expected.minreal(),
             ss2tf(result).minreal(),
         )
@@ -584,13 +584,13 @@ class TestStateSpace:
             # matrices instead.
             result = (sys * sys**-1).minreal()
             expected = StateSpace([], [], [], np.eye(2), dt=0)
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 ss2tf(expected).minreal(),
                 ss2tf(result).minreal(),
             )
             result = (sys**-1 * sys).minreal()
             expected = StateSpace([], [], [], np.eye(2), dt=0)
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 ss2tf(expected).minreal(),
                 ss2tf(result).minreal(),
             )
@@ -616,14 +616,14 @@ class TestStateSpace:
             # Divide by self
             result = (sys.__truediv__(sys)).minreal()
             expected = StateSpace([], [], [], np.eye(2), dt=0)
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 ss2tf(expected).minreal(),
                 ss2tf(result).minreal(),
             )
             # Divide by TF
             result = sys.__truediv__(TransferFunction.s)
             expected = ss2tf(sys) / TransferFunction.s
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 expected.minreal(),
                 ss2tf(result).minreal(),
             )
@@ -634,14 +634,14 @@ class TestStateSpace:
         for sys in [sys222, sys322]:
             result = (sys.__rtruediv__(sys)).minreal()
             expected = StateSpace([], [], [], np.eye(2), dt=0)
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 ss2tf(expected).minreal(),
                 ss2tf(result).minreal(),
             )
             # Divide TF by SS
             result = sys.__rtruediv__(TransferFunction.s)
             expected = TransferFunction.s / sys
-            assert _tf_close_coeff(
+            assert_tf_close_coeff(
                 expected.minreal(),
                 result.minreal(),
             )
@@ -649,7 +649,7 @@ class TestStateSpace:
         sys = tf2ss(TransferFunction([1, 2], [2, 1]))
         result = sys.__rtruediv__(np.eye(2))
         expected = TransferFunction([2, 1], [1, 2]) * np.eye(2)
-        assert _tf_close_coeff(
+        assert_tf_close_coeff(
             expected.minreal(),
             ss2tf(result).minreal(),
         )

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -10,12 +10,12 @@ import numpy as np
 import pytest
 
 import control as ct
-from control import StateSpace, TransferFunction, defaults, evalfr, isctime, \
-    isdtime, reset_defaults, rss, sample_system, set_defaults, ss, ss2tf, tf, \
-    tf2ss, zpk
+from control import (StateSpace, TransferFunction, defaults, evalfr, isctime,
+                     isdtime, reset_defaults, rss, sample_system, set_defaults,
+                     ss, ss2tf, tf, tf2ss, zpk)
 from control.statesp import _convert_to_statespace
-from control.tests.conftest import slycotonly
-from control.xferfcn import _convert_to_transfer_function, _tf_close_coeff
+from control.tests.conftest import assert_tf_close_coeff, slycotonly
+from control.xferfcn import _convert_to_transfer_function
 
 
 class TestXferFcn:
@@ -424,7 +424,7 @@ class TestXferFcn:
                 [op(tf_arr[1, 0], tf_siso), op(tf_arr[1, 1], tf_siso)],
             ])
             result = op(tf_mimo, tf_siso)
-            assert _tf_close_coeff(expected.minreal(), result.minreal())
+            assert_tf_close_coeff(expected.minreal(), result.minreal())
 
     @pytest.mark.parametrize(
         "left, right, expected",
@@ -496,7 +496,7 @@ class TestXferFcn:
     def test_mul_mimo_siso(self, left, right, expected):
         """Test multiplication of a MIMO and a SISO system."""
         result = left.__mul__(right)
-        assert _tf_close_coeff(expected.minreal(), result.minreal())
+        assert_tf_close_coeff(expected.minreal(), result.minreal())
 
     @pytest.mark.parametrize(
         "left, right, expected",
@@ -568,7 +568,7 @@ class TestXferFcn:
     def test_rmul_mimo_siso(self, left, right, expected):
         """Test right multiplication of a MIMO and a SISO system."""
         result = right.__rmul__(left)
-        assert _tf_close_coeff(expected.minreal(), result.minreal())
+        assert_tf_close_coeff(expected.minreal(), result.minreal())
 
     @pytest.mark.parametrize(
         "left, right, expected",
@@ -605,7 +605,7 @@ class TestXferFcn:
     def test_truediv_mimo_siso(self, left, right, expected):
         """Test true division of a MIMO and a SISO system."""
         result = left.__truediv__(right)
-        assert _tf_close_coeff(expected.minreal(), result.minreal())
+        assert_tf_close_coeff(expected.minreal(), result.minreal())
 
     @pytest.mark.parametrize(
         "left, right, expected",
@@ -631,7 +631,7 @@ class TestXferFcn:
     def test_rtruediv_mimo_siso(self, left, right, expected):
         """Test right true division of a MIMO and a SISO system."""
         result = right.__rtruediv__(left)
-        assert _tf_close_coeff(expected.minreal(), result.minreal())
+        assert_tf_close_coeff(expected.minreal(), result.minreal())
 
     @pytest.mark.parametrize("named", [False, True])
     def test_slice(self, named):
@@ -925,9 +925,9 @@ class TestXferFcn:
             ],
         )
         tf_appended_1 = tf1.append(tf2)
-        assert _tf_close_coeff(tf_exp_1, tf_appended_1)
+        assert_tf_close_coeff(tf_exp_1, tf_appended_1)
         tf_appended_2 = tf1.append(tf2).append(tf3)
-        assert _tf_close_coeff(tf_exp_2, tf_appended_2)
+        assert_tf_close_coeff(tf_exp_2, tf_appended_2)
 
     def test_convert_to_transfer_function(self):
         """Test for correct state space to transfer function conversion."""

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -2007,53 +2007,6 @@ def _float2str(value):
     return f"{value:{_num_format}}"
 
 
-def _tf_close_coeff(tf_a, tf_b, rtol=1e-5, atol=1e-8):
-    """Check if two transfer functions have close coefficients.
-
-    Parameters
-    ----------
-    tf_a : TransferFunction
-        First transfer function.
-    tf_b : TransferFunction
-        Second transfer function.
-    rtol : float
-        Relative tolerance for ``np.allclose``.
-    atol : float
-        Absolute tolerance for ``np.allclose``.
-
-    Returns
-    -------
-    bool
-        True if transfer function cofficients are all close.
-    """
-    # Check number of outputs and inputs
-    if tf_a.noutputs != tf_b.noutputs:
-        return False
-    if tf_a.ninputs != tf_b.ninputs:
-        return False
-    # Check timestep
-    if tf_a.dt != tf_b.dt:
-        return False
-    # Check coefficient arrays
-    for i in range(tf_a.noutputs):
-        for j in range(tf_a.ninputs):
-            if not np.allclose(
-                tf_a.num[i][j],
-                tf_b.num[i][j],
-                rtol=rtol,
-                atol=atol,
-            ):
-                return False
-            if not np.allclose(
-                tf_a.den[i][j],
-                tf_b.den[i][j],
-                rtol=rtol,
-                atol=atol,
-            ):
-                return False
-    return True
-
-
 def _create_poly_array(shape, default=None):
     out = np.empty(shape, dtype=np.ndarray)
     if default is not None:


### PR DESCRIPTION
The OS/BLAS testing matrix started to fail with some macOS tests and the assertion messages make them hard to inspect:

https://github.com/python-control/python-control/actions/runs/13087050463/job/36519541162#step:9:298

```python
 FAILED control/tests/statesp_test.py::TestStateSpace::test_pow - assert False
 +  where False = _tf_close_coeff(TransferFunction(\n[[array([1.]), array([0.])],\n [array([0.]), array([1.])]],\n[[array([1.]), array([1.])],\n [array([1.]), array([1.])]],\noutputs=2, inputs=2), TransferFunction(\n[[array([1.]), array([-2.76395297e-15, -1.35541257e-13,  9.01576541e-13])],\n [array([0.]), array([1.])]],\n[[array([1.]), array([  1.,   3.,  -9., -41.])],\n [array([1.]), array([1.])]],\noutputs=2, inputs=2))
 +    where TransferFunction(\n[[array([1.]), array([0.])],\n [array([0.]), array([1.])]],\n[[array([1.]), array([1.])],\n [array([1.]), array([1.])]],\noutputs=2, inputs=2) = minreal()
 +      where minreal = TransferFunction(\n[[array([1.]), array([0.])],\n [array([0.]), array([1.])]],\n[[array([1.]), array([1.])],\n [array([1.]), array([1.])]],\noutputs=2, inputs=2).minreal
 +        where TransferFunction(\n[[array([1.]), array([0.])],\n [array([0.]), array([1.])]],\n[[array([1.]), array([1.])],\n [array([1.]), array([1.])]],\noutputs=2, inputs=2) = ss2tf(StateSpace(\narray([], shape=(0, 0), dtype=float64),\narray([], shape=(0, 2), dtype=float64),\narray([], shape=(2, 0), dtype=float64),\narray([[1., 0.],\n       [0., 1.]]),\nstates=0, outputs=2, inputs=2))
 +    and   TransferFunction(\n[[array([1.]), array([-2.76395297e-15, -1.35541257e-13,  9.01576541e-13])],\n [array([0.]), array([1.])]],\n[[array([1.]), array([  1.,   3.,  -9., -41.])],\n [array([1.]), array([1.])]],\noutputs=2, inputs=2) = minreal()
 +      where minreal = TransferFunction(\n[[array([  1.,   3.,  -9., -41.]), \n  array([-2.76395297e-15, -1.35541257e-13,  9.01576541e-13])],\n ....,   3.,  -9., -41.]), array([  1.,   3.,  -9., -41.])],\n [array([1.]), array([1., 0., 0., 0.])]],\noutputs=2, inputs=2).minreal
 +        where TransferFunction(\n[[array([  1.,   3.,  -9., -41.]), \n  array([-2.76395297e-15, -1.35541257e-13,  9.01576541e-13])],\n ....,   3.,  -9., -41.]), array([  1.,   3.,  -9., -41.])],\n [array([1.]), array([1., 0., 0., 0.])]],\noutputs=2, inputs=2) = ss2tf(StateSpace(\narray([[  4.86563613,  -0.22114886, -14.38268526],\n       [  3.86388385,  -1.64824725, -16.2652334 ],\n    ... [0.00000000e+00, 2.59786829e-16, 3.85014366e-15]]),\narray([[1., 0.],\n       [0., 1.]]),\nstates=3, outputs=2, inputs=2))
```


Let's try to make this easier by using numpy's and pytest's assertion rewriting.