### PR TITLE
Uniform processing of time response and optimization parameters

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -1,7 +1,7 @@
 # config.py - package defaults
 # RMM, 4 Nov 2012
 #
-# TODO: add ability to read/write configuration files (ala matplotlib)
+# TODO: add ability to read/write configuration files (a la matplotlib)
 
 """Functions to access default parameter values.
 
@@ -390,7 +390,7 @@ def _process_legacy_keyword(kwargs, oldkey, newkey, newval, warn_oldkey=True):
     Use this function to handle a legacy keyword that has been renamed.
     This function pops the old keyword off of the kwargs dictionary and
     issues a warning.  If both the old and new keyword are present, a
-    ControlArgument exception is raised.
+    `ControlArgument` exception is raised.
 
     Parameters
     ----------
@@ -442,7 +442,7 @@ def _process_param(name, defval, kwargs, alias_mapping, sigval=None):
     aliases and legacy aliases::
 
        alias_mapping = {
-            'argument_name_1', (['alias', ...], ['legacy', ...]),
+            'argument_name_1': (['alias', ...], ['legacy', ...]),
             ...}
 
     If `param` is a named keyword in the function signature with default
@@ -452,7 +452,7 @@ def _process_param(name, defval, kwargs, alias_mapping, sigval=None):
         param = _process_param('param', defval, kwargs, function_aliases)
 
     If `param` is a variable keyword argument (in `kwargs`), `defval` can
-    be pssed as either None or the default value to use if `param` is not
+    be passed as either None or the default value to use if `param` is not
     present in `kwargs`.
 
     Parameters
@@ -462,7 +462,7 @@ def _process_param(name, defval, kwargs, alias_mapping, sigval=None):
     defval : object or dict
         Default value for the parameter.
     kwargs : dict
-        Dictionary of varaible keyword arguments.
+        Dictionary of variable keyword arguments.
     alias_mapping : dict
         Dictionary providing aliases and legacy names.
     sigval : object, optional
@@ -478,7 +478,7 @@ def _process_param(name, defval, kwargs, alias_mapping, sigval=None):
     Raises
     ------
     TypeError
-        If multiple keyword aliased are used for the same parameter.
+        If multiple keyword aliases are used for the same parameter.
 
     Warns
     -----
@@ -527,7 +527,7 @@ def _process_kwargs(kwargs, alias_mapping):
     a tuple consisting of valid aliases and legacy aliases::
 
        alias_mapping = {
-            'argument_name_1', (['alias', ...], ['legacy', ...]),
+            'argument_name_1': (['alias', ...], ['legacy', ...]),
             ...}
 
     If an alias is present in the dictionary of keywords, it will be used

--- a/control/config.py
+++ b/control/config.py
@@ -415,9 +415,10 @@ def _process_legacy_keyword(kwargs, oldkey, newkey, newval, warn_oldkey=True):
         Value of the (new) keyword.
 
     """
-    warnings.warn(
-        "replace `_process_legacy_keyword` with `_process_param` "
-        "or `_process_kwargs`", PendingDeprecationWarning)
+    # TODO: turn on this warning when ready to deprecate
+    # warnings.warn(
+    #     "replace `_process_legacy_keyword` with `_process_param` "
+    #     "or `_process_kwargs`", PendingDeprecationWarning)
     if oldkey in kwargs:
         if warn_oldkey:
             warnings.warn(

--- a/control/config.py
+++ b/control/config.py
@@ -553,7 +553,6 @@ def _process_kwargs(kwargs, alias_mapping):
     """
     for name in alias_mapping or []:
         aliases, legacy = alias_mapping[name]
-        newval = None
 
         for kw in legacy:
             if kw in kwargs:

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -22,10 +22,11 @@ import numpy as np
 import scipy as sp
 
 from . import config
+from .config import _process_param, _process_kwargs
 from .iosys import InputOutputSystem, _parse_spec, _process_iosys_keywords, \
     common_timebase, iosys_repr, isctime, isdtime
 from .timeresp import TimeResponseData, TimeResponseList, \
-    _check_convert_array, _process_time_response
+    _check_convert_array, _process_time_response, _timeresp_aliases
 
 __all__ = ['NonlinearIOSystem', 'InterconnectedSystem', 'nlsys',
            'input_output_response', 'find_eqpt', 'linearize',
@@ -1471,9 +1472,9 @@ def nlsys(updfcn, outfcn=None, **kwargs):
 
 
 def input_output_response(
-        sys, T, U=0., X0=0, params=None, ignore_errors=False,
-        transpose=False, return_x=False, squeeze=None,
-        solve_ivp_kwargs=None, t_eval='T', **kwargs):
+        sys, timepts=None, inputs=0., initial_state=0., params=None,
+        ignore_errors=False, transpose=False, return_states=False,
+        squeeze=None, solve_ivp_kwargs=None, evaluation_times='T', **kwargs):
     """Compute the output response of a system to a given input.
 
     Simulate a dynamical system with a given input and return its output
@@ -1483,22 +1484,23 @@ def input_output_response(
     ----------
     sys : `NonlinearIOSystem` or list of `NonlinearIOSystem`
         I/O system(s) for which input/output response is simulated.
-    T : array_like
+    timepts (or T) : array_like
         Time steps at which the input is defined; values must be evenly spaced.
-    U : array_like, list, or number, optional
-        Input array giving input at each time `T` (default = 0).  If a list
-        is specified, each element in the list will be treated as a portion
-        of the input and broadcast (if necessary) to match the time vector.
-    X0 : array_like, list, or number, optional
+    inputs (or U) : array_like, list, or number, optional
+        Input array giving input at each time in `timepts` (default =
+        0). If a list is specified, each element in the list will be
+        treated as a portion of the input and broadcast (if necessary) to
+        match the time vector.
+    initial_state (or X0) : array_like, list, or number, optional
         Initial condition (default = 0).  If a list is given, each element
         in the list will be flattened and stacked into the initial
         condition.  If a smaller number of elements are given that the
         number of states in the system, the initial condition will be padded
         with zeros.
-    t_eval : array-list, optional
+    evaluation_times (or t_eval) : array-list, optional
         List of times at which the time response should be computed.
-        Defaults to `T`.
-    return_x : bool, optional
+        Defaults to `timepts`.
+    return_states (or return_x) : bool, optional
         If True, return the state vector when assigning to a tuple.  See
         `forced_response` for more details.  If True, return the values of
         the state at each time Default is False.
@@ -1523,7 +1525,7 @@ def input_output_response(
         method.  See `TimeResponseData` for more detailed information.
     response.time : array
         Time values of the output.
-    response.output : array
+    response.outputs : array
         Response of the system.  If the system is SISO and `squeeze` is not
         True, the array is 1D (indexed by time).  If the system is not SISO
         or `squeeze` is False, the array is 2D (indexed by output and time).
@@ -1581,6 +1583,18 @@ def input_output_response(
     #
     # Process keyword arguments
     #
+    _process_kwargs(kwargs, _timeresp_aliases)
+    T = _process_param('timepts', timepts, kwargs, _timeresp_aliases)
+    U = _process_param('inputs', inputs, kwargs, _timeresp_aliases, sigval=0.)
+    X0 = _process_param(
+        'initial_state', initial_state, kwargs, _timeresp_aliases, sigval=0.)
+    return_x = _process_param(
+        'return_states', return_states, kwargs, _timeresp_aliases,
+        sigval=False)
+    # TODO: replace default value of evaluation_times with None?
+    t_eval = _process_param(
+        'evaluation_times', evaluation_times, kwargs, _timeresp_aliases,
+        sigval='T')
 
     # Figure out the method to be used
     solve_ivp_kwargs = solve_ivp_kwargs.copy() if solve_ivp_kwargs else {}
@@ -1605,9 +1619,10 @@ def input_output_response(
         sysdata, responses = sys, []
         for sys in sysdata:
             responses.append(input_output_response(
-                sys, T, U=U, X0=X0, params=params, transpose=transpose,
-                return_x=return_x, squeeze=squeeze, t_eval=t_eval,
-                solve_ivp_kwargs=solve_ivp_kwargs, **kwargs))
+                sys, timepts=T, inputs=U, initial_state=X0, params=params,
+                transpose=transpose, return_states=return_x, squeeze=squeeze,
+                evaluation_times=t_eval, solve_ivp_kwargs=solve_ivp_kwargs,
+                **kwargs))
         return TimeResponseList(responses)
 
     # Sanity checking on the input
@@ -1894,8 +1909,9 @@ class OperatingPoint():
 
 
 def find_operating_point(
-        sys, x0, u0=None, y0=None, t=0, params=None, iu=None, iy=None,
-        ix=None, idx=None, dx0=None, root_method=None, root_kwargs=None,
+        sys, initial_state=0., inputs=None, outputs=None, t=0, params=None,
+        input_indices=None, output_indices=None, state_indices=None,
+        deriv_indices=None, derivs=None, root_method=None, root_kwargs=None,
         return_outputs=None, return_result=None, **kwargs):
     """Find an operating point for an input/output system.
 
@@ -1929,13 +1945,13 @@ def find_operating_point(
     ----------
     sys : `NonlinearIOSystem`
         I/O system for which the operating point is sought.
-    x0 : list of initial state values
+    initial_state (or x0) : list of initial state values
         Initial guess for the value of the state near the operating point.
-    u0 : list of input values, optional
+    inputs (or u0) : list of input values, optional
         If `y0` is not specified, sets the value of the input.  If `y0` is
         given, provides an initial guess for the value of the input.  Can
         be omitted if the system does not have any inputs.
-    y0 : list of output values, optional
+    outputs (or y0) : list of output values, optional
         If specified, sets the desired values of the outputs at the
         operating point.
     t : float, optional
@@ -1943,22 +1959,22 @@ def find_operating_point(
     params : dict, optional
         Parameter values for the system.  Passed to the evaluation functions
         for the system as default values, overriding internal defaults.
-    iu : list of input indices, optional
+    input_indices (or iu) : list of input indices, optional
         If specified, only the inputs with the given indices will be fixed at
         the specified values in solving for an operating point.  All other
         inputs will be varied.  Input indices can be listed in any order.
-    iy : list of output indices, optional
+    output_indices (or iy) : list of output indices, optional
         If specified, only the outputs with the given indices will be fixed
         at the specified values in solving for an operating point.  All other
         outputs will be varied.  Output indices can be listed in any order.
-    ix : list of state indices, optional
+    state_indices (or ix) : list of state indices, optional
         If specified, states with the given indices will be fixed at the
         specified values in solving for an operating point.  All other
         states will be varied.  State indices can be listed in any order.
-    dx0 : list of update values, optional
+    derivs (or dx0) : list of update values, optional
         If specified, the value of update map must match the listed value
         instead of the default value for an equilibrium point.
-    idx : list of state indices, optional
+    deriv_indices (or idx) : list of state indices, optional
         If specified, state updates with the given indices will have their
         update maps fixed at the values given in `dx0`.  All other update
         values will be ignored in solving for an operating point.  State
@@ -2014,8 +2030,28 @@ def find_operating_point(
     from scipy.optimize import root
 
     # Process keyword arguments
-    return_outputs = config._process_legacy_keyword(
-        kwargs, 'return_y', 'return_outputs', return_outputs)
+    aliases = {
+        'initial_state': (['x0', 'X0'], []),
+        'inputs': (['u0'], []),
+        'outputs': (['y0'], []),
+        'derivs': (['dx0'], []),
+        'input_indices': (['iu'], []),
+        'output_indices': (['iy'], []),
+        'state_indices': (['ix'], []),
+        'deriv_indices': (['idx'], []),
+        'return_outputs': ([], ['return_y']),
+    }
+    _process_kwargs(kwargs, aliases)
+    x0 = _process_param('initial_state', initial_state, kwargs, aliases)
+    u0 = _process_param('inputs', inputs, kwargs, aliases)
+    y0 = _process_param('outputs', outputs, kwargs, aliases)
+    dx0 = _process_param('derivs', derivs, kwargs, aliases)
+    iu = _process_param('input_indices', input_indices, kwargs, aliases)
+    iy = _process_param('output_indices', output_indices, kwargs, aliases)
+    ix = _process_param('state_indices', state_indices, kwargs, aliases)
+    idx = _process_param('deriv_indices', deriv_indices, kwargs, aliases)
+    return_outputs = _process_param(
+        'return_outputs', return_outputs, kwargs, aliases)
     if kwargs:
         raise TypeError("unrecognized keyword(s): " + str(kwargs))
 
@@ -2025,9 +2061,9 @@ def find_operating_point(
         root_kwargs['method'] = root_method
 
     # Figure out the number of states, inputs, and outputs
-    x0, nstates = _process_vector_argument(x0, "x0", sys.nstates)
-    u0, ninputs = _process_vector_argument(u0, "u0", sys.ninputs)
-    y0, noutputs = _process_vector_argument(y0, "y0", sys.noutputs)
+    x0, nstates = _process_vector_argument(x0, "initial_states", sys.nstates)
+    u0, ninputs = _process_vector_argument(u0, "inputs", sys.ninputs)
+    y0, noutputs = _process_vector_argument(y0, "outputs", sys.noutputs)
 
     # Make sure the input arguments match the sizes of the system
     if len(x0) != nstates or \

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -2042,7 +2042,8 @@ def find_operating_point(
         'return_outputs': ([], ['return_y']),
     }
     _process_kwargs(kwargs, aliases)
-    x0 = _process_param('initial_state', initial_state, kwargs, aliases)
+    x0 = _process_param(
+        'initial_state', initial_state, kwargs, aliases, sigval=0.)
     u0 = _process_param('inputs', inputs, kwargs, aliases)
     y0 = _process_param('outputs', outputs, kwargs, aliases)
     dx0 = _process_param('derivs', derivs, kwargs, aliases)

--- a/control/optimal.py
+++ b/control/optimal.py
@@ -49,6 +49,19 @@ _optimal_defaults = {
     'optimal.solve_ivp_options': {},
 }
 
+# Parameter and keyword aliases
+_optimal_aliases = {
+    # param:                  ([alias, ...],                [legacy, ...])
+    'integral_cost':          (['trajectory_cost', 'cost'], []),
+    'initial_state':          (['x0', 'X0'],                []),
+    'initial_input':          (['u0', 'U0'],                []),
+    'final_state':            (['xf'],                      []),
+    'final_input':            (['uf'],                      []),
+    'initial_time':           (['T0'],                      []),
+    'trajectory_constraints': (['constraints'],             []),
+    'return_states':          (['return_x'],                []),
+}
+
 
 class OptimalControlProblem():
     """Description of a finite horizon, optimal control problem.
@@ -334,7 +347,8 @@ class OptimalControlProblem():
 
             # Integrate the cost
             costs = np.array(costs)
-           # Approximate the integral using trapezoidal rule
+
+            # Approximate the integral using trapezoidal rule
             cost = np.sum(0.5 * (costs[:-1] + costs[1:]) * dt)
 
         else:
@@ -1018,20 +1032,6 @@ class OptimalControlResult(sp.optimize.OptimizeResult):
         self.states = response.states
 
 
-# Parameter and keyword aliases
-_optimal_aliases = {
-    # param:                  ([alias, ...],                [legacy, ...])
-    'integral_cost':          (['trajectory_cost', 'cost'], []),
-    'initial_state':          (['x0', 'X0'],                []),
-    'initial_input':          (['u0', 'U0'],                []),
-    'final_state':            (['xf'],                      []),
-    'final_input':            (['uf'],                      []),
-    'initial_time':           (['T0'],                      []),
-    'trajectory_constraints': (['constraints'],             []),
-    'return_states':          (['return_x'],                []),
-}
-
-
 # Compute the input for a nonlinear, (constrained) optimal control problem
 def solve_optimal_trajectory(
         sys, timepts, initial_state=None, integral_cost=None,
@@ -1183,7 +1183,8 @@ def solve_optimal_trajectory(
             kwargs['minimize_method'] = method
         else:
             if kwargs.get('trajectory_method'):
-                raise ValueError("'trajectory_method' specified more than once")
+                raise ValueError(
+                    "'trajectory_method' specified more than once")
             warnings.warn(
                 "'method' parameter is deprecated; assuming trajectory_method",
                 FutureWarning)
@@ -1819,7 +1820,6 @@ class OptimalEstimationProblem():
         return OptimalEstimationResult(
             self, res, squeeze=squeeze, print_summary=print_summary)
 
-
     #
     # Create an input/output system implementing an moving horizon estimator
     #
@@ -1827,6 +1827,7 @@ class OptimalEstimationProblem():
     # xhat, u, v, y for all previous time points.  When the system update
     # function is called,
     #
+
     def create_mhe_iosystem(
             self, estimate_labels=None, measurement_labels=None,
             control_labels=None, inputs=None, outputs=None, **kwargs):
@@ -2490,6 +2491,7 @@ def output_range_constraint(sys, lb, ub):
     # Return a nonlinear constraint object based on the polynomial
     return (opt.NonlinearConstraint, _evaluate_output_range_constraint, lb, ub)
 
+
 #
 # Create a constraint on the disturbance input
 #
@@ -2534,6 +2536,7 @@ def disturbance_range_constraint(sys, lb, ub):
 # Utility functions
 #
 
+
 #
 # Process trajectory constraints
 #
@@ -2545,6 +2548,7 @@ def disturbance_range_constraint(sys, lb, ub):
 # internal representation (currently a tuple with the constraint type as the
 # first element.
 #
+
 def _process_constraints(clist, name):
     if clist is None:
         clist = []
@@ -2560,7 +2564,7 @@ def _process_constraints(clist, name):
         if isinstance(constraint, tuple):
             # Original style of constraint
             ctype, fun, lb, ub = constraint
-            if not ctype in [opt.LinearConstraint, opt.NonlinearConstraint]:
+            if ctype not in [opt.LinearConstraint, opt.NonlinearConstraint]:
                 raise TypeError(f"unknown {name} constraint type {ctype}")
             constraint_list.append(constraint)
         elif isinstance(constraint, opt.LinearConstraint):

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -977,16 +977,17 @@ def _create_trajectory(
     # Compute the forward trajectory
     if dir == 'forward' or dir == 'both':
         fwdresp = input_output_response(
-            sys, timepts, X0=X0, params=params, ignore_errors=True)
+            sys, timepts, initial_state=X0, params=params, ignore_errors=True)
         if not fwdresp.success and not suppress_warnings:
-            warnings.warn(f"{X0=}, {fwdresp.message}")
+            warnings.warn(f"initial_state={X0}, {fwdresp.message}")
 
     # Compute the reverse trajectory
     if dir == 'reverse' or dir == 'both':
         revresp = input_output_response(
-            revsys, timepts, X0=X0, params=params, ignore_errors=True)
+            revsys, timepts, initial_state=X0, params=params,
+            ignore_errors=True)
         if not revresp.success and not suppress_warnings:
-            warnings.warn(f"{X0=}, {revresp.message}")
+            warnings.warn(f"initial_state={X0}, {revresp.message}")
 
     # Create the trace to plot
     if dir == 'forward':

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1525,7 +1525,7 @@ class StateSpace(NonlinearIOSystem, LTI):
             return (self.C @ x).reshape((-1,)) \
                 + (self.D @ u).reshape((-1,))  # return as row vector
 
-    # convenience alias, import needs to go over the submodule to avoid circular imports
+    # convenience alias, import needs submodule to avoid circular imports
     initial_response = control.timeresp.initial_response
 
 

--- a/control/tests/docstrings_test.py
+++ b/control/tests/docstrings_test.py
@@ -46,7 +46,7 @@ function_skiplist = [
 
 # List of keywords that we can skip testing (special cases)
 keyword_skiplist = {
-    control.input_output_response: ['method'],
+    control.input_output_response: ['method', 't_eval'],    # solve_ivp_kwargs
     control.nyquist_plot: ['color'],                        # separate check
     control.optimal.solve_optimal_trajectory:
       ['method', 'return_x'],                               # deprecated
@@ -637,14 +637,15 @@ def _check_parameter_docs(
         docstring = docstring[start:]
 
     # Look for the parameter name in the docstring
+    argname_ = argname + r"( \(or .*\))*"
     if match := re.search(
-            "\n" + r"((\w+|\.{3}), )*" + argname + r"(, (\w+|\.{3}))*:",
+            "\n" + r"((\w+|\.{3}), )*" + argname_ + r"(, (\w+|\.{3}))*:",
             docstring):
         # Found the string, but not in numpydoc form
         _warn(f"{funcname}: {argname} docstring missing space")
 
     elif not (match := re.search(
-            "\n" + r"((\w+|\.{3}), )*" + argname + r"(, (\w+|\.{3}))* :",
+            "\n" + r"((\w+|\.{3}), )*" + argname_ + r"(, (\w+|\.{3}))* :",
             docstring)):
         if fail_if_missing:
             _fail(f"{funcname} '{argname}' not documented")

--- a/control/tests/iosys_test.py
+++ b/control/tests/iosys_test.py
@@ -2161,7 +2161,8 @@ def test_operating_point():
     assert isinstance(op_point[1], np.ndarray)
     assert isinstance(op_point[2], np.ndarray)
 
-    with pytest.warns(FutureWarning, match="return_outputs"):
+    with pytest.warns(
+            (FutureWarning, PendingDeprecationWarning), match="return_outputs"):
         op_point = ct.find_operating_point(sys, 0, 0, return_y=True)
         assert len(op_point) == 3
         assert isinstance(op_point[0], np.ndarray)

--- a/control/tests/kwargs_test.py
+++ b/control/tests/kwargs_test.py
@@ -30,6 +30,7 @@ import control.tests.statesp_test as statesp_test
 import control.tests.statefbk_test as statefbk_test
 import control.tests.stochsys_test as stochsys_test
 import control.tests.timeplot_test as timeplot_test
+import control.tests.timeresp_test as timeresp_test
 import control.tests.trdata_test as trdata_test
 
 
@@ -260,9 +261,12 @@ kwarg_unittest = {
     'find_eqpt': iosys_test.test_find_operating_point,
     'find_operating_point': iosys_test.test_find_operating_point,
     'flatsys.flatsys': test_unrecognized_kwargs,
+    'forced_response': timeresp_test.test_timeresp_aliases,
     'frd': frd_test.TestFRD.test_unrecognized_keyword,
     'gangof4': test_matplotlib_kwargs,
     'gangof4_plot': test_matplotlib_kwargs,
+    'impulse_response': timeresp_test.test_timeresp_aliases,
+    'initial_response': timeresp_test.test_timeresp_aliases,
     'input_output_response': test_unrecognized_kwargs,
     'interconnect': interconnect_test.test_interconnect_exceptions,
     'time_response_plot': timeplot_test.test_errors,
@@ -294,6 +298,8 @@ kwarg_unittest = {
     'set_defaults': test_unrecognized_kwargs,
     'singular_values_plot': test_matplotlib_kwargs,
     'ss': test_unrecognized_kwargs,
+    'step_info': timeresp_test.test_timeresp_aliases,
+    'step_response': timeresp_test.test_timeresp_aliases,
     'LTI.to_ss': test_unrecognized_kwargs,          # tested via 'ss'
     'ss2io': test_unrecognized_kwargs,
     'ss2tf': test_unrecognized_kwargs,
@@ -342,6 +348,7 @@ kwarg_unittest = {
     'NonlinearIOSystem.__init__':
         interconnect_test.test_interconnect_exceptions,
     'StateSpace.__init__': test_unrecognized_kwargs,
+    'StateSpace.initial_response': timeresp_test.test_timeresp_aliases,
     'StateSpace.sample': test_unrecognized_kwargs,
     'TimeResponseData.__call__': trdata_test.test_response_copy,
     'TimeResponseData.plot': timeplot_test.test_errors,
@@ -356,6 +363,8 @@ kwarg_unittest = {
         optimal_test.test_ocp_argument_errors,
     'optimal.OptimalEstimationProblem.__init__':
         optimal_test.test_oep_argument_errors,
+    'optimal.OptimalEstimationProblem.compute_estimate':
+        stochsys_test.test_oep,
     'optimal.OptimalEstimationProblem.create_mhe_iosystem':
         optimal_test.test_oep_argument_errors,
     'phaseplot.streamlines': test_matplotlib_kwargs,

--- a/control/tests/phaseplot_test.py
+++ b/control/tests/phaseplot_test.py
@@ -167,7 +167,8 @@ def test_phaseplane_errors():
         lambda t, x, u, params: np.array(
             [x[1], -0.25 * (x[0] - 0.01 * x[0]**3) - 0.1 * x[1]]),
         states=2, inputs=0)
-    with pytest.warns(UserWarning, match=r"X0=array\(.*\), solve_ivp failed"):
+    with pytest.warns(
+            UserWarning, match=r"initial_state=\[.*\], solve_ivp failed"):
         ct.phase_plane_plot(
             sys, [-12, 12, -10, 10], 15, gridspec=[2, 9],
             plot_separatrices=False)

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -1638,9 +1638,9 @@ def test_convenience_aliases():
     # Make sure that unrecognized keywords for response functions are caught
     for method in [LTI.impulse_response, LTI.initial_response,
                    LTI.step_response]:
-        with pytest.raises(TypeError, match="unexpected keyword"):
+        with pytest.raises(TypeError, match="unrecognized keyword"):
             method(sys, unknown=True)
-    with pytest.raises(TypeError, match="unexpected keyword"):
+    with pytest.raises(TypeError, match="unrecognized keyword"):
         LTI.forced_response(sys, [0, 1], [1, 1], unknown=True)
 
 

--- a/control/tests/stochsys_test.py
+++ b/control/tests/stochsys_test.py
@@ -404,6 +404,10 @@ def test_oep(dt):
     np.testing.assert_allclose(
         est3.states[:, -1], res3.states[:, -1], atol=meas_mag, rtol=meas_mag)
 
+    # Make sure unknown keywords generate an error
+    with pytest.raises(TypeError, match="unrecognized keyword"):
+        est3 = oep1.compute_estimate(Y3, U, unknown=True)
+
 
 @pytest.mark.slow
 def test_mhe():

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -744,6 +744,7 @@ _timeresp_aliases = {
     # param:            ([alias, ...], [legacy, ...])
     'timepts':          (['T'],        []),
     'inputs':           (['U'],        ['u']),
+    'outputs':          (['Y'],        ['y']),
     'initial_state':    (['X0'],       ['x0']),
     'final_output':     (['yfinal'],   []),
     'return_states':    (['return_x'], []),
@@ -1022,8 +1023,9 @@ def forced_response(
     Examples
     --------
     >>> G = ct.rss(4)
-    >>> T = np.linspace(0, 10)
-    >>> T, yout = ct.forced_response(G, T=T)
+    >>> timepts = np.linspace(0, 10)
+    >>> inputs = np.sin(timepts)
+    >>> tout, yout = ct.forced_response(G, timepts, inputs)
 
     See :ref:`time-series-convention` and
     :ref:`package-configuration-parameters`.
@@ -1630,6 +1632,8 @@ def step_info(
     # Process keyword arguments
     _process_kwargs(kwargs, _timeresp_aliases)
     T = _process_param('timepts', timepts, kwargs, _timeresp_aliases)
+    T_num = _process_param(
+        'timepts_num', timepts_num, kwargs, _timeresp_aliases)
     yfinal = _process_param(
         'final_output', final_output, kwargs, _timeresp_aliases)
 
@@ -1637,7 +1641,8 @@ def step_info(
         raise TypeError("unrecognized keyword(s): ", str(kwargs))
 
     if isinstance(sysdata, (StateSpace, TransferFunction, NonlinearIOSystem)):
-        T, Yout = step_response(sysdata, T, squeeze=False, params=params)
+        T, Yout = step_response(
+            sysdata, T, timepts_num=T_num, squeeze=False, params=params)
         if yfinal:
             InfValues = np.atleast_2d(yfinal)
         else:

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -1632,8 +1632,6 @@ def step_info(
     T = _process_param('timepts', timepts, kwargs, _timeresp_aliases)
     yfinal = _process_param(
         'final_output', final_output, kwargs, _timeresp_aliases)
-    T_num = _process_param(
-        'timepts_num', timepts_num, kwargs, _timeresp_aliases)
 
     if kwargs:
         raise TypeError("unrecognized keyword(s): ", str(kwargs))

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -54,6 +54,21 @@ __all__ = ['forced_response', 'step_response', 'step_info',
            'initial_response', 'impulse_response', 'TimeResponseData',
            'TimeResponseList']
 
+# Dictionary of aliases for time response commands
+_timeresp_aliases = {
+    # param:            ([alias, ...], [legacy, ...])
+    'timepts':          (['T'],        []),
+    'inputs':           (['U'],        ['u']),
+    'outputs':          (['Y'],        ['y']),
+    'initial_state':    (['X0'],       ['x0']),
+    'final_output':     (['yfinal'],   []),
+    'return_states':    (['return_x'], []),
+    'evaluation_times': (['t_eval'],   []),
+    'timepts_num':      (['T_num'],    []),
+    'input_indices':    (['input'],    []),
+    'output_indices':   (['output'],   []),
+}
+
 
 class TimeResponseData:
     """Input/output system time response data.
@@ -344,7 +359,7 @@ class TimeResponseData:
             # Make sure the shape is OK
             if multi_trace and \
                (self.x.ndim != 3 or self.x.shape[1] != self.ntraces) or \
-               not multi_trace and self.x.ndim != 2 :
+               not multi_trace and self.x.ndim != 2:
                 raise ValueError("State vector is the wrong shape")
 
             # Make sure time dimension of state is the right length
@@ -701,6 +716,7 @@ class TimeResponseData:
         """
         return time_response_plot(self, *args, **kwargs)
 
+
 #
 # Time response data list class
 #
@@ -739,20 +755,6 @@ class TimeResponseList(list):
                         lines[row, col] += cplt.lines[row, col]
         return ControlPlot(lines, cplt.axes, cplt.figure)
 
-# Dictionary of aliases for time response commands
-_timeresp_aliases = {
-    # param:            ([alias, ...], [legacy, ...])
-    'timepts':          (['T'],        []),
-    'inputs':           (['U'],        ['u']),
-    'outputs':          (['Y'],        ['y']),
-    'initial_state':    (['X0'],       ['x0']),
-    'final_output':     (['yfinal'],   []),
-    'return_states':    (['return_x'], []),
-    'evaluation_times': (['t_eval'],   []),
-    'timepts_num':      (['T_num'],    []),
-    'input_indices':    (['input'],    []),
-    'output_indices':   (['output'],   []),
-}
 
 # Process signal labels
 def _process_labels(labels, signal, length):
@@ -991,8 +993,8 @@ def forced_response(
         True, the array is 1D (indexed by time).  If the system is not SISO or
         `squeeze` is False, the array is 2D (indexed by output and time).
     resp.states : array
-        Time evolution of the state vector, represented as a 2D array indexed by
-        state and time.
+        Time evolution of the state vector, represented as a 2D array
+        indexed by state and time.
     resp.inputs : array
         Input(s) to the system, indexed by input and time.
 
@@ -1428,7 +1430,8 @@ def step_response(
     output = _process_param(
         'output_indices', output_indices, kwargs, _timeresp_aliases)
     return_x = _process_param(
-        'return_states', return_states, kwargs, _timeresp_aliases, sigval=False)
+        'return_states', return_states, kwargs, _timeresp_aliases,
+        sigval=False)
     T_num = _process_param(
         'timepts_num', timepts_num, kwargs, _timeresp_aliases)
 
@@ -1839,7 +1842,8 @@ def initial_response(
     output = _process_param(
         'output_indices', output_indices, kwargs, _timeresp_aliases)
     return_x = _process_param(
-        'return_states', return_states, kwargs, _timeresp_aliases, sigval=False)
+        'return_states', return_states, kwargs, _timeresp_aliases,
+        sigval=False)
     T_num = _process_param(
         'timepts_num', timepts_num, kwargs, _timeresp_aliases)
 
@@ -1972,7 +1976,8 @@ def impulse_response(
     output = _process_param(
         'output_indices', output_indices, kwargs, _timeresp_aliases)
     return_x = _process_param(
-        'return_states', return_states, kwargs, _timeresp_aliases, sigval=False)
+        'return_states', return_states, kwargs, _timeresp_aliases,
+        sigval=False)
     T_num = _process_param(
         'timepts_num', timepts_num, kwargs, _timeresp_aliases)
 

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -305,7 +305,7 @@ Parameter aliases
 -----------------
 
 As described above, parameter names are generally longer strings that
-describe the purpose fo the paramater.  Similar to `matplotlib` (e.g.,
+describe the purpose of the parameter.  Similar to `matplotlib` (e.g.,
 the use of `lw` as an alias for `linewidth`), some commonly used
 parameter names can be specified using an "alias" that allows the use
 of a shorter key.
@@ -321,11 +321,11 @@ variable by replacing aliases with the full key::
   _process_kwargs(kwargs, aliases)
 
 The values for named parameters can then be assigned to a local
-variable using a call to :func:`~config.process_param` of the form::
+variable using a call to :func:`~config._process_param` of the form::
 
-  var = _process_kwargs('param', param, kwargs, aliases)
+  var = _process_param('param', param, kwargs, aliases)
 
-where 'param` is the named parameter used in the function signature
+where `param` is the named parameter used in the function signature
 and var is the local variable in the function (may also be `param`,
 but doesn't have to be).
 
@@ -356,7 +356,7 @@ The alias mapping is a dictionary that returns a tuple consisting of
 valid aliases and legacy aliases::
 
   alias_mapping = {
-      'argument_name_1', (['alias', ...], ['legacy', ...]),
+      'argument_name_1': (['alias', ...], ['legacy', ...]),
        ...}
 
 If an alias is present in the dictionary of keywords, it will be used

--- a/doc/iosys.rst
+++ b/doc/iosys.rst
@@ -269,7 +269,8 @@ Finally, we simulate the closed loop system:
 
   # Simulate the system
   Ld = 30
-  resp = ct.input_output_response(closed, timepts, U=Ld, X0=[15, 20])
+  resp = ct.input_output_response(
+      closed, timepts, inputs=Ld, initial_state=[15, 20])
   cplt = resp.plot(
       plot_inputs=False, overlay_signals=True, legend_loc='upper left')
   cplt.axes[0, 0].axhline(Ld, linestyle='--', color='black')

--- a/doc/optimal.rst
+++ b/doc/optimal.rst
@@ -294,7 +294,7 @@ Plotting the results:
   # Simulate the system dynamics (open loop)
   resp = ct.input_output_response(
       vehicle, timepts, result.inputs, x0,
-      t_eval=np.linspace(0, Tf, 100))
+      evaluation_times=np.linspace(0, Tf, 100))
   t, y, u = resp.time, resp.outputs, resp.inputs
 
   plt.subplot(3, 1, 1)

--- a/doc/stochastic.rst
+++ b/doc/stochastic.rst
@@ -375,7 +375,8 @@ Given noisy measurements :math:`y` and control inputs :math:`u`, an
 estimate of the states over the time points can be computed using the
 :func:`~optimal.OptimalEstimationProblem.compute_estimate` method::
 
-  estim = oep.compute_optimal(Y, U[, X0=x0, initial_guess=(xhat, v)])
+  estim = oep.compute_optimal(
+      Y, U[, initial_state=x0, initial_guess=(xhat, v)])
   xhat, v, w = estim.states, estim.inputs, estim.outputs
 
 For discrete-time systems, the


### PR DESCRIPTION
This PR regularizes the use of various keywords for time responses and optimization routines, while maintaining backward compatibility with existing code.  The motivation for the PR is that over time we have introduced different terms to refer to parameters that have the same purpose.  This can be confusing for people trying to use the package.

For example:
* The named parameters `x0` and `X0` are used in different places for the initial state in simulation and optimization functions.   
* The parameter `return_x` is used when a function should return the state as part of a tuple, though sometime `return_states` is used instead.  
* Responses use the `states` property (not `x`) and setting the the state names is done via `states`. 
* Similar issues arise for inputs (`u0`, `U`,  `inputs`) and outputs (`y0`, `outputs`).
* Time points for simulation and optimization are sometimes referred to as `timepts` but other times as `T`.
* In the optimization and flatness modules, cost functions are referred to as `cost`, `trajectory_cost` or `integral cost`, depending on the function, and constraints are referred to as `trajectory_constraints` in some places as `constraints` in others.
* Other parameters have names that don't seem to fit existing python-control naming patterns: `t_eval`, `yfinal`, etc.

To address these issues, this PR introduces a common set of terms across various time response and optimal control functions, with the following more consistent usage patterns and functionality:

* Parameters specifying the inputs, outputs, and states are referred to as `inputs`, `outputs`, and `states` consistently throughout the functions.
* Variables associated with inputs, outputs, states and time use those words plus an appropriate modifier: `initial_state`, `final_output`, `input_indices` etc.
* Aliases are used both to maintain backward compatibility and to allow shorthand descriptions: e.g., `U`, `Y`, `X0`.  Short form aliases are documented in docstrings by listing the parameter as `long_form (or sf) : type`.
* Existing legacy keywords are allowed and generate a `PendingDeprecationWarning`.
* Specifying a parameter value in two different ways (eg, via long form and an alias) generates a `TypeError`.

The implementation is done in a manner that can later be utilized for other functions where we want to have aliases and legacy keys, as documented in the Developer Notes section of the Reference Manual:

> [P]arameter names are generally longer strings that describe the purpose fo the paramater. Similar to `matplotlib` (e.g., the use of `lw` as an alias for `linewidth`), some commonly used parameter names can be specified using an “alias” that allows the use of a shorter key.
>
>Named parameter and keyword variable aliases are processed using the `config._process_kwargs()`  and `config._process_param()` functions. These functions allow the specification of a list of aliases and a list of legacy keys for a given named parameter or keyword. To make use of these functions, the `_process_kwargs()` is first called to update the kwargs variable by replacing aliases with the full key:
> ```
> _process_kwargs(kwargs, aliases)
> ```
>The values for named parameters can then be assigned to a local variable using a call to process_param() of the form:
> ```
> var = _process_kwargs('param', param, kwargs, aliases)
> ```
> where `param` is the named parameter used in the function signature and `var` is the local variable in the function (may also be param, but doesn’t have to be).
>
> ...
> 
> The alias mapping is a dictionary that returns a tuple consisting of valid aliases and legacy aliases:
> ```
> alias_mapping = {
>     'argument_name_1', (['alias', ...], ['legacy', ...]),
>      ...}
> ```
> If an alias is present in the dictionary of keywords, it will be used to set the value of the argument. If a legacy keyword is used, a warning is issued.

Two primary tables have been created in this PR.  The first is a 
dictionary of aliases and legacy names for time response commands (from `timeresp.py`):
```
_timeresp_aliases = {
    # param:            ([alias, ...], [legacy, ...])
    'timepts':          (['T'],        []),
    'inputs':           (['U'],        ['u']),
    'outputs':          (['Y'],        ['y']),
    'initial_state':    (['X0'],       ['x0']),
    'final_output':     (['yfinal'],   []),
    'return_states':    (['return_x'], []),
    'evaluation_times': (['t_eval'],   []),
    'timepts_num':      (['T_num'],    []),
    'input_indices':    (['input'],    []),
    'output_indices':   (['output'],   []),
}
```
The second is a dictionary of aliases for optimal control functions (from `optimal.py`):
```
_optimal_aliases = {
    # param:                  ([alias, ...],                [legacy, ...])
    'integral_cost':          (['trajectory_cost', 'cost'], []),
    'initial_state':          (['x0', 'X0'],                []),
    'initial_input':          (['u0', 'U0'],                []),
    'final_state':            (['xf'],                      []),
    'final_input':            (['uf'],                      []),
    'initial_time':           (['T0'],                      []),
    'trajectory_constraints': (['constraints'],             []),
    'return_states':          (['return_x'],                []),
}
```
