### PR TITLE
Silence warning from Conda in Github Actions

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -19,7 +19,7 @@ jobs:
         activate-environment: doctest-env
         environment-file: .github/conda-env/doctest-env.yml
         miniforge-version: latest
-        channels: conda-forge
+        channels: conda-forge,defaults
         channel-priority: strict
         auto-update-conda: false
         auto-activate-base: false

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -38,7 +38,7 @@ jobs:
         activate-environment: test-env
         environment-file: .github/conda-env/test-env.yml
         miniforge-version: latest
-        channels: conda-forge
+        channels: conda-forge,defaults
         channel-priority: strict
         auto-update-conda: false
         auto-activate-base: false


### PR DESCRIPTION
The warning is

  /home/runner/miniconda3/lib/python3.12/site-packages/conda/base/context.py:201:
  FutureWarning: Adding 'defaults' to channel list implicitly is
  deprecated and will be removed in 25.3.

This change adds defaults to the channel list.