### PR TITLE
Fix Latex not being rendered in HTML output in VSCode

### DIFF
--- a/control/iosys.py
+++ b/control/iosys.py
@@ -314,6 +314,9 @@ class InputOutputSystem():
     def _repr_html_(self):
         # Defaults to using __repr__; override in subclasses
         return None
+    
+    def _repr_markdown_(self):
+        return self._repr_html_()
 
     @property
     def repr_format(self):

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -1440,6 +1440,7 @@ def test_html_repr(gmats, ref, dt, dtref, repr_type, num_format, editsdefaults):
     dt_html = dtref.format(dt=dt, fmt=defaults['statesp.latex_num_format'])
     ref_html = ref[refkey].format(dt=dt_html)
     assert g._repr_html_() == ref_html
+    assert g._repr_html_() == g._repr_markdown_()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
...by adding a blanket `_repr_markdown_` for `InputOutputSystem` which is the same as `_repr_html_` but the renderer for `_repr_markdown_` will also render contained Latex.

Closes #1132 