### PR TITLE
Lint fixes on benchmarks and examples/*.py

### DIFF
--- a/benchmarks/flatsys_bench.py
+++ b/benchmarks/flatsys_bench.py
@@ -7,7 +7,6 @@
 
 import numpy as np
 import math
-import control as ct
 import control.flatsys as flat
 import control.optimal as opt
 

--- a/benchmarks/optestim_bench.py
+++ b/benchmarks/optestim_bench.py
@@ -6,7 +6,6 @@
 # used for optimization-based estimation.
 
 import numpy as np
-import math
 import control as ct
 import control.optimal as opt
 

--- a/benchmarks/optimal_bench.py
+++ b/benchmarks/optimal_bench.py
@@ -6,7 +6,6 @@
 # performance of the functions used for optimization-base control.
 
 import numpy as np
-import math
 import control as ct
 import control.flatsys as fs
 import control.optimal as opt
@@ -20,7 +19,6 @@ integrator_table = {
     'default': (None, {}),
     'RK23': ('RK23', {}),
     'RK23_sloppy': ('RK23', {'atol': 1e-4, 'rtol': 1e-2}),
-    'RK45': ('RK45', {}),
     'RK45': ('RK45', {}),
     'RK45_sloppy': ('RK45', {'atol': 1e-4, 'rtol': 1e-2}),
     'LSODA': ('LSODA', {}),
@@ -129,9 +127,6 @@ def time_optimal_lq_methods(integrator_name, minimizer_name, method):
     Tf = 10
     timepts = np.linspace(0, Tf, 20)
 
-    # Create the basis function to use
-    basis = get_basis('poly', 12, Tf)
-
     res = opt.solve_ocp(
         sys, timepts, x0, traj_cost, constraints, terminal_cost=term_cost,
         solve_ivp_method=integrator[0], solve_ivp_kwargs=integrator[1],
@@ -223,8 +218,6 @@ def time_discrete_aircraft_mpc(minimizer_name):
     # compute the steady state values for a particular value of the input
     ud = np.array([0.8, -0.3])
     xd = np.linalg.inv(np.eye(5) - A) @ B @ ud
-    yd = C @ xd
-
     # provide constraints on the system signals
     constraints = [opt.input_range_constraint(sys, [-5, -6], [5, 6])]
 
@@ -234,7 +227,6 @@ def time_discrete_aircraft_mpc(minimizer_name):
     cost = opt.quadratic_cost(model, Q, R, x0=xd, u0=ud)
 
     # Set the time horizon and time points
-    Tf = 3
     timepts = np.arange(0, 6) * 0.2
 
     # Get the minimizer parameters to use

--- a/examples/bdalg-matlab.py
+++ b/examples/bdalg-matlab.py
@@ -1,7 +1,7 @@
-# bdalg-matlab.py - demonstrate some MATLAB commands for block diagram altebra
+# bdalg-matlab.py - demonstrate some MATLAB commands for block diagram algebra
 # RMM, 29 May 09
 
-from control.matlab import *    # MATLAB-like functions
+from control.matlab import ss, ss2tf, tf, tf2ss    # MATLAB-like functions
 
 # System matrices
 A1 = [[0, 1.], [-4, -1]]

--- a/examples/check-controllability-and-observability.py
+++ b/examples/check-controllability-and-observability.py
@@ -4,8 +4,8 @@ Example to check the controllability and the observability of a state space syst
 RMM, 6 Sep 2010
 """
 
-import numpy as np  # Load the scipy functions
-from control.matlab import *  # Load the controls systems library
+import numpy as np  # Load the numpy functions
+from control.matlab import ss, ctrb, obsv # Load the controls systems library
 
 # Parameters defining the system
 

--- a/examples/cruise-control.py
+++ b/examples/cruise-control.py
@@ -247,7 +247,6 @@ def pi_update(t, x, u, params={}):
     # Assign variables for inputs and states (for readability)
     v = u[0]                    # current velocity
     vref = u[1]                 # reference velocity
-    z = x[0]                    # integrated error
 
     # Compute the nominal controller output (needed for anti-windup)
     u_a = pi_output(t, x, u, params)
@@ -394,7 +393,7 @@ def sf_output(t, z, u, params={}):
     ud = params.get('ud', 0)
 
     # Get the system state and reference input
-    x, y, r = u[0], u[1], u[2]
+    x, r = u[0], u[2]
 
     return ud - K * (x - xd) - ki * z + kf * (r - yd)
 
@@ -440,13 +439,13 @@ theta_hill = [
     4./180. * pi for t in T]
 t, y = ct.input_output_response(
     cruise_sf, T, [vref, gear, theta_hill], [X0[0], 0],
-    params={'K': K, 'kf': kf, 'ki': 0.0, 'kf': kf, 'xd': xd, 'ud': ud, 'yd': yd})
+    params={'K': K, 'kf': kf, 'ki': 0.0, 'xd': xd, 'ud': ud, 'yd': yd})
 subplots = cruise_plot(cruise_sf, t, y, label='Proportional', linetype='b--')
 
 # Response of the system with state feedback + integral action
 t, y = ct.input_output_response(
     cruise_sf, T, [vref, gear, theta_hill], [X0[0], 0],
-    params={'K': K, 'kf': kf, 'ki': 0.1, 'kf': kf, 'xd': xd, 'ud': ud, 'yd': yd})
+    params={'K': K, 'kf': kf, 'ki': 0.1, 'xd': xd, 'ud': ud, 'yd': yd})
 cruise_plot(cruise_sf, t, y, label='PI control', t_hill=8, linetype='b-',
             subplots=subplots, legend=True)
 

--- a/examples/kincar.py
+++ b/examples/kincar.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import control as ct
 import control.flatsys as fs
 
 #

--- a/examples/mrac_siso_mit.py
+++ b/examples/mrac_siso_mit.py
@@ -46,7 +46,6 @@ def adaptive_controller_state(t, xc, uc, params):
     # Parameters
     gam = params["gam"]
     Am = params["Am"]
-    Bm = params["Bm"]
     signB = params["signB"]
 
     # Controller inputs

--- a/examples/phase_plane_plots.py
+++ b/examples/phase_plane_plots.py
@@ -5,9 +5,8 @@
 # using the phaseplot module.  Most of these figures line up with examples
 # in FBS2e, with different display options shown as different subplots.
 
-import time
 import warnings
-from math import pi, sqrt
+from math import pi
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pvtol-nested-ss.py
+++ b/examples/pvtol-nested-ss.py
@@ -10,7 +10,6 @@
 
 import os
 import matplotlib.pyplot as plt  # MATLAB plotting functions
-from control.matlab import *    # MATLAB-like functions
 import numpy as np
 import math
 import control as ct
@@ -23,12 +22,12 @@ g = 9.8         # gravitational constant
 c = 0.05        # damping factor (estimated)
 
 # Transfer functions for dynamics
-Pi = tf([r], [J, 0, 0])  # inner loop (roll)
-Po = tf([1], [m, c, 0])  # outer loop (position)
+Pi = ct.tf([r], [J, 0, 0])  # inner loop (roll)
+Po = ct.tf([1], [m, c, 0])  # outer loop (position)
 
 # Use state space versions
-Pi = tf2ss(Pi)
-Po = tf2ss(Po)
+Pi = ct.tf2ss(Pi)
+Po = ct.tf2ss(Po)
 
 #
 # Inner loop control design
@@ -40,10 +39,10 @@ Po = tf2ss(Po)
 
 # Design a simple lead controller for the system
 k, a, b = 200, 2, 50
-Ci = k*tf([1, a], [1, b])  # lead compensator
+Ci = k*ct.tf([1, a], [1, b])  # lead compensator
 
 # Convert to statespace
-Ci = tf2ss(Ci)
+Ci = ct.tf2ss(Ci)
 
 # Compute the loop transfer function for the inner loop
 Li = Pi*Ci
@@ -51,49 +50,49 @@ Li = Pi*Ci
 
 # Bode plot for the open loop process
 plt.figure(1)
-bode(Pi)
+ct.bode(Pi)
 
 # Bode plot for the loop transfer function, with margins
 plt.figure(2)
-bode(Li)
+ct.bode(Li)
 
 # Compute out the gain and phase margins
 #! Not implemented
 # (gm, pm, wcg, wcp) = margin(Li);
 
 # Compute the sensitivity and complementary sensitivity functions
-Si = feedback(1, Li)
+Si = ct.feedback(1, Li)
 Ti = Li*Si
 
 # Check to make sure that the specification is met
 plt.figure(3)
-gangof4(Pi, Ci)
+ct.gangof4(Pi, Ci)
 
 # Compute out the actual transfer function from u1 to v1 (see L8.2 notes)
 # Hi = Ci*(1-m*g*Pi)/(1+Ci*Pi);
-Hi = parallel(feedback(Ci, Pi), -m*g*feedback(Ci*Pi, 1))
+Hi = ct.parallel(ct.feedback(Ci, Pi), -m*g*ct.feedback(Ci*Pi, 1))
 
 plt.figure(4)
 plt.clf()
-bode(Hi)
+ct.bode(Hi)
 
 # Now design the lateral control system
 a, b, K = 0.02, 5, 2
-Co = -K*tf([1, 0.3], [1, 10])  # another lead compensator
+Co = -K*ct.tf([1, 0.3], [1, 10])  # another lead compensator
 
 # Convert to statespace
-Co = tf2ss(Co)
+Co = ct.tf2ss(Co)
 
 # Compute the loop transfer function for the outer loop
 Lo = -m*g*Po*Co
 
 plt.figure(5)
-bode(Lo, display_margins=True)  # margin(Lo)
+ct.bode(Lo, display_margins=True)  # margin(Lo)
 
 # Finally compute the real outer-loop loop gain + responses
 L = Co*Hi*Po
-S = feedback(1, L)
-T = feedback(L, 1)
+S = ct.feedback(1, L)
+T = ct.feedback(L, 1)
 
 # Compute stability margins
 #! Not yet implemented
@@ -101,7 +100,7 @@ T = feedback(L, 1)
 
 plt.figure(6)
 plt.clf()
-out = ct.bode(L, logspace(-4, 3), initial_phase=-math.pi/2)
+out = ct.bode(L, np.logspace(-4, 3), initial_phase=-math.pi/2)
 axs = ct.get_plot_axes(out)
 
 # Add crossover line to magnitude plot
@@ -111,7 +110,7 @@ axs[0, 0].semilogx([1e-4, 1e3], 20*np.log10([1, 1]), 'k-')
 # Nyquist plot for complete design
 #
 plt.figure(7)
-nyquist(L)
+ct.nyquist(L)
 
 # set up the color
 color = 'b'
@@ -126,10 +125,10 @@ color = 'b'
 #  'EdgeColor', color, 'FaceColor', color);
 
 plt.figure(9)
-Yvec, Tvec = step(T, linspace(1, 20))
+Yvec, Tvec = ct.step_response(T, np.linspace(1, 20))
 plt.plot(Tvec.T, Yvec.T)
 
-Yvec, Tvec = step(Co*S, linspace(1, 20))
+Yvec, Tvec = ct.step_response(Co*S, np.linspace(1, 20))
 plt.plot(Tvec.T, Yvec.T)
 
 #TODO: PZmap for statespace systems has not yet been implemented.
@@ -142,7 +141,7 @@ plt.plot(Tvec.T, Yvec.T)
 # Gang of Four
 plt.figure(11)
 plt.clf()
-gangof4(Hi*Po, Co, linspace(-2, 3))
+ct.gangof4(Hi*Po, Co, np.linspace(-2, 3))
 
 if 'PYCONTROL_TEST_EXAMPLES' not in os.environ:
     plt.show()

--- a/examples/pvtol.py
+++ b/examples/pvtol.py
@@ -64,8 +64,6 @@ def _pvtol_flat_forward(states, inputs, params={}):
     F1, F2 = inputs
 
     # Use equations of motion for higher derivates
-    x1ddot = (F1 * cos(theta) - F2 * sin(theta)) / m
-    x2ddot = (F1 * sin(theta) + F2 * cos(theta) - m * g) / m
     thddot = (r * F1) / J
 
     # Flat output is a point above the vertical axis
@@ -110,7 +108,6 @@ def _pvtol_flat_reverse(zflag, params={}):
     J = params.get('J', 0.0475)         # inertia around pitch axis
     r = params.get('r', 0.25)           # distance to center of force
     g = params.get('g', 9.8)            # gravitational constant
-    c = params.get('c', 0.05)           # damping factor (estimated)
 
     # Given the flat variables, solve for the state
     theta = np.arctan2(-zflag[0][2],  zflag[1][2] + g)
@@ -185,10 +182,6 @@ pvtol_windy = ct.NonlinearIOSystem(
 def _noisy_update(t, x, u, params):
     # Get the inputs
     F1, F2, Dx, Dy = u[:4]
-    if u.shape[0] > 4:
-        Nx, Ny, Nth = u[4:]
-    else:
-        Nx, Ny, Nth = 0, 0, 0
 
     # Get the system response from the original dynamics
     xdot, ydot, thetadot, xddot, yddot, thddot = \
@@ -196,7 +189,6 @@ def _noisy_update(t, x, u, params):
 
     # Get the parameter values we need
     m = params.get('m', 4.)             # mass of aircraft
-    J = params.get('J', 0.0475)         # inertia around pitch axis
 
     # Now add the disturbances
     xddot += Dx / m
@@ -219,7 +211,6 @@ pvtol_noisy = ct.NonlinearIOSystem(
 def pvtol_noisy_A(x, u, params={}):
     # Get the parameter values we need
     m = params.get('m', 4.)             # mass of aircraft
-    J = params.get('J', 0.0475)         # inertia around pitch axis
     c = params.get('c', 0.05)           # damping factor (estimated)
 
     # Get the angle and compute sine and cosine

--- a/examples/secord-matlab.py
+++ b/examples/secord-matlab.py
@@ -3,7 +3,8 @@
 
 import os
 import matplotlib.pyplot as plt   # MATLAB plotting functions
-from control.matlab import *  # MATLAB-like functions
+import numpy as np
+from control.matlab import ss, step, bode, nyquist, rlocus # MATLAB-like functions
 
 # Parameters defining the system
 m = 250.0           # system mass
@@ -24,7 +25,7 @@ plt.show(block=False)
 
 # Bode plot for the system
 plt.figure(2)
-mag, phase, om = bode(sys, logspace(-2, 2), plot=True)
+mag, phase, om = bode(sys, np.logspace(-2, 2), plot=True)
 plt.show(block=False)
 
 # Nyquist plot for the system
@@ -32,7 +33,7 @@ plt.figure(3)
 nyquist(sys)
 plt.show(block=False)
 
-# Root lcous plot for the system
+# Root locus plot for the system
 rlocus(sys)
 
 if 'PYCONTROL_TEST_EXAMPLES' not in os.environ:

--- a/examples/sisotool_example.py
+++ b/examples/sisotool_example.py
@@ -10,24 +10,24 @@ with proper branching
 
 #%%
 import matplotlib.pyplot as plt
-from control.matlab import *
+import control as ct
 
 # first example, aircraft attitude equation
-s = tf([1,0],[1])
+s = ct.tf([1,0],[1])
 Kq = -24
 T2 = 1.4
 damping = 2/(13**.5)
 omega = 13**.5
 H = (Kq*(1+T2*s))/(s*(s**2+2*damping*omega*s+omega**2))
 plt.close('all')
-sisotool(-H)
+ct.sisotool(-H)
 
 #%%
 
 # a simple RL, with multiple poles in the origin
 plt.close('all')
 H = (s+0.3)/(s**4 + 4*s**3 + 6.25*s**2)
-sisotool(H)
+ct.sisotool(H)
 
 #%%
 
@@ -43,4 +43,4 @@ a3 = 1.0
 plt.close('all')
 H = (b0 + b1*s + b2*s**2) / (a0 + a1*s + a2*s**2 + a3*s**3)
 
-sisotool(H)
+ct.sisotool(H)

--- a/examples/slycot-import-test.py
+++ b/examples/slycot-import-test.py
@@ -5,7 +5,7 @@ RMM, 28 May 09
 """
 
 import numpy as np
-from control.matlab import *
+import control as ct
 from control.exception import slycot_check
 
 # Parameters defining the system
@@ -17,12 +17,12 @@ b = 60.0   # damping constant
 A = np.array([[1, -1, 1.], [1, -k/m, -b/m], [1, 1, 1]])
 B = np.array([[0], [1/m], [1]])
 C = np.array([[1., 0, 1.]])
-sys = ss(A, B, C, 0)
+sys = ct.ss(A, B, C, 0)
 
 # Python control may be used without slycot, for example for a pole placement.
 # Eigenvalue placement
 w = [-3, -2, -1]
-K = place(A, B, w)
+K = ct.place(A, B, w)
 print("[python-control (from scipy)] K = ", K)
 print("[python-control (from scipy)] eigs = ", np.linalg.eig(A - B*K)[0])
 

--- a/examples/type2_type3.py
+++ b/examples/type2_type3.py
@@ -4,9 +4,10 @@
 
 import os
 import matplotlib.pyplot as plt  # Grab MATLAB plotting functions
-from control.matlab import *     # MATLAB-like functions
-from numpy import pi
-integrator = tf([0, 1], [1, 0])  # 1/s
+import control as ct
+import numpy as np
+
+integrator = ct.tf([0, 1], [1, 0])  # 1/s
 
 # Parameters defining the system
 J = 1.0
@@ -29,20 +30,20 @@ C_type3 = (1. + Ki*integrator)*(1. + Kii*integrator)*Kp
 
 # System Transfer Functions
 # tricky because the disturbance (base motion) is coupled in by friction
-closed_loop_type2 = feedback(C_type2*feedback(P, friction), gyro)
+closed_loop_type2 = ct.feedback(C_type2*ct.feedback(P, friction), gyro)
 disturbance_rejection_type2 = P*friction/(1. + P*friction+P*C_type2)
-closed_loop_type3 = feedback(C_type3*feedback(P, friction), gyro)
+closed_loop_type3 = ct.feedback(C_type3*ct.feedback(P, friction), gyro)
 disturbance_rejection_type3 = P*friction/(1. + P*friction + P*C_type3)
 
 # Bode plot for the system
 plt.figure(1)
-bode(closed_loop_type2, logspace(0, 2)*2*pi, dB=True, Hz=True)  # blue
-bode(closed_loop_type3, logspace(0, 2)*2*pi, dB=True, Hz=True)  # green
+ct.bode(closed_loop_type2, np.logspace(0, 2)*2*np.pi, dB=True, Hz=True)  # blue
+ct.bode(closed_loop_type3, np.logspace(0, 2)*2*np.pi, dB=True, Hz=True)  # green
 plt.show(block=False)
 
 plt.figure(2)
-bode(disturbance_rejection_type2, logspace(0, 2)*2*pi, Hz=True)  # blue
-bode(disturbance_rejection_type3, logspace(0, 2)*2*pi, Hz=True)  # green
+ct.bode(disturbance_rejection_type2, np.logspace(0, 2)*2*np.pi, Hz=True)  # blue
+ct.bode(disturbance_rejection_type3, np.logspace(0, 2)*2*np.pi, Hz=True)  # green
 
 if 'PYCONTROL_TEST_EXAMPLES' not in os.environ:
     plt.show()

--- a/examples/vehicle.py
+++ b/examples/vehicle.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import control as ct
 import control.flatsys as fs
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ filterwarnings = [
 [tool.ruff]
 
 # TODO: expand to cover all code
-include = ['control/**.py']
+include = ['control/**.py', 'benchmarks/*.py']
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ filterwarnings = [
 [tool.ruff]
 
 # TODO: expand to cover all code
-include = ['control/**.py', 'benchmarks/*.py']
+include = ['control/**.py', 'benchmarks/*.py', 'examples/*.py']
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
I don't think these are too controversial.

# CI failures

I see two failures on CI , but I can't see that these changes caused them:

first, in `doctest-linux`: https://github.com/roryyorke/python-control/actions/runs/13612156165/job/38050709282

```
Traceback
=========

      File "/home/runner/miniconda3/envs/doctest-env/lib/python3.12/site-packages/sphinx/events.py", line 415, in emit
        raise ExtensionError(
    sphinx.errors.ExtensionError: Handler <function html_collect_pages at 0x7f36a35016c0> for event 'html-collect-pages' threw an exception (exception: module 'sphinx.util' has no attribute 'console')
```

which seems to be https://github.com/sphinx-doc/sphinx/issues/13352.

Then in `install-examples`: https://github.com/roryyorke/python-control/actions/runs/13612156159/job/38050709274

```
ModuleNotFoundError: No module named 'autoreload'
```

I'll install jupyterlab in my dev environment and see if I can reproduce this.  I can't see that changing *.py files in examples could cause this.

# tfvis.py and  ~~Pwm~~ Pmw

When I ran `tfvis.py` under Python 3.12, I got

```
AttributeError: module 'collections' has no attribute 'Callable'
```

in ~~Pwm~~ Pmw code.

`Callable` was moved to `collections.abc` in Python 3.10 (October 2021).  The hack below lets the script run, but unless ~~pwm~~ Pmw is updated we should consider retiring this example.

```diff
modified   examples/tfvis.py
@@ -48,6 +48,9 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from control.matlab import logspace
 from numpy import array, conj, polymul, real, size
 
+import collections.abc
+collections.Callable = collections.abc.Callable
+
 
 def make_poly(facts):
     """ Create polynomial from factors """
```

# Warnings in examples

Some examples raise control deprecation warnings, e.g., `genswitch.py` uses `phase_plot` instead of `phase_plane_plot`.  I started looking into this, but it got a bit involved.

# Lint on notebooks

`ruff` can also run on Jupyter notebooks.  Some fixes  are obvious:

```
examples/bode-and-nyquist-plots.ipynb:cell 2:2:17: F401 [*] `scipy` imported but unused
  |
1 | import numpy as np
2 | import scipy as sp
  |                 ^^ F401
3 | import matplotlib.pyplot as plt
4 | import control as ct
  |
  = help: Remove unused import: `scipy`
```

but I'm less sure about changing these `*` imports; they are convenient, and make things more familiar for Matlab users:

```
examples/pvtol-lqr-nested.ipynb:cell 3:2:1: F403 `from matplotlib.pyplot import *` used; unable to detect undefined names
  |
1 | from numpy import *             # Grab all of the NumPy functions
2 | from matplotlib.pyplot import * # Grab MATLAB plotting functions
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F403
3 | from control.matlab import *    # MATLAB-like functions
4 | %matplotlib inline
  |
```