### PR TITLE
Fix CI doctest, install-examples

### DIFF
--- a/.github/conda-env/doctest-env.yml
+++ b/.github/conda-env/doctest-env.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - matplotlib
   - scipy
-  - sphinx
+  - sphinx<8.2
   - sphinx_rtd_theme
   - ipykernel
   - nbsphinx

--- a/.github/workflows/install_examples.yml
+++ b/.github/workflows/install_examples.yml
@@ -20,7 +20,8 @@ jobs:
            --quiet --yes \
            python=3.12 pip \
            numpy matplotlib scipy \
-           slycot pmw jupyter
+           slycot pmw jupyter \
+           ipython!=9.0
 
     - name: Install from source
       run: |


### PR DESCRIPTION
Fixes gh-1136.

I tried '!=8.2' for sphinx-doc, which didn't work, so I used '<8.2'. I think '!=8.2.*' might, but didn't try it.  See https://packaging.python.org/en/latest/specifications/version-specifiers/#id5 (not sure this applies to Conda/Mamba - it should).