### PR TITLE
Fix color cycling not working in singular_values_plot

### DIFF
--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -2556,12 +2556,12 @@ def singular_values_plot(
             nyq_freq = None
 
         # Determine the color to use for this response
-        color = _get_color(
+        current_color = _get_color(
             color, fmt=fmt, offset=color_offset + idx_sys,
             color_cycle=color_cycle)
 
         # To avoid conflict with *fmt, only pass color kw if non-None
-        color_arg = {} if color is None else {'color': color}
+        color_arg = {} if current_color is None else {'color': current_color}
 
         # Decide on the system name
         sysname = response.sysname if response.sysname is not None \

--- a/control/tests/freqplot_test.py
+++ b/control/tests/freqplot_test.py
@@ -680,6 +680,39 @@ def test_display_margins(nsys, display_margins, gridkw, match):
         assert cplt.axes[0, 0].get_title() == ''
 
 
+def test_singular_values_plot_colors():
+    # Define some systems for testing
+    sys1 = ct.rss(4, 2, 2, strictly_proper=True)
+    sys2 = ct.rss(4, 2, 2, strictly_proper=True)
+
+    # Get the default color cycle
+    color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']
+
+    # Plot the systems individually and make sure line colors are OK
+    cplt = ct.singular_values_plot(sys1)
+    assert cplt.lines.size == 1
+    assert len(cplt.lines[0]) == 2
+    assert cplt.lines[0][0].get_color() == color_cycle[0]
+    assert cplt.lines[0][1].get_color() == color_cycle[0]
+
+    cplt = ct.singular_values_plot(sys2)
+    assert cplt.lines.size == 1
+    assert len(cplt.lines[0]) == 2
+    assert cplt.lines[0][0].get_color() == color_cycle[1]
+    assert cplt.lines[0][1].get_color() == color_cycle[1]
+    plt.close('all')
+
+    # Plot the systems as a list and make sure colors are OK
+    cplt = ct.singular_values_plot([sys1, sys2])
+    assert cplt.lines.size == 2
+    assert len(cplt.lines[0]) == 2
+    assert len(cplt.lines[1]) == 2
+    assert cplt.lines[0][0].get_color() == color_cycle[0]
+    assert cplt.lines[0][1].get_color() == color_cycle[0]
+    assert cplt.lines[1][0].get_color() == color_cycle[1]
+    assert cplt.lines[1][1].get_color() == color_cycle[1]
+
+
 if __name__ == "__main__":
     #
     # Interactive mode: generate plots for manual viewing


### PR DESCRIPTION
This seems to have been caused by a name collision between the function scope `color` variable and the loop-"local" `color` variable. The first time `_get_color` is called it will replace the function level `color` so in the next iteration a colorspec is explicitly passed to `_get_color` so it will no longer automatically cycle through colors.

Closes #1134 