### PR TITLE
Fix CI errors in NumPy 2.3.1

### DIFF
--- a/control/optimal.py
+++ b/control/optimal.py
@@ -746,9 +746,9 @@ class OptimalControlProblem():
                 states = self.last_states
             else:
                 states = self._simulate_states(self.x, inputs)
-                self.last_x = self.x
-                self.last_states = states
-                self.last_coeffs = coeffs
+                self.last_x = self.x.copy()             # save initial state
+                self.last_states = states               # always a new object
+                self.last_coeffs = coeffs.copy()        # save coefficients
 
         return states, inputs
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1350,7 +1350,7 @@ def _c2d_matched(sysC, Ts, **kwargs):
         zpoles[idx] = z
         pregainden[idx] = 1 - z
     zgain = np.multiply.reduce(pregainnum) / np.multiply.reduce(pregainden)
-    gain = sysC.dcgain() / zgain
+    gain = sysC.dcgain() / zgain.real
     sysDnum, sysDden = zpk2tf(zzeros, zpoles, gain)
     return TransferFunction(sysDnum, sysDden, Ts, **kwargs)
 


### PR DESCRIPTION
This PR fixes a couple of CI errors that arose in NumPy 2.3.1 and that hadn't shown up prior to this:
* In `optimal.py`, there was a bug in saving old values of an array, where it `copy` should have been used.
* In `lti.py`, there is a difference in the way `numpy.multiply` returns values (perhaps due to rounding?) that was causing transfer functions with complex coefficients when using `c2d`.
Fixes for both are very small and I'll merge this quickly so that I can release 0.10.2 this weekend.
