### PR TITLE
BugFix: `place_acker` output should be 2D array

### DIFF
--- a/control/statefbk.py
+++ b/control/statefbk.py
@@ -252,7 +252,7 @@ def place_acker(A, B, poles):
     K = np.linalg.solve(ct, pmat)
 
     K = K[-1, :]                # Extract the last row
-    return K
+    return _ssmatrix(K)
 
 
 def lqr(*args, **kwargs):


### PR DESCRIPTION
`place_acker` function's output is a 1D array, while it should be a 2D array as described in its doc string.