### PR TITLE
Robust hinfsyn: add suboptimal synth

### DIFF
--- a/control/robust.py
+++ b/control/robust.py
@@ -85,7 +85,7 @@ def h2syn(P, nmeas, ncon):
     return K
 
 
-def hinfsyn(P, nmeas, ncon, gamTry):
+def hinfsyn(P, nmeas, ncon, gamTry=None):
     # TODO: document significance of rcond
     """H-infinity control synthesis for plant P.
 


### PR DESCRIPTION
to obtain numerically more robust controllers, usually a slightly suboptimal controller is synthesized after running the first optimization.