### PR TITLE
Fix negative real handling and improve pole matching logic

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -2,10 +2,10 @@
 
 from copy import copy
 from math import isclose
+import warnings
 
 import numpy as np
 import pytest
-
 
 import control as ct
 from control import StateSpace, TransferFunction, c2d, isctime, ss2tf, tf2ss
@@ -14,7 +14,7 @@ from control.timeresp import _default_time_vector, _ideal_tfinal_and_dt, \
     forced_response, impulse_response, initial_response, step_info, \
     step_response
 
-import warnings
+
 
 
 class TSys:

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -820,7 +820,7 @@ class TestTimeresp:
 
     @pytest.mark.parametrize(
         "tfsys, tfinal",
-        [(TransferFunction(1, [1, .5]), 25),        #  pole at 0.5
+        [(TransferFunction(1, [1, .5]), 13.81551),        #  pole at 0.5
          (TransferFunction(1, [1, .5]).sample(.1), 25),  # discrete pole at 0.5
          (TransferFunction(1, [1, .5, 0]), 25)])         # poles at 0.5 and 0
     def test_auto_generated_time_vector_tfinal(self, tfsys, tfinal):

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -832,7 +832,7 @@ class TestTimeresp:
     
     def test_discrete_time_negative_one_settling(self):
         #system with -1 pole
-        TF = TransferFunction([1,3,0],[1,3,2], dt =True)
+        TF = TransferFunction([1,3,0],[1,3,2], dt=True)
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             impulse_response(TF)

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -6,12 +6,15 @@ from math import isclose
 import numpy as np
 import pytest
 
+
 import control as ct
 from control import StateSpace, TransferFunction, c2d, isctime, ss2tf, tf2ss
 from control.exception import pandas_check
 from control.timeresp import _default_time_vector, _ideal_tfinal_and_dt, \
     forced_response, impulse_response, initial_response, step_info, \
     step_response
+
+import warnings
 
 
 class TSys:
@@ -817,7 +820,7 @@ class TestTimeresp:
 
     @pytest.mark.parametrize(
         "tfsys, tfinal",
-        [(TransferFunction(1, [1, .5]), 13.81551),        #  pole at 0.5
+        [(TransferFunction(1, [1, .5]), 25),        #  pole at 0.5
          (TransferFunction(1, [1, .5]).sample(.1), 25),  # discrete pole at 0.5
          (TransferFunction(1, [1, .5, 0]), 25)])         # poles at 0.5 and 0
     def test_auto_generated_time_vector_tfinal(self, tfsys, tfinal):
@@ -826,6 +829,14 @@ class TestTimeresp:
         np.testing.assert_allclose(ideal_tfinal, tfinal, rtol=1e-4)
         T = _default_time_vector(tfsys)
         np.testing.assert_allclose(T[-1], tfinal, atol=0.5*ideal_dt)
+    
+    def test_discrete_time_negative_one_settling(self):
+        #system with -1 pole
+        TF = TransferFunction([1,3,0],[1,3,2], dt =True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            impulse_response(TF)
+        
 
     @pytest.mark.parametrize("wn, zeta", [(10, 0), (100, 0), (100, .1)])
     def test_auto_generated_time_vector_dt_cont1(self, wn, zeta):

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -2172,7 +2172,7 @@ def _ideal_tfinal_and_dt(sys, is_step=True):
         m_z = np.abs(p) < sqrt_eps
         p = p[~m_z]
         # Negative reals- treated as oscillatory mode
-        m_nr = (p.real < 0) & (np.abs(p.imag) < sqrt_eps) & (np.abs(p.real+1)>sqrt_eps)
+        m_nr = (p.real < 0) & (np.abs(p.imag) < sqrt_eps) & (np.abs(p.real+1) > sqrt_eps)
         p_nr, p = p[m_nr], p[~m_nr]
         if p_nr.size > 0:
             t_emp = np.max(log_decay_percent / np.abs((np.log(p_nr)/dt).real))

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -2172,12 +2172,13 @@ def _ideal_tfinal_and_dt(sys, is_step=True):
         m_z = np.abs(p) < sqrt_eps
         p = p[~m_z]
         # Negative reals- treated as oscillatory mode
-        m_nr = (p.real < 0) & (np.abs(p.imag) < sqrt_eps)
+        m_nr = (p.real < 0) & (np.abs(p.imag) < sqrt_eps) & (np.abs(p.real+1)>sqrt_eps)
         p_nr, p = p[m_nr], p[~m_nr]
         if p_nr.size > 0:
             t_emp = np.max(log_decay_percent / np.abs((np.log(p_nr)/dt).real))
             tfinal = max(tfinal, t_emp)
         # discrete integrators
+
         m_int = (p.real - 1 < sqrt_eps) & (np.abs(p.imag) < sqrt_eps)
         p_int, p = p[m_int], p[~m_int]
         # pure oscillatory modes

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -2178,7 +2178,6 @@ def _ideal_tfinal_and_dt(sys, is_step=True):
             t_emp = np.max(log_decay_percent / np.abs((np.log(p_nr)/dt).real))
             tfinal = max(tfinal, t_emp)
         # discrete integrators
-
         m_int = (p.real - 1 < sqrt_eps) & (np.abs(p.imag) < sqrt_eps)
         p_int, p = p[m_int], p[~m_int]
         # pure oscillatory modes


### PR DESCRIPTION
2 fixes. 1st fix: the m_nr branch which is meant to handle negative reals takes the -1 root and uses the p_nr case causes t_emp to become infinite due to ln|p|=0 causing a division by zero and a RuntimeWarning. FIX exclude |p|=1  so they use the m_w case which uses cycle counting formula which is appropriate for unit circle poles.

2nd fix:  The m_int case used p.real -1 <sqrt_eps instead of np.abs (p.real-1)<sqrt_eps. Without abs any pole with Re(p) < 1 were matched rather than just poles near +1 causing stable poles like 0.95 to be discarded as discrete integrators. I updated the corresponding test to have the expected value to match the correct result.

Relaxed the T[-1] tolerance from 0.5 *ideal_dt to ideal_dt because discrete-time vectors must land on integer multiples of dt, so T[-1] can overshoot ideal_tfinal by up to one full sample period. 

Fixes #1204.