### PR TITLE
Fix zero-input interconnect D matrix shape

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -2295,7 +2295,7 @@ def _ssmatrix(data, axis=1, square=None, rows=None, cols=None, name=None):
 
     Returns
     -------
-    arr : 2D array, with shape (0, 0) if a is empty
+    arr : 2D array, with shape (0, 0) for empty vectors or matrices
 
     """
     # Process the name of the object, if available
@@ -2310,9 +2310,9 @@ def _ssmatrix(data, axis=1, square=None, rows=None, cols=None, name=None):
     if (ndim > 2):
         raise ValueError(f"state-space matrix{name} must be 2-dimensional")
 
-    elif (ndim == 2 and shape == (1, 0)) or \
-         (ndim == 1 and shape == (0, )):
-        # Passed an empty matrix or empty vector; change shape to (0, 0)
+    elif (ndim == 2 and shape == (0, 0)) or \
+            (ndim == 1 and shape == (0, )):
+        # Passed a 0-by-0 matrix or empty vector; change shape to (0, 0)
         shape = (0, 0)
 
     elif ndim == 1:

--- a/control/tests/interconnect_test.py
+++ b/control/tests/interconnect_test.py
@@ -432,6 +432,36 @@ def test_linear_interconnect():
         outlist=['plant.y'], outputs='y')
     assert clsys.syslist[0].name == 'ctrl'
 
+
+def test_interconnect_zero_input_one_output():
+    plant = ct.ss(
+        [[1, 1], [0, -2]],
+        [[0], [1]],
+        [[1, 0]],
+        [[0]],
+        inputs=['u'],
+        outputs=['y'],
+        name='plant',
+        dt=True,
+    )
+    controller = ct.ss(
+        [[2.25, 1], [-5, -0.5]],
+        [[-1.25], [4.5]],
+        [[-0.5, 1.5]],
+        [[0]],
+        inputs=['y'],
+        outputs=['u'],
+        name='controller',
+        dt=True,
+    )
+
+    sys = ct.interconnect([plant, controller], inplist=None, outlist=['y'])
+
+    assert sys.ninputs == 0
+    assert sys.noutputs == 1
+    assert sys.D.shape == (1, 0)
+
+
 @pytest.mark.parametrize(
     "connections, inplist, outlist, inputs, outputs", [
         pytest.param(


### PR DESCRIPTION
Fixes #1176.

## Summary
- preserves explicitly shaped empty state-space matrices such as `(1, 0)` in `_ssmatrix`
- allows `interconnect()` to linearize systems with zero inputs and one or more outputs without collapsing `D` to `(0, 0)`
- adds a regression test for the zero-input/one-output feedback interconnection case

## Validation
- `python -m pytest control\tests\interconnect_test.py -q -k "zero_input_one_output or linear_interconnect or interconnect_series"`
- `python -m pytest control\tests\statesp_test.py -q`
- `python -m ruff check control\statesp.py control\tests\interconnect_test.py`
- `python -m compileall -q control\statesp.py control\tests\interconnect_test.py`
- `git diff --check`

AI-assisted contribution: implemented with OpenAI Codex and reviewed locally before submission.