### PR TITLE
Fix time_response_plot for response lists

### DIFF
--- a/control/tests/timeplot_test.py
+++ b/control/tests/timeplot_test.py
@@ -369,6 +369,24 @@ def test_list_responses(resp_fcn):
             assert cplt.lines[row, col][0].get_color() == 'tab:blue'
             assert cplt.lines[row, col][1].get_color() == 'tab:orange'
 
+    # Make sure the public plotting function also accepts response lists
+    plt.figure()
+    cplt = ct.time_response_plot(resp_combined)
+    assert cplt.lines.shape == shape
+    for row in range(2):        # just look at the outputs
+        for col in range(shape[1]):
+            assert cplt.lines[row, col][0].get_color() == 'tab:blue'
+            assert cplt.lines[row, col][1].get_color() == 'tab:orange'
+
+    # Plain Python lists of time responses should follow the same path
+    plt.figure()
+    cplt = ct.time_response_plot([resp1, resp2])
+    assert cplt.lines.shape == shape
+    for row in range(2):        # just look at the outputs
+        for col in range(shape[1]):
+            assert cplt.lines[row, col][0].get_color() == 'tab:blue'
+            assert cplt.lines[row, col][1].get_color() == 'tab:orange'
+
 
 @pytest.mark.slycot
 @pytest.mark.usefixtures('mplcleanup')

--- a/control/timeplot.py
+++ b/control/timeplot.py
@@ -52,7 +52,7 @@ def time_response_plot(
 
     Parameters
     ----------
-    data : `TimeResponseData`
+    data : `TimeResponseData` or list of `TimeResponseData`
         Data to be plotted.
     plot_inputs : bool or str, optional
         Sets how and where to plot the inputs:
@@ -175,6 +175,24 @@ def time_response_plot(
 
     """
     from .ctrlplot import _process_ax_keyword, _process_line_labels
+
+    # If given a list of time responses, plot them sequentially on the same
+    # axes using the same path as TimeResponseList.plot().
+    if isinstance(data, list):
+        if len(data) == 0:
+            raise ValueError("response list must contain at least one response")
+
+        from .timeresp import TimeResponseList
+
+        list_kwargs = dict(
+            ax=ax, plot_inputs=plot_inputs, plot_outputs=plot_outputs,
+            transpose=transpose, overlay_traces=overlay_traces,
+            overlay_signals=overlay_signals, add_initial_zero=add_initial_zero,
+            trace_labels=trace_labels, title=title, relabel=relabel)
+        if label is not None:
+            list_kwargs['label'] = label
+
+        return TimeResponseList(data).plot(*fmt, **list_kwargs, **kwargs)
 
     #
     # Process keywords and set defaults


### PR DESCRIPTION
Fixes #1171.

`step_response([sys1, sys2])` and related simulation calls return `TimeResponseList`. Calling `.plot()` on that object already worked, but calling the public function directly raised before it could plot:

```text
AttributeError: 'TimeResponseList' object has no attribute 'plot_inputs'
```

This routes `TimeResponseList` and plain Python lists of time responses through the existing `TimeResponseList.plot()` path. The change is scoped to the crash/list-support part of the issue and leaves the color-improvement discussion separate.

Local validation:

- Red repro before fix: `ct.time_response_plot(ct.step_response([sys1, sys2]))` raised `AttributeError: 'TimeResponseList' object has no attribute 'plot_inputs'`.
- After fix smoke: same call returns a `(1, 1)` plot with two lines for SISO responses.
- `MPLBACKEND=Agg PYTHONPATH=. python -m pytest control\tests\timeplot_test.py::test_list_responses -q` -> 5 passed
- `MPLBACKEND=Agg PYTHONPATH=. python -m pytest control\tests\timeplot_test.py -q` -> 73 passed, 3 skipped
- `python -m ruff check control\timeplot.py control\tests\timeplot_test.py`
- `python -m compileall -q control\timeplot.py control\tests\timeplot_test.py`
- `git diff --check`

Authored with assistance from OpenAI Codex.

---
*AI Disclosure: Codex (ChatGPT 5.5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*