### PR TITLE
fix(timeresp): avoid warning for discrete -1 poles

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -1,5 +1,6 @@
 """timeresp_test.py - test time response functions"""
 
+import warnings
 from copy import copy
 from math import isclose
 
@@ -582,6 +583,17 @@ class TestTimeresp:
 
         np.testing.assert_array_equal(response.inputs,Uexpected)
 
+    def test_discrete_time_impulse_negative_poles_no_warning(self):
+        # A negative pole on the unit circle should be treated as oscillatory.
+        sysd = ct.TransferFunction([1, 3, 0], [1, 3, 2], dt=True)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            response = ct.impulse_response(sysd, 5)
+
+        np.testing.assert_allclose(response.time, np.arange(6))
+        assert np.all(np.isfinite(response.outputs))
+
     @pytest.mark.parametrize("tsystem", ["siso_ss1"], indirect=True)
     def test_impulse_response_warnD(self, tsystem):
         """Test warning about direct feedthrough"""
@@ -826,6 +838,15 @@ class TestTimeresp:
         np.testing.assert_allclose(ideal_tfinal, tfinal, rtol=1e-4)
         T = _default_time_vector(tfsys)
         np.testing.assert_allclose(T[-1], tfinal, atol=0.5*ideal_dt)
+
+    @pytest.mark.parametrize(
+        "tfsys, tfinal",
+        [(TransferFunction(1, [1, .5], dt=True), 9.96578),  # pole at -0.5
+         (TransferFunction(1, [1, 1], dt=True), 10)])       # pole at -1
+    def test_discrete_negative_real_pole_tfinal(self, tfsys, tfinal):
+        """Confirm discrete negative real pole time horizon estimates."""
+        ideal_tfinal, _ = _ideal_tfinal_and_dt(tfsys)
+        np.testing.assert_allclose(ideal_tfinal, tfinal, rtol=1e-4)
 
     @pytest.mark.parametrize("wn, zeta", [(10, 0), (100, 0), (100, .1)])
     def test_auto_generated_time_vector_dt_cont1(self, wn, zeta):

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -2172,13 +2172,17 @@ def _ideal_tfinal_and_dt(sys, is_step=True):
         m_z = np.abs(p) < sqrt_eps
         p = p[~m_z]
         # Negative reals- treated as oscillatory mode
-        m_nr = (p.real < 0) & (np.abs(p.imag) < sqrt_eps)
+        m_nr = (
+            (p.real < 0) & (np.abs(p.imag) < sqrt_eps) &
+            (np.abs(np.abs(p) - 1) >= sqrt_eps))
         p_nr, p = p[m_nr], p[~m_nr]
         if p_nr.size > 0:
             t_emp = np.max(log_decay_percent / np.abs((np.log(p_nr)/dt).real))
             tfinal = max(tfinal, t_emp)
         # discrete integrators
-        m_int = (p.real - 1 < sqrt_eps) & (np.abs(p.imag) < sqrt_eps)
+        m_int = (
+            (p.real > 0) & (p.real - 1 < sqrt_eps) &
+            (np.abs(p.imag) < sqrt_eps))
         p_int, p = p[m_int], p[~m_int]
         # pure oscillatory modes
         m_w = (np.abs(np.abs(p) - 1) < sqrt_eps)


### PR DESCRIPTION
Fixes python-control/python-control#1204.

`_ideal_tfinal_and_dt()` already treats negative real discrete poles separately, but a pole exactly on the unit circle at `-1` was still sent through the decaying negative-real path. That path divides by `real(log(pole))`, which is zero for `-1`, so `impulse_response()` emitted a `RuntimeWarning` even though the response itself was valid.

This change keeps decaying negative real poles such as `-0.5` on the existing decay-based path, keeps positive real discrete poles on the existing padded path, and lets unit-circle negative real poles flow to the pure oscillatory-mode estimate.

Verification:

- Reproduced the issue script with `warnings.simplefilter("error", RuntimeWarning)` before the fix.
- `python -m pytest control\tests\timeresp_test.py::TestTimeresp::test_auto_generated_time_vector_tfinal control\tests\timeresp_test.py::TestTimeresp::test_discrete_negative_real_pole_tfinal control\tests\timeresp_test.py::TestTimeresp::test_discrete_time_impulse_negative_poles_no_warning -q`
- `python -m pytest control\tests\timeresp_test.py -q`
- `python -m ruff check --no-cache control\timeresp.py control\tests\timeresp_test.py`
- `PYTHONPYCACHEPREFIX=C:\tmp\pycache-python-control-1204 python -m compileall -q control\timeresp.py control\tests\timeresp_test.py`
- `git diff --check`

AI-assisted contribution: implemented with OpenAI Codex and manually verified with the commands above.