### PR TITLE
fix(xferfcn): normalize real zpk coefficients

### DIFF
--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -52,6 +52,9 @@ class TestXferFcn:
 
         with pytest.raises(TypeError, match="unsupported data type"):
             ct.tf([1j], [1, 2, 3])
+        for dtype in [np.complex64, np.complex128]:
+            with pytest.raises(TypeError, match="unsupported data type"):
+                ct.tf(np.array([1 + 1j], dtype=dtype), [1, 2, 3])
 
         # good input
         TransferFunction([[[0, 1], [2, 3]],
@@ -1549,6 +1552,19 @@ def test_zpk(zeros, poles, gain, args, kwargs):
 
     if kwargs.get('name'):
         assert sys.name == kwargs.get('name')
+
+
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_zpk_complex_dtype_real_coefficients(dtype):
+    zeros = np.array([1 + 1j, 1 - 1j], dtype=dtype)
+    poles = np.array([-1 + 1j, -1 - 1j], dtype=dtype)
+
+    sys = ct.zpk(zeros, poles, gain=1, dt=0)
+
+    assert sys.num_array[0, 0].dtype == float
+    assert sys.den_array[0, 0].dtype == float
+    assert "float32" not in str(sys)
+
 
 @pytest.mark.parametrize("create, args, kwargs, convert", [
     (StateSpace, ([-1], [1], [1], [0]), {}, ss2tf),

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1960,7 +1960,7 @@ def _clean_part(data, name="<unknown>"):
     if isinstance(data, np.ndarray) and data.ndim == 2 and \
        data.dtype == object and isinstance(data[0, 0], np.ndarray):
         # Data is already in the right format
-        return data
+        out = data
     elif isinstance(data, ndarray) and data.ndim == 3 and \
           isinstance(data[0, 0, 0], valid_types):
         out = np.empty(data.shape[0:2], dtype=np.ndarray)
@@ -1995,15 +1995,26 @@ def _clean_part(data, name="<unknown>"):
             "The numerator and denominator inputs must be scalars or vectors "
             "(for\nSISO), or lists of lists of vectors (for SISO or MIMO).")
 
-    # Check for coefficients that are ints and convert to floats
+    # Check for real numeric coefficients and normalize floating arrays
     for i in range(out.shape[0]):
         for j in range(out.shape[1]):
-            for k in range(len(out[i, j])):
-                if isinstance(out[i, j][k], (int, np.integer)):
-                    out[i, j][k] = float(out[i, j][k])
-                elif isinstance(out[i, j][k], unsupported_types):
+            coefficients = np.asarray(out[i, j])
+            convert_to_float = np.issubdtype(coefficients.dtype, np.floating)
+            if np.iscomplexobj(coefficients):
+                real_coefficients = coefficients.real
+                zero_tol = 1000 * np.finfo(float).eps * max(
+                    1, np.max(np.abs(real_coefficients)))
+                if np.any(np.abs(coefficients.imag) > zero_tol):
                     raise TypeError(
-                        f"unsupported data type: {type(out[i, j][k])}")
+                        f"unsupported data type: {type(coefficients.flat[0])}")
+                coefficients = real_coefficients
+                convert_to_float = True
+            for k in range(len(coefficients)):
+                if isinstance(coefficients[k], unsupported_types):
+                    raise TypeError(
+                        f"unsupported data type: {type(coefficients[k])}")
+            out[i, j] = np.asarray(
+                coefficients, dtype=float) if convert_to_float else coefficients
     return out
 
 

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1977,7 +1977,7 @@ def _clean_part(data, name="<unknown>"):
     if isinstance(data, np.ndarray) and data.ndim == 2 and \
        data.dtype == object and isinstance(data[0, 0], np.ndarray):
         # Data is already in the right format
-        return data
+        out = data
     elif isinstance(data, ndarray) and data.ndim == 3 and \
           isinstance(data[0, 0, 0], valid_types):
         out = np.empty(data.shape[0:2], dtype=np.ndarray)
@@ -2012,15 +2012,26 @@ def _clean_part(data, name="<unknown>"):
             "The numerator and denominator inputs must be scalars or vectors "
             "(for\nSISO), or lists of lists of vectors (for SISO or MIMO).")
 
-    # Check for coefficients that are ints and convert to floats
+    # Check for real numeric coefficients and normalize floating arrays
     for i in range(out.shape[0]):
         for j in range(out.shape[1]):
-            for k in range(len(out[i, j])):
-                if isinstance(out[i, j][k], (int, np.integer)):
-                    out[i, j][k] = float(out[i, j][k])
-                elif isinstance(out[i, j][k], unsupported_types):
+            coefficients = np.asarray(out[i, j])
+            convert_to_float = np.issubdtype(coefficients.dtype, np.floating)
+            if np.iscomplexobj(coefficients):
+                real_coefficients = coefficients.real
+                zero_tol = 1000 * np.finfo(float).eps * max(
+                    1, np.max(np.abs(real_coefficients)))
+                if np.any(np.abs(coefficients.imag) > zero_tol):
                     raise TypeError(
-                        f"unsupported data type: {type(out[i, j][k])}")
+                        f"unsupported data type: {type(coefficients.flat[0])}")
+                coefficients = real_coefficients
+                convert_to_float = True
+            for k in range(len(coefficients)):
+                if isinstance(coefficients[k], unsupported_types):
+                    raise TypeError(
+                        f"unsupported data type: {type(coefficients[k])}")
+            out[i, j] = np.asarray(
+                coefficients, dtype=float) if convert_to_float else coefficients
     return out
 
 


### PR DESCRIPTION
Fixes python-control/python-control#1188.

This does **not** add support for complex transfer-function coefficients. Instead, it keeps that boundary explicit while normalizing the cases that should remain real:

- `zpk()` with complex dtype zero/pole arrays can produce real polynomial coefficients with either `float32` dtype or tiny imaginary roundoff from `zpk2tf()`.
- `float32` coefficients later made `str(sys)` fail because the polynomial printer evals the array repr and does not have `float32` in scope.
- tiny imaginary numerical residue could make otherwise-real conjugate-root systems fail with `unsupported data type: numpy.complex128`.

The fix validates coefficient arrays in `_clean_part()`, accepts complex arrays only when their imaginary parts are numerical zero at coefficient scale, normalizes accepted floating arrays to default float dtype, and continues rejecting actual complex coefficients.

Verification:

- Reproduced the issue path before the fix: `complex64` zpk systems created successfully but `str(sys)` failed with `NameError: name 'float32' is not defined`; `complex128` intermittently raised `TypeError` depending on random roots.
- 100-seed smoke after the fix: `complex64` and `complex128` zpk systems both created and printed successfully for all seeds.
- `python -m pytest control\tests\xferfcn_test.py::TestXferFcn::test_constructor_bad_input_type control\tests\xferfcn_test.py::test_zpk_complex_dtype_real_coefficients -q`
- `python -m pytest control\tests\xferfcn_test.py -q`
- `python -m ruff check --no-cache control\xferfcn.py control\tests\xferfcn_test.py`
- `PYTHONPYCACHEPREFIX=C:\tmp\pycache-python-control-1188 python -m compileall -q control\xferfcn.py control\tests\xferfcn_test.py`
- `git diff --check`

AI-assisted contribution: implemented with OpenAI Codex and manually verified with the commands above.

---
*AI Disclosure: Codex (ChatGPT 5.5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*