### PR TITLE
Fix forced_response time inference for transposed inputs

### DIFF
--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -1245,6 +1245,17 @@ class TestTimeresp:
         assert y.shape == ysh_no
         assert x.shape == (T.size, sys.nstates)
 
+    def test_forced_response_transpose_without_time_vector(self):
+        sys = ct.ss(
+            [[0.5]], [[1.0, -0.25]], [[1.0]], [[0.0, 0.0]], dt=True)
+        U = np.column_stack((np.arange(5.0), np.arange(5.0) + 10))
+
+        response = ct.forced_response(sys, inputs=U, transpose=True)
+
+        np.testing.assert_allclose(response.time, np.arange(U.shape[0]))
+        np.testing.assert_allclose(response.inputs, U)
+        assert response.outputs.shape == (U.shape[0], sys.noutputs)
+
 
 @pytest.mark.pandas
 def test_to_pandas():

--- a/control/tests/timeresp_test.py
+++ b/control/tests/timeresp_test.py
@@ -1254,6 +1254,17 @@ class TestTimeresp:
         assert y.shape == ysh_no
         assert x.shape == (T.size, sys.nstates)
 
+    def test_forced_response_transpose_without_time_vector(self):
+        sys = ct.ss(
+            [[0.5]], [[1.0, -0.25]], [[1.0]], [[0.0, 0.0]], dt=True)
+        U = np.column_stack((np.arange(5.0), np.arange(5.0) + 10))
+
+        response = ct.forced_response(sys, inputs=U, transpose=True)
+
+        np.testing.assert_allclose(response.time, np.arange(U.shape[0]))
+        np.testing.assert_allclose(response.inputs, U)
+        assert response.outputs.shape == (U.shape[0], sys.noutputs)
+
 
 @pytest.mark.pandas
 def test_to_pandas():

--- a/control/timeresp.py
+++ b/control/timeresp.py
@@ -1112,7 +1112,7 @@ def forced_response(
                 raise ValueError('Parameters `T` and `U` can\'t both be '
                                  'zero for discrete-time simulation')
             # Set T to equally spaced samples with same length as U
-            if U.ndim == 1:
+            if U.ndim == 1 or transpose:
                 n_steps = U.shape[0]
             else:
                 n_steps = U.shape[1]


### PR DESCRIPTION
## Summary

Fixes #931.

When `forced_response()` is called for a discrete-time system with `timepts=None`, it infers the generated time vector length from `inputs`. With `transpose=True`, 2D input data is supplied in `(time, input)` order, but the current code still reads `U.shape[1]`, treating the input count as the number of time steps.

This changes the inference to use `U.shape[0]` for 2D inputs when `transpose=True`, matching the later `_check_convert_array(..., transpose=True)` conversion.

## Validation

- Red repro before the fix: `forced_response(sys, inputs=U, transpose=True)` with `U.shape == (5, 2)` failed with `ValueError: Parameter U: Wrong shape ... Expected: (2, 2)`.
- `python -m pytest control/tests/timeresp_test.py -k forced_response_transpose_without_time_vector -q` passed.
- `python -m pytest control/tests/timeresp_test.py -q -p no:cacheprovider` passed: 253 passed, 46 skipped.
- `python -m ruff check --no-cache control\timeresp.py control\tests\timeresp_test.py` passed.
- `PYTHONPYCACHEPREFIX=C:\tmp\pycache-python-control-931 python -m compileall -q control\timeresp.py control\tests\timeresp_test.py` passed.
- `git diff --check` passed.

---
*AI Disclosure: Codex (ChatGPT 5.5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*