### PR TITLE
Preserve complex StateSpace matrices

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -2302,7 +2302,8 @@ def _ssmatrix(data, axis=1, square=None, rows=None, cols=None, name=None):
     name = "" if name is None else " " + name
 
     # Convert the data into an array (always making a copy)
-    arr = np.array(data, dtype=float)
+    dtype = complex if np.iscomplexobj(data) else float
+    arr = np.array(data, dtype=dtype)
     ndim = arr.ndim
     shape = arr.shape
 

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -2304,7 +2304,8 @@ def _ssmatrix(data, axis=1, square=None, rows=None, cols=None, name=None):
     name = "" if name is None else " " + name
 
     # Convert the data into an array (always making a copy)
-    arr = np.array(data, dtype=float)
+    dtype = complex if np.iscomplexobj(data) else float
+    arr = np.array(data, dtype=dtype)
     ndim = arr.ndim
     shape = arr.shape
 

--- a/control/tests/statesp_test.py
+++ b/control/tests/statesp_test.py
@@ -8,6 +8,7 @@ BG,  26 Jul 2020 merge statesp_array_test.py differences into statesp_test.py
 """
 
 import operator
+import warnings
 
 import numpy as np
 import pytest
@@ -136,7 +137,6 @@ class TestStateSpace:
          ((np.ones((3, 3)), np.ones((3, 2)),
            np.ones((2, 3)), np.ones((2, 3))), ValueError,
           r"Incompatible dimensions of D matrix; expected \(2, 2\)"),
-         (([1j], 2, 3, 0), TypeError, "real number, not 'complex'"),
         ])
     def test_constructor_invalid(self, args, exc, errmsg):
         """Test invalid input to StateSpace() constructor"""
@@ -145,6 +145,22 @@ class TestStateSpace:
             StateSpace(*args)
         with pytest.raises(exc, match=errmsg):
             ss(*args)
+
+    def test_constructor_complex_matrices(self):
+        """Test complex-valued matrices in StateSpace() constructor"""
+        A = np.array([[1 + 1j, 2 - 3j], [3 + 2j, 4 - 1j]])
+        B = np.array([[1 - 2j], [3 + 4j]])
+        C = np.array([[5 + 6j, 7 - 8j]])
+        D = np.array([[9 + 10j]])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            sys = StateSpace(A, B, C, D)
+
+        np.testing.assert_allclose(sys.A, A)
+        np.testing.assert_allclose(sys.B, B)
+        np.testing.assert_allclose(sys.C, C)
+        np.testing.assert_allclose(sys.D, D)
 
     def test_constructor_warns(self, sys322ABCD):
         """Test ambiguos input to StateSpace() constructor"""


### PR DESCRIPTION
Fixes #1058.

`StateSpace(A, B, C, D)` currently coerces every state-space matrix through `np.array(..., dtype=float)`, which silently discards imaginary parts from complex-valued matrices and emits `ComplexWarning`. State-space operations already evaluate complex frequencies and NumPy can safely keep real matrices as floats, so this changes `_ssmatrix()` to preserve complex dtype only when the input is complex-valued.

The regression test covers complex A/B/C/D matrices and treats constructor warnings as errors, so the old `ComplexWarning` path fails directly.

Validation:
- Reproduced the issue on current `main` before the fix: complex matrices were stored as real matrices and emitted four `ComplexWarning`s.
- `python -m pytest control/tests/statesp_test.py::TestStateSpace::test_constructor_complex_matrices control/tests/statesp_test.py::TestStateSpace::test_constructor_invalid -q`
- `python -m pytest control/tests/statesp_test.py -q`
- `python -m pytest control/tests/convert_test.py control/tests/type_conversion_test.py control/tests/xferfcn_test.py control/tests/bdalg_test.py -q`
- `python -m ruff check control/statesp.py control/tests/statesp_test.py`
- `python -m compileall -q control`
- `git diff --check`

Note: I also attempted `python -m pytest control/tests -q`, but the local Windows run exceeded a 5-minute timeout before producing useful output.

Assisted-by: OpenAI Codex

---
*AI Disclosure: Codex (ChatGPT 5.5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*