### PR TITLE
Fix time_response_plot for response lists

### DIFF
--- a/control/tests/timeplot_test.py
+++ b/control/tests/timeplot_test.py
@@ -321,6 +321,34 @@ def test_combine_time_responses():
         ct.combine_time_responses([resp1, resp])
 
 
+@pytest.mark.usefixtures('mplcleanup')
+def test_time_response_plot_response_list():
+    sys = ct.ss(ct.tf([1, 2], [3, 4, 5]))
+    timepts = np.linspace(0, 10)
+    resp1 = ct.input_output_response(sys, timepts, np.sin(timepts))
+    resp2 = ct.input_output_response(sys, timepts, np.cos(timepts))
+
+    cplt = ct.time_response_plot(
+        [resp1, resp2], trace_labels=["sine input", "cosine input"])
+    assert cplt.lines.shape == (2, 2)
+    assert cplt.axes[0, 0].get_title() == "sine input"
+    assert cplt.axes[0, 1].get_title() == "cosine input"
+    assert all(len(lines.item()) == 1 for lines in np.nditer(
+        cplt.lines, flags=["refs_ok"]))
+    plt.close()
+
+    cplt = ct.time_response_plot([resp1, resp2], plot_inputs=True)
+    assert cplt.lines.shape == (2, 2)
+    assert all(len(lines.item()) == 1 for lines in np.nditer(
+        cplt.lines, flags=["refs_ok"]))
+    plt.close()
+
+    cplt = ct.time_response_plot([resp1, resp2], plot_inputs='overlay')
+    assert cplt.lines.shape == (1, 2)
+    assert all(len(lines.item()) == 2 for lines in np.nditer(
+        cplt.lines, flags=["refs_ok"]))
+
+
 @pytest.mark.parametrize("resp_fcn", [
     ct.step_response, ct.initial_response, ct.impulse_response,
     ct.forced_response, ct.input_output_response])

--- a/control/timeplot.py
+++ b/control/timeplot.py
@@ -52,8 +52,9 @@ def time_response_plot(
 
     Parameters
     ----------
-    data : `TimeResponseData`
-        Data to be plotted.
+    data : `TimeResponseData` or list of `TimeResponseData`
+        Data to be plotted.  Lists of responses are combined into a
+        multi-trace response before plotting.
     plot_inputs : bool or str, optional
         Sets how and where to plot the inputs:
             * False: don't plot the inputs
@@ -179,6 +180,9 @@ def time_response_plot(
     #
     # Process keywords and set defaults
     #
+    if isinstance(data, (list, tuple)):
+        data = combine_time_responses(data, trace_labels=trace_labels)
+
     # Set up defaults
     ax_user = ax
     sharex = config._get_param('timeplot', 'sharex', kwargs, pop=True)


### PR DESCRIPTION
## Summary

Fixes `time_response_plot()` when called directly with a list of `TimeResponseData` objects, as shown in #1171.

The function now combines response lists into a multi-trace response before calculating plot layout, so callers do not hit `AttributeError` on list attributes such as `plot_inputs` or `ninputs`.

## Checks

- Red repro before fix: `ct.time_response_plot([resp1, resp2])` failed with `AttributeError: 'list' object has no attribute 'plot_inputs'`.
- Red repro before fix: `ct.time_response_plot([resp1, resp2], plot_inputs=True)` failed with `AttributeError: 'list' object has no attribute 'ninputs'`.
- `MPLBACKEND=Agg python -m pytest control/tests/timeplot_test.py::test_time_response_plot_response_list control/tests/timeplot_test.py::test_list_responses -q` passed: 6 passed.
- `MPLBACKEND=Agg python -m pytest control/tests/timeplot_test.py -q` passed: 74 passed, 3 skipped.
- `MPLBACKEND=Agg python -m pytest control/tests/timeresp_test.py control/tests/trdata_test.py -q` passed: 276 passed, 46 skipped.
- `python -m ruff check control/timeplot.py control/tests/timeplot_test.py` passed.
- `python -m compileall -q control/timeplot.py control/tests/timeplot_test.py` passed.
- `git diff --check HEAD~1..HEAD` passed.

---
*AI Disclosure: Claude Code (Opus 5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*