### PR TITLE
Fix scalar feedback for square MIMO state-space systems

### DIFF
--- a/control/statesp.py
+++ b/control/statesp.py
@@ -1003,6 +1003,8 @@ class StateSpace(NonlinearIOSystem, LTI):
         """
         # Convert the system to state space, if possible
         try:
+            if np.isscalar(other) and self.ninputs == self.noutputs:
+                other = other * eye(self.ninputs)
             other = _convert_to_statespace(other)
         except:
             pass

--- a/control/tests/bdalg_test.py
+++ b/control/tests/bdalg_test.py
@@ -143,6 +143,31 @@ class TestFeedback:
             0.142857142857143, -0.571428571428571, 0.857142857142857]])
         np.testing.assert_array_almost_equal(ans2.D, [[-0.285714285714286]])
 
+    def test_mimo_ss_scalar_feedback(self):
+        """MIMO state space system with scalar feedback block."""
+        sys_static = StateSpace([], [], [], [[1, 0], [0, 2]])
+        ans1 = feedback(sys_static)
+        ans2 = feedback(sys_static, np.eye(2))
+        np.testing.assert_array_almost_equal(ans1.D, ans2.D)
+
+        ans3 = feedback(sys_static, 2)
+        ans4 = feedback(sys_static, 2 * np.eye(2))
+        np.testing.assert_array_almost_equal(ans3.D, ans4.D)
+
+        sys_dynamic = StateSpace(
+            [[-1, 0], [0, -2]], [[1, 0], [0, 1]],
+            [[1, 0], [0, 1]], [[0, 0], [0, 0]])
+        ans5 = feedback(sys_dynamic)
+        ans6 = feedback(sys_dynamic, np.eye(2))
+        np.testing.assert_array_almost_equal(ans5.A, ans6.A)
+        np.testing.assert_array_almost_equal(ans5.B, ans6.B)
+        np.testing.assert_array_almost_equal(ans5.C, ans6.C)
+        np.testing.assert_array_almost_equal(ans5.D, ans6.D)
+
+        sys_nonsquare = StateSpace([], [], [], [[1, 2, 3], [4, 5, 6]])
+        with pytest.raises(ValueError, match="compatible inputs/outputs"):
+            feedback(sys_nonsquare)
+
 
     def testSSTF(self, tsys):
         """State space system with transfer function feedback block."""


### PR DESCRIPTION
## Summary

Fix `feedback(sys)` / `feedback(sys, scalar)` for square MIMO `StateSpace` systems by treating scalar feedback as `scalar * I` with the system input/output size.

Before this change, the default `sys2=1` was converted to a 1x1 static state-space system, so square MIMO systems failed the feedback dimension check even though explicit identity feedback worked.

Rectangular MIMO systems keep the existing incompatible-dimensions error.

## Checks

- Red repro before fix: `ct.feedback(ct.ss([], [], [], [[1, 0], [0, 2]]))` failed with `ValueError: State space systems don't have compatible inputs/outputs for feedback.`
- Red repro before fix: `ct.feedback(ct.rss(2, 2, 2))` failed with the same dimension error.
- Post-fix smoke confirmed default square MIMO feedback matches explicit `np.eye(n)` feedback for static and dynamic systems.
- `python -m pytest control/tests/bdalg_test.py::TestFeedback::test_mimo_ss_scalar_feedback -q` passed: 1 passed.
- `python -m pytest control/tests/bdalg_test.py control/tests/statesp_test.py control/tests/type_conversion_test.py -q` passed: 1226 passed, 112 skipped, 1 xfailed, 1 warning.
- `python -m ruff check control/statesp.py control/tests/bdalg_test.py` passed.
- `python -m compileall -q control/statesp.py control/tests/bdalg_test.py` passed.
- `git diff --check HEAD~1..HEAD` passed.

---
*AI Disclosure: Claude Code (Opus 5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*