### PR TITLE
Use initial root-locus limits when choosing gains

### DIFF
--- a/control/rlocus.py
+++ b/control/rlocus.py
@@ -188,7 +188,9 @@ def root_locus_plot(
     if isinstance(sysdata, list) and all(
             [isinstance(sys, LTI) for sys in sysdata]) or \
             isinstance(sysdata, LTI):
-        responses = root_locus_map(sysdata, gains=gains)
+        responses = root_locus_map(
+            sysdata, gains=gains, xlim=kwargs.get('xlim'),
+            ylim=kwargs.get('ylim'))
     else:
         responses = sysdata
 

--- a/control/tests/rlocus_test.py
+++ b/control/tests/rlocus_test.py
@@ -180,6 +180,19 @@ def test_root_locus_plots(sys, grid, xlim, ylim, interactive):
     # TODO: add tests to make sure everything "looks" OK
 
 
+@pytest.mark.usefixtures("mplcleanup")
+def test_root_locus_plot_initial_limits_refine_gains():
+    sys = ct.tf([1000], [1, 25, 100, 0])
+    xlim = (-10.813628105112421, 14.760795435937652)
+    ylim = (-35.61713798641108, 33.879716621220311)
+
+    cplt = ct.root_locus_plot(
+        sys, grid=False, xlim=xlim, ylim=ylim, interactive=False)
+    expected = ct.root_locus_map(sys, xlim=xlim, ylim=ylim)
+
+    assert len(cplt.lines[0, 2][0].get_xdata()) == len(expected.gains)
+
+
 # Test deprecated keywords
 @pytest.mark.parametrize("keyword", ["kvect", "k"])
 @pytest.mark.usefixtures("mplcleanup")


### PR DESCRIPTION
## Summary
- Pass `xlim` and `ylim` from `root_locus_plot()` into the initial `root_locus_map()` call.
- Keeps the plotted root-locus sampling consistent with the explicit viewport before any zoom callback runs.
- Adds a regression that compares the initial plotted loci count against `root_locus_map(..., xlim=..., ylim=...)`.

## Tests
- `MPLBACKEND=Agg python -m pytest control/tests/rlocus_test.py::test_root_locus_plot_initial_limits_refine_gains -q`
- `MPLBACKEND=Agg python -m pytest control/tests/rlocus_test.py -q`
- `python -m ruff check --no-cache control/rlocus.py control/tests/rlocus_test.py`
- `python -m compileall -q control/rlocus.py control/tests/rlocus_test.py`

---
*AI Disclosure: Claude Code (Opus 5) was used during code navigation, initial drafting, and PR text preparation. All logic, code changes, and test cases have been manually reviewed, verified, and tested locally by the author in accordance with the NumPy AI Policy.*