### PR TITLE
Fix typos in comments, docstrings, and error messages

### DIFF
--- a/control/flatsys/bspline.py
+++ b/control/flatsys/bspline.py
@@ -54,7 +54,7 @@ class BSplineFamily(BasisFamily):
             raise NotImplementedError(
                 "breakpoints for each spline variable not yet supported")
         elif breakpoints.ndim != 1:
-            raise ValueError("breakpoints must be convertable to a 1D array")
+            raise ValueError("breakpoints must be convertible to a 1D array")
         elif breakpoints.size < 2:
             raise ValueError("break point vector must have at least 2 values")
         elif np.any(np.diff(breakpoints) <= 0):

--- a/control/nlsys.py
+++ b/control/nlsys.py
@@ -839,7 +839,7 @@ class InterconnectedSystem(NonlinearIOSystem):
                 iosys_repr(sys, format='info'), width=78,
                 initial_indent=" * ", subsequent_indent="    ")) + "\n"
 
-        # Build a list of input, output, and inpout signals
+        # Build a list of input, output, and input/output signals
         input_list, output_list, inpout_list = [], [], []
         for sys in self.syslist:
             input_list += [sys.name + "." + lbl for lbl in sys.input_labels]
@@ -2641,7 +2641,7 @@ def interconnect(
     dprint = lambda s: None if not debug else print(s)
 
     #
-    # Pre-process connecton list
+    # Pre-process connection list
     #
     # Support for various "vector" forms of specifications is handled here,
     # by expanding any specifications that refer to more than one signal.

--- a/control/optimal.py
+++ b/control/optimal.py
@@ -2544,7 +2544,7 @@ def disturbance_range_constraint(sys, lb, ub):
 # constraint followed by the arguments.  However, they are now specified
 # directly as SciPy constraint objects.
 #
-# The _process_constraints() function will covert everything to a consistent
+# The _process_constraints() function will convert everything to a consistent
 # internal representation (currently a tuple with the constraint type as the
 # first element.
 #

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -446,7 +446,7 @@ def streamplot(
     Returns
     -------
     out : StreamplotSet
-        Containter object with lines and arrows contained in the
+        Container object with lines and arrows contained in the
         streamplot. See `matplotlib.axes.Axes.streamplot` for details.
 
     Other Parameters

--- a/control/robust.py
+++ b/control/robust.py
@@ -64,7 +64,7 @@ def h2syn(P, nmeas, ncon):
     """
     # Check for ss system object, need a utility for this?
 
-    # TODO: Check for continous or discrete, only continuous supported right now
+    # TODO: Check for continuous or discrete, only continuous supported right now
 
     try:
         from slycot import sb10hd
@@ -146,7 +146,7 @@ def hinfsyn(P, nmeas, ncon):
 
     # Check for ss system object, need a utility for this?
 
-    # TODO: Check for continous or discrete, only continuous supported right now
+    # TODO: Check for continuous or discrete, only continuous supported right now
 
     try:
         from slycot import sb10ad

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -976,7 +976,7 @@ class StateSpace(NonlinearIOSystem, LTI):
             # The QZ algorithm solves the generalized eigenvalue problem: given
             # `L = [A, B; C, D]` and `M = [I_nxn 0]`, find all finite lambda
             # for which there exist nontrivial solutions of the equation
-            # `Lz - lamba Mz`.
+            # `Lz - lambda Mz`.
             #
             # The generalized eigenvalue problem is only solvable if its
             # arguments are square matrices.

--- a/control/timeplot.py
+++ b/control/timeplot.py
@@ -477,7 +477,7 @@ def time_response_plot(
     # of signals (when overlay_signal is True or plot+inputs = 'overlay'.
     #
     # Traces are labeled at the top of the first row of plots (regular) or
-    # the left edge of rows (tranpose).
+    # the left edge of rows (transpose).
     #
 
     # Time units on the bottom


### PR DESCRIPTION
Fix several typos found by codespell in source files.

Changes:
- `control/robust.py`: `continous` -> `continuous` (2 occurrences in TODO comments)
- `control/timeplot.py`: `tranpose` -> `transpose` (comment)
- `control/nlsys.py`: `inpout` -> `input/output` (comment), `connecton` -> `connection` (comment)
- `control/optimal.py`: `covert` -> `convert` (comment)
- `control/phaseplot.py`: `Containter` -> `Container` (docstring)
- `control/statesp.py`: `lamba` -> `lambda` (comment)
- `control/flatsys/bspline.py`: `convertable` -> `convertible` (error message string)