### PR TITLE
DOC: follow NumPy policy for contributions that use "AI"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,3 +177,7 @@ Your contributions are welcome!  Simply fork the GitHub repository and send a
 Please see the `Developer's Wiki`_ for detailed instructions.
 
 .. _Developer's Wiki: https://github.com/python-control/python-control/wiki
+
+Please follow the `AI Policy of NumPy`_ when writing issues and pull requests.
+
+.. _AI Policy of NumPy: https://numpy.org/doc/stable/dev/ai_policy.html


### PR DESCRIPTION
I propose that we follow the ["AI policy" for contributions to NumPy](https://numpy.org/doc/stable/dev/ai_policy.html). Recently we have had several pull requests that I suspect were written by bots that have little or no human management (e.g., https://github.com/python-control/python-control/pull/1239). I believe leveraging tools for code writing is worthwhile; however, we need to establish guidelines to ensure accountability and to avoid wasting time.

I have read through a variety of policies that different projects have established for acceptable use of "AI tools," and I think NumPy's is the most complete and practical, so I propose that we use it.