### PR TITLE
Fix CI test and doctest failures with updated NumPy, SciPy, and Matplotlib

### DIFF
--- a/control/descfcn.py
+++ b/control/descfcn.py
@@ -188,8 +188,7 @@ def describing_function(
 
     # Go through all of the amplitudes we were given
     retdf = np.empty(np.shape(A), dtype=complex)
-    df = retdf                  # Access to the return array
-    df.shape = (-1, )           # as a 1D array
+    df = retdf.reshape((-1, ))  # Access to the return array as a 1D array
     for i, a in enumerate(np.atleast_1d(A)):
         # Make sure we got a valid argument
         if a == 0:

--- a/control/lti.py
+++ b/control/lti.py
@@ -706,15 +706,15 @@ def bandwidth(sys, dbdrop=-3):
     Examples
     --------
     >>> G = ct.tf([1], [1, 1])
-    >>> ct.bandwidth(G)
-    np.float64(0.9976283451102316)
+    >>> ct.bandwidth(G)                     # doctest: +ELLIPSIS
+    np.float64(0.99762834511023...)
 
     >>> G1 = ct.tf(0.1, [1, 0.1])
     >>> wn2 = 1
     >>> zeta2 = 0.001
     >>> G2 = ct.tf(wn2**2, [1, 2*zeta2*wn2, wn2**2])
-    >>> ct.bandwidth(G1*G2)
-    np.float64(0.10184838823897456)
+    >>> ct.bandwidth(G1*G2)                 # doctest: +ELLIPSIS
+    np.float64(0.10184838823897...)
 
     """
     if not isinstance(sys, LTI):

--- a/control/modelsimp.py
+++ b/control/modelsimp.py
@@ -73,7 +73,7 @@ def hankel_singular_values(sys):
     WoWc = Wo @ Wc
     w, v = np.linalg.eig(WoWc)
 
-    hsv = np.sqrt(w)
+    hsv = np.sqrt(w.real)
     hsv = np.array(hsv)
     hsv = np.sort(hsv)
     # Return the Hankel singular values, high to low

--- a/control/phaseplot.py
+++ b/control/phaseplot.py
@@ -892,6 +892,7 @@ def separatrices(
                 timepts = np.linspace(0, timescale)
 
             # Run the trajectory starting in eigenvector directions
+            dir = dir.real      # use real components only
             for eps in [-radius, radius]:
                 x0 = xeq + dir * eps
                 if evals[j].real < 0:

--- a/control/statesp.py
+++ b/control/statesp.py
@@ -261,9 +261,9 @@ class StateSpace(NonlinearIOSystem, LTI):
 
         # Reset shapes if the system is static
         if static:
-            A.shape = (0, 0)
-            B.shape = (0, self.ninputs)
-            C.shape = (self.noutputs, 0)
+            A = A.reshape((0, 0))
+            B = B.reshape((0, self.ninputs))
+            C = C.reshape((self.noutputs, 0))
 
         # Check to make sure everything is consistent
         _check_shape(A, self.nstates, self.nstates, name="A")

--- a/control/tests/ctrlplot_test.py
+++ b/control/tests/ctrlplot_test.py
@@ -748,8 +748,7 @@ def test_pole_zero_subplots(savefig=False):
     sys2 = ct.tf([1, 0.2], [1, 1, 3, 1, 1], name='sys2')
     ct.root_locus_plot([sys1, sys2], ax=ax_array[0, 0])
     cplt = ct.root_locus_plot([sys1, sys2], ax=ax_array[1, 0])
-    with pytest.warns(UserWarning, match="Tight layout not applied"):
-        cplt.set_plot_title("Root locus plots (w/ specified axes)")
+    cplt.set_plot_title("Root locus plots (w/ specified axes)")
     if savefig:
         plt.savefig("ctrlplot-pole_zero_subplots.png")
 

--- a/control/tests/nyquist_test.py
+++ b/control/tests/nyquist_test.py
@@ -374,7 +374,7 @@ def test_nyquist_indent_im():
 
 def test_nyquist_indent_near_imaginary_axis():
     """Test indent direction for poles near the imaginary axis."""
-    sys = ct.tf([1, 11, 10], [0.01, 1, 0.01, 1])
+    sys = ct.zpk([-10, -1], [-100, 0.001+1j, 0.001-1j], 10)
     omega = np.linspace(0, 2, 21)
 
     _, contour_default = ct.nyquist_response(

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -190,5 +190,5 @@ This documentation has a number of notional conventions and functionality:
   .. doctest::
 
      >>> sys = ct.tf([1], [1, 0.5, 1])
-     >>> ct.bandwidth(sys)
-     np.float64(1.4839084518312828)
+     >>> ct.bandwidth(sys)               # doctest: +ELLIPSIS
+     np.float64(1.4839084518312...)


### PR DESCRIPTION
A collection of small, independent fixes for test and doctest failures
appearing in CI. No functional changes to the library API. Open PRs
with failing CI tests should rebase onto `main` once this is merged.

### NumPy: unsupported `shape` assignment

`ndarray.shape` assignment is no longer supported in these contexts;
replaced with `reshape()`.

- `control/descfcn.py` — `describing_function()`
- `control/statesp.py` — `StateSpace.__init__()`, static-system reshaping

### NumPy: complex-to-real casts

Discard the (numerically zero) imaginary parts explicitly rather than
letting NumPy warn on the implicit cast.

- `control/modelsimp.py` — `hankel_singular_values()` takes `sqrt(w.real)`,
  since `Wo @ Wc` is symmetric positive semidefinite in exact arithmetic
- `control/phaseplot.py` — `separatrices()` uses the real part of the
  eigenvector, avoiding complex initial conditions

### Matplotlib: warning no longer emitted

- `control/tests/ctrlplot_test.py` — drop the `pytest.warns(UserWarning,
  match="Tight layout not applied")` check in
  `test_pole_zero_subplots()`, which no longer fires

### Platform-dependent numerics

- `control/tests/nyquist_test.py` — `test_nyquist_indent_near_imaginary_axis()`
  now constructs the system with `ct.zpk()`, placing the poles near the
  imaginary axis explicitly instead of relying on the roots of a
  polynomial, which gave inconsistent indent signs
- `control/lti.py`, `doc/intro.rst` — `bandwidth()` doctests use
  `# doctest: +ELLIPSIS` with ~14 significant digits. The value comes from
  a `scipy.optimize.root_scalar` bisection, so the last digit or two of
  the repr varies across SciPy/BLAS builds; the full-precision literals
  passed locally but failed on GitHub runners. `+ELLIPSIS` keeps the
  examples verified, unlike the `+SKIP` used elsewhere for
  platform-dependent output, and `trim_doctest_flags` (on by default)
  strips the flag comment from the rendered HTML.

### Testing

`make doctest` in `doc/`: 728 tests, 0 failures
(Python 3.14.6, NumPy 2.5.1, SciPy 1.18.0).

### AI disclosure

Per the AI policy referenced in README.rst: the `bandwidth()` doctest
change was written with assistance from Claude Code. I have reviewed it
and take responsibility for its content.
