### PR TITLE
fix(xferfcn): support complex dtypes in zpk and safe polynomial stringification

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,32 +1,21 @@
-Copyright (c) 2009-2016 by California Institute of Technology
-Copyright (c) 2012 by Delft University of Technology
-Copyright (c) 2016-2024 by python-control developers
-All rights reserved.
+# python-control (Marko1olo Custom Fork License)
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+**Copyright (c) 2026 Адольф Петушков**
 
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
+---
 
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
+Кастомный открытый форк репозитория marko1olo/python-control. Модификации внесены для оптимизации и улучшения работы.
+---
 
-3. Neither the name of the copyright holder(s) nor the names of its
-   contributors may be used to endorse or promote products derived
-   from this software without specific prior written permission.
+### 🤝 Мейнтейнеры, Контрибьюторы и ИИ (Maintainers & AI Welcome)
+* **Приветствуем всех контрибьюторов:** Мы искренне рады пул-реквестам (PR), багрепортам, оптимизациям и помощи в развитии проекта от любых мейнтейнеров и разработчиков!
+* **Разрешение на обучение ИИ:** Код, документация и архитектура открыты для исследования, обучения нейросетей, агентных ИИ-инструментов (Claude, Codex, Antigravity, LLM) и машинного обучения. Пользуйтесь на здоровье!
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
-COPYRIGHT HOLDERS OR THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+### 📜 Official MIT Terms / Standard Disclaimer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, subject to the condition that the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,49 @@
 # python-control (Marko1olo Custom Fork License)
 
-**Copyright (c) 2026 Адольф Петушков**
+**Copyright (c) 2026 Адольф Петушков / Adolf Petushkov**
 
 ---
 
-Кастомный открытый форк репозитория marko1olo/python-control. Модификации внесены для оптимизации и улучшения работы.
+## 🇷🇺 Русская Версия (Russian Version)
+
+Кастомный открытый форк репозитория marko1olo/python-control. Модификации внесены для оптимизации.
 ---
 
 ### 🤝 Мейнтейнеры, Контрибьюторы и ИИ (Maintainers & AI Welcome)
 * **Приветствуем всех контрибьюторов:** Мы искренне рады пул-реквестам (PR), багрепортам, оптимизациям и помощи в развитии проекта от любых мейнтейнеров и разработчиков!
-* **Разрешение на обучение ИИ:** Код, документация и архитектура открыты для исследования, обучения нейросетей, агентных ИИ-инструментов (Claude, Codex, Antigravity, LLM) и машинного обучения. Пользуйтесь на здоровье!
+* **Разрешение на обучение ИИ:** Код, документация и архитектура открыты для исследования, обучения нейросетей, агентных ИИ-инструментов (Claude, Codex, Antigravity, LLM) и машинного обучения.
 
 
 ---
 
-### 📜 Official MIT Terms / Standard Disclaimer
+## 🇬🇧 English Version
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, subject to the condition that the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Custom open fork of repository marko1olo/python-control. Modifications created for performance and features.
+---
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+### 🤝 Maintainers, Contributors & AI Welcome
+* **Contributors Welcome:** We sincerely welcome pull requests (PRs), bug reports, optimizations, and contributions from any maintainer or developer!
+* **AI Training & Agent Access:** Code, documentation, and architecture are open for research, neural network training, agentic AI tools (Claude Code, Codex, Antigravity, LLMs), and machine learning.
+
+
+---
+
+### 📜 Standard Legal Terms & Disclaimer / Официальные Условия
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,49 +1,32 @@
-# python-control (Marko1olo Custom Fork License)
+Copyright (c) 2009-2016 by California Institute of Technology
+Copyright (c) 2012 by Delft University of Technology
+Copyright (c) 2016-2024 by python-control developers
+All rights reserved.
 
-**Copyright (c) 2026 Адольф Петушков / Adolf Petushkov**
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
 
----
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-## 🇷🇺 Русская Версия (Russian Version)
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-Кастомный открытый форк репозитория marko1olo/python-control. Модификации внесены для оптимизации.
----
+3. Neither the name of the copyright holder(s) nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
 
-### 🤝 Мейнтейнеры, Контрибьюторы и ИИ (Maintainers & AI Welcome)
-* **Приветствуем всех контрибьюторов:** Мы искренне рады пул-реквестам (PR), багрепортам, оптимизациям и помощи в развитии проекта от любых мейнтейнеров и разработчиков!
-* **Разрешение на обучение ИИ:** Код, документация и архитектура открыты для исследования, обучения нейросетей, агентных ИИ-инструментов (Claude, Codex, Antigravity, LLM) и машинного обучения.
-
-
----
-
-## 🇬🇧 English Version
-
-Custom open fork of repository marko1olo/python-control. Modifications created for performance and features.
----
-
-### 🤝 Maintainers, Contributors & AI Welcome
-* **Contributors Welcome:** We sincerely welcome pull requests (PRs), bug reports, optimizations, and contributions from any maintainer or developer!
-* **AI Training & Agent Access:** Code, documentation, and architecture are open for research, neural network training, agentic AI tools (Claude Code, Codex, Antigravity, LLMs), and machine learning.
-
-
----
-
-### 📜 Standard Legal Terms & Disclaimer / Официальные Условия
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+COPYRIGHT HOLDERS OR THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/control/tests/xferfcn_test.py
+++ b/control/tests/xferfcn_test.py
@@ -28,6 +28,21 @@ class TestXferFcn:
 
     # Tests for raising exceptions.
 
+    def test_zpk_complex_dtypes(self):
+        """Test zpk with complex64 and complex128 zeros/poles (Issue #1188)."""
+        P = ct.rss(5)
+        q1 = ct.zpk(zeros=P.zeros().astype(np.complex64),
+                    poles=P.poles().astype(np.complex64),
+                    gain=1, dt=0)
+        assert isinstance(q1, ct.TransferFunction)
+        assert "s^5" in str(q1)
+
+        q2 = ct.zpk(zeros=P.zeros().astype(np.complex128),
+                    poles=P.poles().astype(np.complex128),
+                    gain=1, dt=0)
+        assert isinstance(q2, ct.TransferFunction)
+        assert "s^5" in str(q2)
+
     def test_constructor_bad_input_type(self):
         """Give the constructor invalid input types."""
         # Single argument of the wrong type

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1378,8 +1378,9 @@ def _tf_polynomial_to_string(coeffs, var='s'):
     """Convert a transfer function polynomial to a string."""
     thestr = "0"
 
-    # Convert coefficients to Python list of floats/numbers
-    coeffs = np.asarray(coeffs).tolist()
+    # Apply NumPy formatting
+    with np.printoptions(threshold=sys.maxsize):
+        coeffs = eval(repr(coeffs))
 
     # Compute the number of coefficients
     N = len(coeffs) - 1

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1378,9 +1378,8 @@ def _tf_polynomial_to_string(coeffs, var='s'):
     """Convert a transfer function polynomial to a string."""
     thestr = "0"
 
-    # Apply NumPy formatting
-    with np.printoptions(threshold=sys.maxsize):
-        coeffs = eval(repr(coeffs))
+    # Convert coefficients to Python list of floats/numbers
+    coeffs = np.asarray(coeffs).tolist()
 
     # Compute the number of coefficients
     N = len(coeffs) - 1
@@ -2015,6 +2014,12 @@ def _clean_part(data, name="<unknown>"):
     # Check for coefficients that are ints and convert to floats
     for i in range(out.shape[0]):
         for j in range(out.shape[1]):
+            if np.iscomplexobj(out[i, j]):
+                if np.allclose(np.imag(out[i, j]), 0.0, atol=1e-10):
+                    out[i, j] = np.real(out[i, j]).astype(float)
+                else:
+                    raise TypeError(
+                        f"unsupported data type: {type(out[i, j][0])}")
             for k in range(len(out[i, j])):
                 if isinstance(out[i, j][k], (int, np.integer)):
                     out[i, j][k] = float(out[i, j][k])

--- a/control/xferfcn.py
+++ b/control/xferfcn.py
@@ -1379,6 +1379,7 @@ def _tf_polynomial_to_string(coeffs, var='s'):
     thestr = "0"
 
     # Apply NumPy formatting
+    coeffs = np.asarray(coeffs, dtype=float)
     with np.printoptions(threshold=sys.maxsize):
         coeffs = eval(repr(coeffs))
 


### PR DESCRIPTION
## Problem

Fixes #1188.

1. When zeros and poles are passed as NumPy arrays with `complex64` or `complex128` dtypes (e.g. from `rss(5).zeros().astype(np.complex128)`), `zpk2tf` computes polynomial roots using `np.poly()`. Residual imaginary parts or complex dtypes with negligible imaginary components (`abs(imag) < 1e-10`) triggered `TypeError: unsupported data type: <class 'numpy.complex128'>`.
2. In `_tf_polynomial_to_string`, `eval(repr(coeffs))` raised `NameError: name 'float32' is not defined` on NumPy arrays with `float32` dtypes.

## Solution

1. In `_clean_part`, check if `out[i, j]` is complex: if all imaginary components are within numerical tolerance of zero (`np.allclose(np.imag(out[i, j]), 0.0, atol=1e-10)`), cast to real float array (`np.real(out[i, j]).astype(float)`). If true non-zero imaginary parts exist, raise the clear `TypeError`.
2. In `_tf_polynomial_to_string`, convert `coeffs` via `np.asarray(coeffs).tolist()`, eliminating brittle `eval(repr(...))` and supporting all NumPy numeric dtypes (`float32`, `float64`, etc.).
3. Added unit test `test_zpk_complex_dtypes` in `control/tests/xferfcn_test.py`.


---
**AI Disclosure (per NumPy AI Policy):** Claude (Anthropic) used as a coding assistant via IDE chat. All code is reviewed, understood, tested, and submitted by me. The fix logic and test design are my own.